### PR TITLE
fix: Production consumed 100x too much raw material on multi-unit-relation products (#16)

### DIFF
--- a/app/Http/Controllers/ProductionController.php
+++ b/app/Http/Controllers/ProductionController.php
@@ -252,13 +252,10 @@ class ProductionController extends Controller
                     continue;
                 }
 
-                // ← ditambahkan: hitung pengali $qty dari satuan input user
-                //   ke satuan terkecil produk (dipakai khusus untuk bahan dos/pack)
-                foreach ($pr as $relasi) {
-                    if ($relasi['pr_unit_id_2'] != $value['unit_id']) {
-                        $qty *= $relasi['pr_unit_value_2'];
-                    }
-                }
+                // Pengali $qty dari satuan input user ke satuan terkecil produk (dipakai
+                // khusus untuk bahan dos/pack) — bug #16: delegate to the fixed
+                // convertQtyToSmallestUnit() instead of re-multiplying every relation row here.
+                $qty = $this->convertQtyToSmallestUnit(1, (int) $value['unit_id'], (int) $value['product_variant_id']);
             }
 
             // Masukkan ke dalam array agregat berdasarkan supplies_id
@@ -602,13 +599,10 @@ class ProductionController extends Controller
                     continue;
                 }
 
-                // ← ditambahkan: hitung pengali $qty dari satuan input user
-                //   ke satuan terkecil produk (dipakai khusus bahan dos/pack)
-                foreach ($pr as $relasi) {
-                    if ($relasi['pr_unit_id_2'] != $value['unit_id']) {
-                        $qty *= $relasi['pr_unit_value_2'];
-                    }
-                }
+                // Pengali $qty dari satuan input user ke satuan terkecil produk (dipakai
+                // khusus bahan dos/pack) — bug #16: delegate to the fixed
+                // convertQtyToSmallestUnit() instead of re-multiplying every relation row here.
+                $qty = $this->convertQtyToSmallestUnit(1, (int) $value['unit_id'], (int) $value['product_variant_id']);
             }
 
             // Masukkan ke dalam array agregat berdasarkan supplies_id
@@ -1349,18 +1343,12 @@ class ProductionController extends Controller
             $bdetail = BomDetail::where('bom_id', $value['bom_id'])->where('status', 1)->get();
             if (!$b) continue;
 
