### PR TITLE
fix: stop invoice actions from clobbering purchase_orders.status

### DIFF
--- a/app/Models/PurchaseOrderDetailInvoice.php
+++ b/app/Models/PurchaseOrderDetailInvoice.php
@@ -145,18 +145,34 @@ class PurchaseOrderDetailInvoice extends Model
        $this->cekInvoice($t->po_id);
     }
 
+    /**
+     * Dinonaktifkan (2026-08-06, GitHub issue #14): dulu method ini men-set purchase_orders.status
+     * jadi 3 ("belum lunas") atau 4 ("lunas penuh") berdasarkan total invoice yang sudah diterima —
+     * dipanggil dari updateInvoicePO/deleteInvoicePO/changeStatusInvoicePO SETIAP kali sebuah invoice
+     * diedit/dihapus/diterima/ditolak, tanpa syarat apa pun.
+     *
+     * Dikonfirmasi oleh PM (2026-08-06): alur status PO yang benar hanya berisi 3 nilai —
+     * status=1 (menunggu konfirmasi) -> status=2 (disetujui) -> status=-1 (ditolak), dan progres
+     * "belum terbayar / menunggu tanda terima / terbayar" SEPENUHNYA dikendalikan oleh kolom
+     * `pembayaran` (1/3/2), bukan oleh `status`. Nilai status=3/4 yang ditulis di sini tidak pernah
+     * ada dalam alur itu — write-nya murni mengotori `purchase_orders.status` di luar domain
+     * {1, 2, -1} yang jadi asumsi di tempat lain, dengan 2 akibat nyata:
+     *   1. `SupplierController::tolakPO()` hanya membalik supplies_stocks kalau `status == 2` —
+     *      begitu status jadi 3/4, membatalkan PO itu TIDAK membalik stok yang sudah ditambah
+     *      accPO, walau permintaan pembatalannya sendiri tetap "berhasil".
+     *   2. `Purchase_Order_Detail.js`'s tombol Batalkan/Terima hanya muncul untuk status 1 atau 2 —
+     *      begitu status jadi 3/4, tombolnya hilang sama sekali, jadi staff tidak bisa lagi menolak
+     *      PO yang menurut alur PM seharusnya masih boleh (belum terbayar/menunggu tanda terima
+     *      -> ditolak).
+     *
+     * Method ini dipertahankan (bukan dihapus) karena masih dipanggil dari 3 tempat — tapi sekarang
+     * sengaja tidak melakukan apa pun, supaya updateInvoicePO/deleteInvoicePO/changeStatusInvoicePO
+     * tidak lagi bisa memindahkan purchase_orders.status sama sekali. Total invoice yang sudah
+     * diterima tetap bisa dihitung ulang kapan pun lewat query yang sama kalau nanti dibutuhkan
+     * untuk field terpisah — lihat cdocs/testing/KNOWN_ISSUES.md.
+     */
     function cekInvoice($po_id) {
-        
-        $total = PurchaseOrderDetailInvoice::where("po_id","=",$po_id)->where("status","=",2)->sum("poi_total");
-        $po = PurchaseOrder::find($po_id);
-        if($total<$po->po_total){
-            $po->status = 3;
-            $po->save();
-        }
-        else{
-            $po->status = 4;
-            $po->save();
-        }
+        // Sengaja kosong — lihat docblock di atas.
     }
 
     function generateInvoicePurchaseOrderID()

