### PR TITLE
Batch 1: testing-suite bootstrap + early fixes (main → fase2)

### DIFF
--- a/resources/views/Backoffice/Production/Production.blade.php
+++ b/resources/views/Backoffice/Production/Production.blade.php
@@ -2,18 +2,52 @@
 @extends('layout.mainlayout')
 @section('custom_css')
     <style>
-        /* Pola DataTable sama Pengiriman (Sales_Order) */
+        /* table-layout:fixed membuat lebar kolom (di bawah) benar-benar dipaksakan — tanpa ini,
+           max-width/word-wrap di satu kolom cuma "saran" dan teks panjang tanpa jeda bisa
+           meluber/tumpang tindih ke kolom sebelah (kolom Status jadi korban paling sering,
+           karena badge-nya kecil dan gampang ketiban teks Keterangan yang membanjir). */
         #tableProduction {
             width: 100% !important;
             table-layout: fixed;
+            min-width: 1250px;
         }
-
-        #tableProduction th,
-        #tableProduction td {
-            white-space: normal !important;
-            word-wrap: break-word;
+        #tableProduction thead th {
+            color: #64748b !important;
+            font-size: 11px;
+            font-weight: 700;
+            text-transform: uppercase;
+            letter-spacing: .4px;
+            background: #f1f5f9 !important;
+            border-bottom: 1px solid #e2e8f0;
+        }
+        #tableProduction tbody td {
+            color: #475569;
+            font-size: 13px;
             vertical-align: middle;
-            box-sizing: border-box;
+        }
+        #tableProduction tbody > tr {
+            border-bottom: 1px solid #f1f5f9;
+            transition: all 0.2s ease;
+        }
+        #tableProduction tbody > tr:hover {
+            background-color: #f8fafc;
+        }
+        #tableProduction td, #tableProduction th {
+            word-wrap: break-word;
+            overflow-wrap: break-word;
+            white-space: normal;
+        }
+        #tableProduction td:nth-child(1), #tableProduction th:nth-child(1) { width: 10%; }
+        #tableProduction td:nth-child(2), #tableProduction th:nth-child(2) { width: 10%; }
+        #tableProduction td:nth-child(3), #tableProduction th:nth-child(3) { width: 19%; } /* Keterangan */
+        #tableProduction td:nth-child(4), #tableProduction th:nth-child(4) { width: 8%; }  /* Status */
+        #tableProduction td:nth-child(5), #tableProduction th:nth-child(5) { width: 12%; } /* Notes Pembatalan */
+        #tableProduction td:nth-child(6), #tableProduction th:nth-child(6) { width: 11%; }
+        #tableProduction td:nth-child(7), #tableProduction th:nth-child(7) { width: 11%; }
+        #tableProduction td:nth-child(8), #tableProduction th:nth-child(8) { width: 11%; }
+        #tableProduction td:nth-child(9), #tableProduction th:nth-child(9) { width: 8%; }  /* Aksi */
+        #addProduction .select2-container {
+            width: 100% !important;
         }
 
         #tableProduction thead th {


### PR DESCRIPTION
Part of the `main` → `fase2/main` batch merge plan (`cdocs/docs/fase2-merge-plan.md`).

## What this brings in
Cherry-picked from `main`: `b8c52d1` (testing-suite bootstrap + early fixes), `ec87fd3` (.gitignore — ended up empty, fase2 already had it).

## Conflicts resolved
- `modal-popup.blade.php` — kept fase2's componentized `@include(...)` structure, discarded main's stale pre-refactor inline HTML.
- `Production.blade.php` — kept the detailed per-column CSS width block (with the overflow-bug rationale) over the generic `table-layout:fixed`-only version.
- `StockController.php` — trivial import merge.
- `SalesOrderDeliveryDetail.php` — discarded a hunk that would've reintroduced the double-deduction bug main itself deprecates 21h later; fase2's existing behavior was already correct.
- `ProductController.php` — removed a duplicate `validateVariantUniqueness()` declaration (both branches added the same guard independently; git merged both silently, PHP fataled on redeclare — caught by running tests, not by conflict markers).

## Scope check
`ProductionController.php` (`accProduction`/`accDeleteProduction`) is **not touched** by this batch — no hold needed here per the standing review request on those two functions (see `cdocs/docs/fase2-merge-plan.md`).

## Testing
Ran Smoke/Health/Workflow/Regression/DatabaseTransaction suites, then re-ran the same suites against baseline `fase2/merge-fase1-into-fase2` in a scratch worktree for comparison — identical failure counts on both sides (all pre-existing test/DB-state drift, none introduced by this batch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)