+            // Pengali $qty (dos/pack) — bug #16: delegate to the fixed
+            // convertQtyToSmallestUnit() instead of re-multiplying every relation row here, so
+            // this reversal path stays symmetric with insertProduction()/accProduction().
             $qty = 1;
             if ($b['unit_id'] != $value['unit_id']) {
-                $pr = ProductRelation::where('product_variant_id', $value['product_variant_id'])
-                    ->where('status', 1)
-                    ->orderBy('pr_id', 'desc')
-                    ->get();
-
-                foreach ($pr as $relasi) {
-                    if ($relasi['pr_unit_id_2'] != $value['unit_id']) {
-                        $qty *= $relasi['pr_unit_value_2'];
-                    }
-                }
+                $qty = $this->convertQtyToSmallestUnit(1, (int) $value['unit_id'], (int) $value['product_variant_id']);
             }
 
             $batchCount = $this->getBatchCount(
@@ -1578,16 +1566,31 @@ class ProductionController extends Controller
 
     private function convertQtyToSmallestUnit(int $qty, int $unitId, int $productVariantId): int
     {
-        $multiplier = 1;
+        // Bug #16: this used to fetch EVERY active product_relations row for the variant and
+        // multiply all of their pr_unit_value_2 together whenever the row's base unit wasn't
+        // $unitId — which is true for every sibling row when a product has more than one
+        // independent "big unit -> Piece" relation (e.g. DOS=20pcs, kg=5pcs, LTR=10pcs all
+        // mapping to Piece). That folded unrelated relations into the multiplier
+        // (20 * 5 * 10 = 1000) instead of picking the single relation that actually matches
+        // $unitId, producing a 100x+ raw-material overconsumption. Walk the chain one hop at a
+        // time instead, exactly like the already-correct convertSuppliesQtyToSmallestUnit()
+        // below — this also makes multi-level ladders (Sak -> DOS -> Piece) resolve correctly.
         $relations = ProductRelation::where('product_variant_id', $productVariantId)
             ->where('status', 1)
-            ->orderBy('pr_id', 'desc')
             ->get();
 
-        foreach ($relations as $relation) {
-            if ($relation['pr_unit_id_2'] != $unitId) {
-                $multiplier *= (int) $relation['pr_unit_value_2'];
+        $multiplier = 1;
+        $currentUnit = $unitId;
+        $guard = 0;
+
+        while ($guard < 20) {
+            $guard++;
+            $rel = $relations->first(fn ($r) => (int) $r->pr_unit_id_1 === (int) $currentUnit);
+            if (!$rel) {
+                break;
             }
+            $multiplier *= (int) $rel->pr_unit_value_2;
+            $currentUnit = (int) $rel->pr_unit_id_2;
         }
 
         return $qty * $multiplier;

--- a/tests/Regression/ProductionRawMaterialOverconsumptionOnMultiUnitRelationTest.php
+++ b/tests/Regression/ProductionRawMaterialOverconsumptionOnMultiUnitRelationTest.php
@@ -1,0 +1,185 @@
+<?php
+
+namespace Tests\Regression;
+
+use App\Models\Bom;
+use App\Models\BomDetail;
+use App\Models\Category;
+use App\Models\Product;
+use App\Models\ProductRelation;
+use App\Models\ProductStock;
+use App\Models\ProductVariant;
+use App\Models\Production;
+use App\Models\Supplies;
+use App\Models\SuppliesStock;
+use Tests\Support\ActingAsStaff;
+use Tests\TestCase;
+
+/**
+ * GitHub issue #16: producing "1 Liter" of a product deducted 1000 pieces of a raw material whose
+ * recipe only needed 1 piece per 1 piece of product — a 100x raw-material overconsumption.
+ *
+ * Root cause (fixed on this branch): `ProductionController::convertQtyToSmallestUnit()` fetched
+ * EVERY active `product_relations` row for the product and multiplied all of their
+ * `pr_unit_value_2` together whenever a row's base unit wasn't the unit actually being converted —
+ * true for every sibling row whenever a product has more than one independent "big unit -> Piece"
+ * relation. The reporter's own product had exactly that "Atur Relasi" shape: DOS=20pcs, kg=5pcs,
+ * LTR=10pcs, all three converging on Piece. Converting "1 Liter" folded all three factors together
+ * (20 * 5 * 10 = 1000) instead of using just the matching LTR relation (10), so a recipe needing 1
+ * piece of "Botol 600ml" per 1 piece of product consumed 1000 pieces instead of 10.
+ *
+ * The same duplicated buggy loop existed in three places (`insertProduction()`'s pre-check,
+ * `accProduction()`'s real deduction, and `accDeleteProduction()`'s reversal) plus the shared
+ * `convertQtyToSmallestUnit()`/`getBatchCount()` pair — all four now delegate to the same fixed,
+ * chain-walking conversion (mirrors the already-correct `convertSuppliesQtyToSmallestUnit()`).
+ *
+ * Real unit ids used (from the committed seed snapshot's `units` table, matching the issue's own
+ * screenshots): 1 = kg, 3 = Liter, 7 = DOS, 9 = Piece.
+ */
+class ProductionRawMaterialOverconsumptionOnMultiUnitRelationTest extends TestCase
+{
+    use ActingAsStaff;
+
+    private const KG_UNIT_ID = 1;
+    private const LITER_UNIT_ID = 3;
+    private const DOS_UNIT_ID = 7;
+    private const PIECE_UNIT_ID = 9;
+    private const WAREHOUSE_ID = 1;
+
+    public function test_producing_in_a_unit_with_multiple_sibling_relations_consumes_the_correct_amount(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $category = new Category();
+        $category->category_name = 'Issue 16 Regression Category';
+        $category->status = 1;
+        $category->save();
+
+        $product = new Product();
+        $product->product_name = 'Issue 16 Regression Product';
+        $product->category_id = $category->category_id;
+        $product->product_unit = json_encode([self::PIECE_UNIT_ID, self::LITER_UNIT_ID]);
+        $product->unit_id = self::PIECE_UNIT_ID;
+        $product->status = 1;
+        $product->save();
+
+        $variant = new ProductVariant();
+        $variant->product_id = $product->product_id;
+        $variant->product_variant_name = 'Issue 16 Regression Variant';
+        $variant->product_variant_sku = 'WF-ISSUE16-'.uniqid();
+        $variant->product_variant_price = 0;
+        $variant->status = 1;
+        $variant->save();
+
+        // ProductStock row at the unit production is actually recorded in (Liter) — the
+        // finished-goods crediting side keys off this directly since no relation maps Liter up
+        // to a still-larger unit (see ProductionController.php:1025: `pr_unit_id_2 == Liter`
+        // never matches here, so it takes the plain "add to this row" branch, not the ladder).
+        $literProductStock = new ProductStock();
+        $literProductStock->product_id = $product->product_id;
+        $literProductStock->product_variant_id = $variant->product_variant_id;
+        $literProductStock->unit_id = self::LITER_UNIT_ID;
+        $literProductStock->warehouse_id = self::WAREHOUSE_ID;
+        $literProductStock->ps_stock = 0;
+        $literProductStock->status = 1;
+        $literProductStock->save();
+
+        // "Atur Relasi" — three INDEPENDENT relations all converging on Piece, matching the real
+        // product's configuration from the bug report screenshots.
+        foreach ([
+            [self::DOS_UNIT_ID, 20],
+            [self::KG_UNIT_ID, 5],
+            [self::LITER_UNIT_ID, 10],
+        ] as [$bigUnitId, $pcsValue]) {
+            $relation = new ProductRelation();
+            $relation->product_variant_id = $variant->product_variant_id;
+            $relation->pr_unit_id_1 = $bigUnitId;
+            $relation->pr_unit_value_1 = 1;
+            $relation->pr_unit_id_2 = self::PIECE_UNIT_ID;
+            $relation->pr_unit_value_2 = $pcsValue;
+            $relation->pr_default = 0;
+            $relation->status = 1;
+            $relation->save();
+        }
+
+        // Recipe ("Resep Bahan Mentah"): 1 Piece of product needs 1 Piece of Botol600ml.
+        $bom = new Bom();
+        $bom->product_id = $variant->product_variant_id; // stores a product_variant_id, see PRODUCTION_FLOW.md
+        $bom->bom_qty = 1;
+        $bom->unit_id = self::PIECE_UNIT_ID;
+        $bom->status = 1;
+        $bom->save();
+
+        $supplies = new Supplies();
+        $supplies->supplies_name = 'Botol 600ml';
+        $supplies->supplies_unit = json_encode([self::PIECE_UNIT_ID]);
+        $supplies->supplies_default_unit = self::PIECE_UNIT_ID;
+        $supplies->status = 1;
+        $supplies->save();
+
+        $suppliesStock = new SuppliesStock();
+        $suppliesStock->supplies_id = $supplies->supplies_id;
+        $suppliesStock->unit_id = self::PIECE_UNIT_ID;
+        $suppliesStock->warehouse_id = self::WAREHOUSE_ID;
+        $suppliesStock->ss_stock = 2000; // plenty — the bug would have consumed 1000 for just 1 Liter
+        $suppliesStock->status = 1;
+        $suppliesStock->save();
+
+        $bomDetail = new BomDetail();
+        $bomDetail->bom_id = $bom->bom_id;
+        $bomDetail->supplies_id = $supplies->supplies_id;
+        $bomDetail->bom_detail_qty = 1;
+        $bomDetail->unit_id = self::PIECE_UNIT_ID;
+        $bomDetail->status = 1;
+        $bomDetail->save();
+
+        // Production of "1 Liter" — exactly the issue's own reproduction steps.
+        $insertResponse = $this->post('/insertProduction', [
+            'production_date' => now()->toDateString(),
+            'production_desc' => 'Issue #16 regression: 1 Liter production',
+            'detail' => json_encode([[
+                'bom_id' => $bom->bom_id,
+                'product_variant_id' => $variant->product_variant_id,
+                'pd_qty' => 1,
+                'unit_id' => self::LITER_UNIT_ID,
+            ]]),
+            'list_bahan' => json_encode([[
+                'supplies_id' => $supplies->supplies_id,
+                'bom_detail_qty' => 1,
+                'unit_id' => self::PIECE_UNIT_ID,
+            ]]),
+        ]);
+        $insertResponse->assertStatus(200);
+        $production = Production::orderByDesc('production_id')->firstOrFail();
+
+        $accResponse = $this->post('/accProduction', ['production_id' => $production->production_id]);
+        $accResponse->assertStatus(200);
+
+        $production->refresh();
+        $this->assertSame(2, (int) $production->status);
+
+        // 1 Liter = 10 Piece per the LTR relation; the recipe needs 1 pc of Botol600ml per 1 pc
+        // of product -> 10 pcs consumed. BEFORE THE FIX this was 1000 (20 * 5 * 10 folded
+        // together from the DOS/kg/LTR siblings instead of picking just LTR).
+        $suppliesStock->refresh();
+        $this->assertSame(1990, $suppliesStock->ss_stock, 'only 10 pieces of Botol600ml consumed for 1 Liter produced, not 1000');
+
+        $this->assertDatabaseHas('log_stocks', [
+            'log_type' => 2,
+            'log_category' => 2,
+            'log_item_id' => $supplies->supplies_id,
+            'unit_id' => self::PIECE_UNIT_ID,
+            'log_jumlah' => 10,
+        ]);
+        $this->assertDatabaseMissing('log_stocks', [
+            'log_type' => 2,
+            'log_category' => 2,
+            'log_item_id' => $supplies->supplies_id,
+            'unit_id' => self::PIECE_UNIT_ID,
+            'log_jumlah' => 1000,
+        ]);
+
+        $literProductStock->refresh();
+        $this->assertSame(1, $literProductStock->ps_stock, 'finished-goods side still credits 1 Liter as recorded — unaffected by the input-side fix');
+    }
+}


### PR DESCRIPTION
Closes #16.

## Bug

`ProductionController::convertQtyToSmallestUnit()` fetched every active `product_relations` row for a product variant and multiplied all of their `pr_unit_value_2` together whenever a row's base unit wasn't the unit being converted. That condition is true for every sibling row whenever a product has more than one independent "big unit → Piece" relation — exactly the reporter's own product's "Atur Relasi" configuration (1 DOS = 20 pcs, 1 kg = 5 pcs, 1 LTR = 10 pcs, all converging on Piece).

Producing "1 Liter" folded all three factors together (`20 × 5 × 10 = 1000`) instead of using just the matching LTR relation (`10`), so a recipe needing 1 piece of "Botol 600ml" per 1 piece of product consumed **1000 pieces instead of 10** — confirmed via the "Lihat Histori Bahan Mentah" stock log in the issue showing `Keluar: 1000 Piece` for a 1-Liter production.

The identical buggy loop was independently duplicated three more times: the dos/pack special-case `$qty` multiplier in `insertProduction()`'s pre-check and in `accProduction()`'s real stock deduction, and again in `accDeleteProduction()`'s stock-reversal path — so both approving *and* cancelling a production were affected, not just a display estimate.

## Fix

Rewrote `convertQtyToSmallestUnit()` to walk the relation chain one hop at a time — find the single row whose `pr_unit_id_1` matches the current unit, apply its factor, move to its base unit, repeat — mirroring the already-correct `convertSuppliesQtyToSmallestUnit()` a few hundred lines below it in the same file (and the same "match the specific row" pattern already used correctly elsewhere: `ProductStock.php`, `SuppliesStock.php`, `CustomerController.php`).

The three duplicated inline `$qty` loops were replaced with calls to this one fixed method, so `insertProduction()`, `accProduction()`, and `accDeleteProduction()`'s reversal path stay symmetric.

## Testing

- New `tests/Regression/ProductionRawMaterialOverconsumptionOnMultiUnitRelationTest.php` reproduces the issue's exact "Atur Relasi" shape and asserts a 1-Liter production consumes 10 pieces, not 1000.
  - Verified it fails against the pre-fix code (1000 consumed, matching the report exactly).
  - Verified it passes post-fix (10 consumed).
- All 25 existing Production tests (`ProductionUnitConversionFlowTest`, `ProductionFlowTest`, `ProductionOutputConversionDoesNotCascadeMultipleLevelsTest`, `ProductionAccSelfHealTest`, etc.) still pass unchanged — every one of their fixtures happens to define only a single `product_relations` row per product, which is exactly why this bug wasn't caught earlier (multiplying "every relation" and "the matching relation" produce the same number when there's only one).
- Full suite (357 tests) re-run: 21 pre-existing failures + 1 error, confirmed present identically on unmodified `main` (unrelated: SalesOrder, StockOpname, ProductVariant uniqueness, external-app routes) — nothing newly broken by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)