--- a/tests/Regression/PurchaseOrderRejectAfterInvoiceAcceptanceSkippedStockReversalTest.php
+++ b/tests/Regression/PurchaseOrderRejectAfterInvoiceAcceptanceSkippedStockReversalTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Tests\Regression;
+
+use App\Models\PurchaseOrder;
+use App\Models\PurchaseOrderDetailInvoice;
+use App\Models\SuppliesStock;
+use App\Models\SuppliesVariant;
+use App\Models\Supplier;
+use Tests\Support\ActingAsStaff;
+use Tests\TestCase;
+
+/**
+ * GitHub issue #14 (closes #14). See cdocs/testing/KNOWN_ISSUES.md and
+ * cdocs/docs/flows/purchase-order-invoice/FLOW.md for the full writeup.
+ *
+ * `SupplierController::tolakPO()`'s stock-reversal branch is gated on
+ * `if ($p->status == 2)`. Before this fix, `PurchaseOrderDetailInvoice::cekInvoice()` moved
+ * `purchase_orders.status` to 3 or 4 on every accept/decline/edit/delete of an invoice — so once
+ * a PO's automatic invoice had been accepted (a completely routine, expected action), calling
+ * `tolakPO` afterward would set `status = -1` and cascade-cancel every related record WITHOUT
+ * reversing the `supplies_stocks` that `accPO` had added, because `status` was no longer exactly
+ * `2`. The cancellation itself reported success; only the stock silently failed to roll back.
+ *
+ * Per the PM's confirmed status flow (2026-08-06), `purchase_orders.status` only ever holds
+ * {1, 2, -1} — "belum terbayar"/"menunggu tanda terima"/"terbayar" are `pembayaran`-driven
+ * sub-states of `status == 2`, and "ditolak" must be reachable from any of them. `cekInvoice()`
+ * is now a no-op (see its docblock), so `status` stays at 2 through invoice acceptance, and
+ * `tolakPO`'s reversal branch fires correctly.
+ */
+class PurchaseOrderRejectAfterInvoiceAcceptanceSkippedStockReversalTest extends TestCase
+{
+    use ActingAsStaff;
+
+    public function test_rejecting_a_po_after_its_invoice_was_accepted_still_reverses_stock(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $variant = SuppliesVariant::where('status', 1)->firstOrFail();
+        $stock = SuppliesStock::where('supplies_id', $variant->supplies_id)->where('status', 1)->firstOrFail();
+        $supplier = Supplier::where('status', 1)->whereNotNull('bank_id')->firstOrFail();
+
+        $qty = 5;
+        $price = 1000;
+        $startingStock = $stock->ss_stock;
+
+        $poId = (int) $this->post('/insertPurchaseOrder', [
+            'po_supplier' => $supplier->supplier_id,
+            'po_date' => now()->toDateString(),
+            'po_total' => $qty * $price,
+            'jenis_discount' => 1,
+            'po_desc' => 'Reject-after-invoice-acceptance regression PO',
+            'po_img' => json_encode([]),
+            'po_detail' => json_encode([[
+                'supplies_variant_id' => $variant->supplies_variant_id,
+                'supplies_name' => 'Regression test supplies',
+                'supplies_variant_name' => $variant->supplies_variant_name,
+                'supplies_variant_sku' => $variant->supplies_variant_sku,
+                'qty' => $qty,
+                'supplies_variant_price' => $price,
+                'unit_id_select' => $stock->unit_id,
+            ]]),
+        ])->json();
+
+        $this->post('/accPO', [
+            'data' => [
+                'po_id' => $poId,
+                'po_supplier' => $supplier->supplier_id,
+                'items' => [[
+                    'supplies_variant_id' => $variant->supplies_variant_id,
+                    'unit_id' => $stock->unit_id,
+                    'pod_sku' => $variant->supplies_variant_sku,
+                    'pod_qty' => $qty,
+                ]],
+            ],
+        ])->assertStatus(200);
+
+        $stock->refresh();
+        $this->assertSame($startingStock + $qty, $stock->ss_stock, 'approval must add the ordered qty to stock');
+
+        // Routine action: accept the PO's automatic invoice. Before the fix, this moved
+        // purchase_orders.status to 4 — which is exactly what broke tolakPO's reversal below.
+        $invoice = PurchaseOrderDetailInvoice::where('po_id', $poId)->firstOrFail();
+        $this->post('/acceptInvoicePO', ['poi_id' => $invoice->poi_id, 'status' => 2])->assertOk();
+
+        $po = PurchaseOrder::findOrFail($poId);
+        $this->assertSame(2, (int) $po->status, 'accepting the invoice must leave purchase_orders.status at 2 (closes #14)');
+
+        // Now reject the already-approved PO — tolakPO must still reverse the stock it added.
+        $this->post('/tolakPO', ['po_id' => $poId])->assertOk();
+
+        $po->refresh();
+        $this->assertSame(-1, (int) $po->status, 'rejecting an approved PO must set status to -1');
+
+        $stock->refresh();
+        $this->assertSame(
+            $startingStock,
+            $stock->ss_stock,
+            'rejecting the PO must reverse the stock accPO added, even though its invoice was already accepted'
+        );
+    }
+}

--- a/tests/Workflow/PurchaseOrderInvoiceFlowTest.php
+++ b/tests/Workflow/PurchaseOrderInvoiceFlowTest.php
@@ -12,10 +12,19 @@ use Tests\TestCase;
 
 /**
  * See cdocs/testing/workflows/PURCHASE_ORDER_INVOICE_FLOW.md for the fully-traced flow this
- * asserts against — builds on the base PurchaseOrderFlowTest pilot. Covers the invoice-acceptance
- * over-payment guard and the purchase_orders.status 3/4 recalculation it drives, which is the
- * actual money-calculation logic in this flow. Tanda Terima Invoice grouping (a separate tracking
- * dimension, po.pembayaran) is a different, not-yet-built pilot.
+ * asserts against — builds on the base PurchaseOrderFlowTest pilot.
+ *
+ * Updated 2026-08-06 (GitHub issue #14, closes #14): `cekInvoice()` used to move
+ * `purchase_orders.status` to 3/4 ("belum lunas"/"lunas penuh") on every accept/decline/edit/delete
+ * of an invoice, with no guard on the invoice's own status. Per the PM's confirmed flow,
+ * `purchase_orders.status` only ever holds {1 menunggu konfirmasi, 2 disetujui, -1 ditolak} —
+ * "belum terbayar / menunggu tanda terima / terbayar" is driven entirely by `pembayaran`
+ * (1/3/2), a separate tracking dimension covered by `PURCHASE_ORDER_TANDA_TERIMA_FLOW.md`, not by
+ * this invoice-acceptance flow. `cekInvoice()` is now a documented no-op (see its docblock in
+ * `PurchaseOrderDetailInvoice.php`), so this suite asserts `purchase_orders.status` stays at 2
+ * (its post-`accPO` value) through every invoice accept/decline/edit/delete scenario below — the
+ * real money-calculation logic that remains is `purchase_order_detail_invoices.status` itself
+ * (2=accepted/0=declined) and `acceptInvoicePO`'s over-payment guard, both untouched by this fix.
  */
 class PurchaseOrderInvoiceFlowTest extends TestCase
 {
@@ -65,7 +74,7 @@ class PurchaseOrderInvoiceFlowTest extends TestCase
         return $poId;
     }
 
-    public function test_accepting_the_automatic_invoice_flips_po_status_to_fully_covered(): void
+    public function test_accepting_the_automatic_invoice_sets_invoice_status_without_touching_po_status(): void
     {
         $this->actingAsSuperAdminStaff();
 
@@ -83,7 +92,7 @@ class PurchaseOrderInvoiceFlowTest extends TestCase
         $invoice->refresh();
         $po->refresh();
         $this->assertSame(2, (int) $invoice->status, 'accepting sets the invoice status to 2');
-        $this->assertSame(4, (int) $po->status, 'an accepted total equal to po_total flips PO status to 4 (fully covered)');
+        $this->assertSame(2, (int) $po->status, 'accepting an invoice no longer moves purchase_orders.status (closes #14) — it stays at 2, driven only by accPO/tolakPO');
     }
 
     public function test_accepting_a_second_invoice_that_would_exceed_po_total_is_rejected(): void
@@ -97,9 +106,10 @@ class PurchaseOrderInvoiceFlowTest extends TestCase
         // Accept the automatic invoice first — it already covers po_total in full.
         $this->post('/acceptInvoicePO', ['poi_id' => $invoice->poi_id, 'status' => 2])->assertOk();
         $po->refresh();
-        $this->assertSame(4, (int) $po->status);
+        $this->assertSame(2, (int) $po->status, 'po.status stays at 2 regardless of invoice acceptance (closes #14)');
 
-        // A second invoice for any positive amount must now be rejected on accept.
+        // A second invoice for any positive amount must now be rejected on accept — this guard is
+        // driven by summing purchase_order_detail_invoices.status=2 rows, independent of po.status.
         // insertInvoicePO's response is the PO's status, not the new invoice's id (see the flow
         // doc) — fetch the created row directly instead.
         $this->post('/insertInvoicePO', [
@@ -116,10 +126,10 @@ class PurchaseOrderInvoiceFlowTest extends TestCase
         $this->assertSame(1, (int) $secondInvoice->status, 'a rejected acceptance must leave the second invoice untouched');
 
         $po->refresh();
-        $this->assertSame(4, (int) $po->status, 'a rejected acceptance must not change PO status');
+        $this->assertSame(2, (int) $po->status, 'a rejected acceptance must not change PO status');
     }
 
-    public function test_declining_an_invoice_leaves_po_status_not_fully_covered(): void
+    public function test_declining_an_invoice_does_not_change_po_status(): void
     {
         $this->actingAsSuperAdminStaff();
 
@@ -132,16 +142,16 @@ class PurchaseOrderInvoiceFlowTest extends TestCase
         $this->assertSame(0, (int) $invoice->status, 'declining sets the invoice status to 0');
 
         $po = PurchaseOrder::findOrFail($poId);
-        $this->assertSame(3, (int) $po->status, 'a declined (uncounted) invoice leaves the accepted total below po_total, so status becomes 3');
+        $this->assertSame(2, (int) $po->status, 'declining an invoice no longer changes purchase_orders.status (closes #14) — pembayaran, not status, tracks payment progress');
     }
 
     /**
-     * BUG (see KNOWN_ISSUES.md): `updateInvoicePO()` unconditionally calls `cekInvoice()` after
-     * saving, regardless of the invoice's own status. Editing a still-PENDING invoice (never
-     * accepted) re-triggers the same status recalculation acceptInvoicePO drives — moving
-     * purchase_orders.status away from 2 with no accept/decline action at all.
+     * ✅ FIXED (2026-08-06, closes #14): `updateInvoicePO()` still calls `cekInvoice()`
+     * unconditionally after saving, but `cekInvoice()` itself is now a no-op (see its docblock) —
+     * so editing a still-pending invoice (never accepted) can no longer move purchase_orders.status
+     * with no accept/decline action ever happening.
      */
-    public function test_editing_a_still_pending_invoice_flips_po_status_with_no_accept_action(): void
+    public function test_editing_a_still_pending_invoice_no_longer_touches_po_status(): void
     {
         $this->actingAsSuperAdminStaff();
 
@@ -157,27 +167,22 @@ class PurchaseOrderInvoiceFlowTest extends TestCase
             'po_id' => $poId,
             'poi_date' => now()->toDateString(),
             'poi_due' => now()->addDays(30)->toDateString(),
-            'poi_total' => $invoice->poi_total, // even an unchanged total re-triggers cekInvoice()
+            'poi_total' => $invoice->poi_total, // even an unchanged total re-triggers the (now no-op) cekInvoice()
         ])->assertOk();
 
         $invoice->refresh();
         $this->assertSame(1, (int) $invoice->status, 'the invoice itself is still pending — updateInvoicePO never touches status');
 
         $po->refresh();
-        $this->assertSame(
-            3,
-            (int) $po->status,
-            'BUG: merely editing a pending invoice flips purchase_orders.status away from 2, with no accept/decline ever called'
-        );
+        $this->assertSame(2, (int) $po->status, 'editing a pending invoice must not move purchase_orders.status');
     }
 
     /**
-     * BUG (see KNOWN_ISSUES.md): editing an ALREADY-ACCEPTED invoice's total downward
-     * retroactively re-runs cekInvoice(), which can flip purchase_orders.status back down from
-     * "fully covered" — a PO can silently regress from status 4 to status 3 purely by editing an
-     * invoice, without any new decline/reject action.
+     * ✅ FIXED (2026-08-06, closes #14): editing an already-accepted invoice's total downward used
+     * to retroactively regress purchase_orders.status from 4 back to 3 via cekInvoice(). Now that
+     * cekInvoice() is a no-op, po.status simply stays at 2 throughout.
      */
-    public function test_editing_an_accepted_invoices_total_downward_regresses_po_status(): void
+    public function test_editing_an_accepted_invoices_total_downward_no_longer_regresses_po_status(): void
     {
         $this->actingAsSuperAdminStaff();
 
@@ -186,7 +191,7 @@ class PurchaseOrderInvoiceFlowTest extends TestCase
 
         $this->post('/acceptInvoicePO', ['poi_id' => $invoice->poi_id, 'status' => 2])->assertOk();
         $po = PurchaseOrder::findOrFail($poId);
-        $this->assertSame(4, (int) $po->status, 'fully accepted, PO is fully covered');
+        $this->assertSame(2, (int) $po->status, 'accepting the invoice does not move po.status');
 
         $this->post('/updateInvoicePO', [
             'poi_id' => $invoice->poi_id,
@@ -197,11 +202,7 @@ class PurchaseOrderInvoiceFlowTest extends TestCase
         ])->assertOk();
 
         $po->refresh();
-        $this->assertSame(
-            3,
-            (int) $po->status,
-            'BUG: reducing an already-accepted invoice\'s total retroactively regresses the PO from fully-covered (4) back to partially-covered (3)'
-        );
+        $this->assertSame(2, (int) $po->status, 'reducing an already-accepted invoice\'s total must not regress purchase_orders.status');
     }
 
     /**
@@ -221,10 +222,10 @@ class PurchaseOrderInvoiceFlowTest extends TestCase
     }
 
     /**
-     * Confirms the same cekInvoice side-effect also fires on delete: soft-deleting a still-pending
-     * invoice (never accepted) flips purchase_orders.status away from 2, same as editing one.
+     * ✅ FIXED (2026-08-06, closes #14): deleting a still-pending invoice used to also flip
+     * purchase_orders.status via the same cekInvoice() side effect as editing. Now it doesn't.
      */
-    public function test_deleting_a_still_pending_invoice_also_flips_po_status(): void
+    public function test_deleting_a_still_pending_invoice_no_longer_flips_po_status(): void
     {
         $this->actingAsSuperAdminStaff();
 
@@ -240,6 +241,6 @@ class PurchaseOrderInvoiceFlowTest extends TestCase
         $this->assertSame(-1, (int) $invoice->status, 'deleteInvoicePO soft-deletes the invoice');
 
         $po->refresh();
-        $this->assertSame(3, (int) $po->status, 'BUG: deleting a pending invoice also flips PO status via the same cekInvoice() side effect');
+        $this->assertSame(2, (int) $po->status, 'deleting a pending invoice must not move purchase_orders.status');
     }
 }


### PR DESCRIPTION
Closes #14.

## PM's confirmed status flow (2026-08-06)

Given directly in response to the issue's question ("untuk purchase order ini status nya urutannya gimana ya?"):

- menunggu konfirmasi → belum terbayar | ditolak
- belum terbayar → menunggu tanda terima | ditolak
- menunggu tanda terima → terbayar | ditolak

Mapped onto real columns:

| PM's label | Code state |
|---|---|
| menunggu konfirmasi | `purchase_orders.status = 1` |
| belum terbayar | `status = 2` and `pembayaran = 1` |
| menunggu tanda terima | `status = 2` and `pembayaran = 3` |
| terbayar | `status = 2` and `pembayaran = 2` |
| ditolak | `status = -1` |

So `status` only ever needs `{1, 2, -1}` — the belum-terbayar/menunggu-tanda-terima/terbayar distinction lives entirely in `pembayaran`, which already progresses correctly via `generateTandaTerimaInvoice`/`accTt` without ever touching `status`.

## The fix

`PurchaseOrderDetailInvoice::cekInvoice()` used to write `status = 3` or `4` ("belum lunas"/"lunas penuh") on every accept/decline/edit/delete of an invoice, regardless of the invoice's own status — values that were never part of the flow above, and nothing else in the codebase reads them meaningfully.

**Compounding bug found while fixing:** once `status` became 3/4, two things silently broke:
1. `tolakPO()`'s stock-reversal branch is gated on `status == 2` — rejecting a PO after its invoice had been accepted skipped the `supplies_stocks` reversal entirely, while still reporting success.
2. `Purchase_Order_Detail.js`'s Batalkan/Tolak button is only shown for status 1 or 2 — it silently disappeared once status hit 3/4, so staff couldn't reject a PO the PM's flow says should still be rejectable.

`cekInvoice()` is now a documented no-op. Its three call sites still call it (harmless), so no other method needed to change.

## Tests

- Rewrote `tests/Workflow/PurchaseOrderInvoiceFlowTest.php` — all 7 cases now assert `purchase_orders.status` stays at 2 through invoice accept/decline/edit/delete (previously asserted the buggy 3/4 flips as "BUG" cases).
- Added `tests/Regression/PurchaseOrderRejectAfterInvoiceAcceptanceSkippedStockReversalTest.php` — reproduces the compounding `tolakPO` bug directly. Verified failing against the pre-fix code before confirming it passes post-fix.

Full suite: 15 failed (same pre-existing, unrelated baseline) / 350 passed — no new regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
