### PR TITLE
Batch 4: Production overdue auto-timeout feature + camera error messages (main → fase2)

### DIFF
--- a/app/Console/Commands/ResolveOverdueProductionsCommand.php
+++ b/app/Console/Commands/ResolveOverdueProductionsCommand.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Support\ProductionOverdueAutoResolver;
+use Illuminate\Console\Command;
+
+/**
+ * Jalankan auto-timeout produksi yang mangkrak (lihat ProductionOverdueAutoResolver) secara
+ * eksplisit lewat cron/scheduler server, alih-alih hanya sebagai efek samping GET /getProduction.
+ *
+ * Contoh:
+ *   php artisan production:resolve-overdue --dry-run
+ *   php artisan production:resolve-overdue --days=7
+ *   php artisan production:resolve-overdue
+ *
+ * Jadwalkan di routes/console.php, mis.:
+ *   Schedule::command('production:resolve-overdue')->dailyAt('01:00');
+ */
+class ResolveOverdueProductionsCommand extends Command
+{
+    protected $signature = 'production:resolve-overdue
+                            {--days= : Ambang hari overdue (default 4, sama seperti getProduction())}
+                            {--dry-run : Hanya tampilkan yang akan diproses, tanpa ubah DB}';
+
+    protected $description = 'Auto-ACC/tolak produksi pending, dan auto-tolak permintaan batal, yang sudah lewat ambang hari overdue';
+
+    public function handle(ProductionOverdueAutoResolver $resolver): int
+    {
+        $days = $this->option('days');
+        $days = $days !== null && $days !== '' ? (int) $days : null;
+        $dryRun = (bool) $this->option('dry-run');
+
+        $this->info($dryRun ? '[DRY-RUN] Scan produksi overdue…' : 'Memproses produksi overdue…');
+
+        $summary = $resolver->resolveOverdue($days, $dryRun);
+
+        if (count($summary['details']) === 0) {
+            $this->info('Tidak ada produksi/permintaan batal yang overdue.');
+            return self::SUCCESS;
+        }
+
+        $this->table(
+            ['production_id', 'production_code', 'action'],
+            array_map(
+                fn (array $row) => [$row['production_id'], $row['production_code'], $row['action']],
+                $summary['details']
+            )
+        );
+
+        $this->info(sprintf(
+            '%s pending: %d dicek (%d approved, %d declined). Cancel request: %d dicek (%d di-timeout).',
+            $dryRun ? 'Akan diproses —' : 'Selesai —',
+            $summary['pending_checked'],
+            $summary['pending_approved'],
+            $summary['pending_declined'],
+            $summary['cancel_checked'],
+            $summary['cancel_timed_out']
+        ));
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Console/Commands/ResolveOverdueProductionsCommand.php
+++ b/app/Console/Commands/ResolveOverdueProductionsCommand.php
@@ -48,15 +48,27 @@ class ResolveOverdueProductionsCommand extends Command
             )
         );
 
-        $this->info(sprintf(
-            '%s pending: %d dicek (%d approved, %d declined). Cancel request: %d dicek (%d di-timeout).',
-            $dryRun ? 'Akan diproses —' : 'Selesai —',
-            $summary['pending_checked'],
-            $summary['pending_approved'],
-            $summary['pending_declined'],
-            $summary['cancel_checked'],
-            $summary['cancel_timed_out']
-        ));
+        if ($dryRun) {
+            // Ditambahkan: dry-run tidak pernah benar-benar memanggil accProduction(), jadi TIDAK
+            // TAHU apakah tiap item bakal berhasil di-approve atau malah gagal (mis. stok bahan
+            // kurang) — dulu baris ini tetap menampilkan "(0 approved, 0 declined)" seolah-olah itu
+            // hasil nyata, padahal tabel di atas sudah benar menampilkan "would auto-acc". Sekarang
+            // cuma melaporkan jumlah yang DITEMUKAN overdue, bukan pura-pura tahu hasil approve-nya.
+            $this->info(sprintf(
+                'Akan diproses — pending: %d ditemukan overdue. Cancel request: %d ditemukan overdue. Lihat kolom "action" di atas untuk detail per baris; jalankan tanpa --dry-run untuk memproses beneran.',
+                $summary['pending_checked'],
+                $summary['cancel_checked']
+            ));
+        } else {
+            $this->info(sprintf(
+                'Selesai — pending: %d dicek (%d approved, %d declined). Cancel request: %d dicek (%d di-timeout).',
+                $summary['pending_checked'],
+                $summary['pending_approved'],
+                $summary['pending_declined'],
+                $summary['cancel_checked'],
+                $summary['cancel_timed_out']
+            ));
+        }
 
         return self::SUCCESS;
     }

--- a/app/Models/Production.php
+++ b/app/Models/Production.php
@@ -84,6 +84,10 @@ class Production extends Model
             : collect();
 
         $relationCache = [];
+        // Schema::hasColumn dicek sekali di luar loop (bukan per-baris) — kolom ini mungkin belum
+        // ada di branch/environment yang menjalankan kode ini, lihat migration
+        // 2026_08_05_010000_add_resolved_by_system_to_productions_table.
+        $hasResolvedBySystemColumn = Schema::hasColumn('productions', 'resolved_by_system');
 
         foreach ($result as $key => $value) {
             $value->items = $detailsByProduction->get($value->production_id, collect())->values();
@@ -113,8 +117,17 @@ class Production extends Model
             }
             $value->total_dos = $dos;
             $value->created_by_name = $value->production_created_by ? ($staffMap[$value->production_created_by] ?? '-') : '-';
-            $value->acc_by_name = $value->acc_by ? ($staffMap[$value->acc_by] ?? '-') : '-';
             $value->cancel_requested_by_name = $value->cancel_requested_by ? ($staffMap[$value->cancel_requested_by] ?? '-') : '-';
+
+            // acc_by tetap diisi dari Session::get('user') oleh accProduction()/declineProduction()
+            // walau yang benar-benar memprosesnya adalah auto-timeout (bukan staf yang kebetulan
+            // sedang buka halaman) — resolved_by_system, kalau ada, menang telak di atas acc_by
+            // untuk KEPERLUAN TAMPILAN, supaya user tidak salah kira staf tersebut yang approve.
+            if ($hasResolvedBySystemColumn && $value->resolved_by_system) {
+                $value->acc_by_name = 'Sistem (Auto-Timeout)';
+            } else {
+                $value->acc_by_name = $value->acc_by ? ($staffMap[$value->acc_by] ?? '-') : '-';
+            }
         }
         return $result;
     }

--- a/app/Models/Production.php
+++ b/app/Models/Production.php
@@ -2,9 +2,7 @@
 
 namespace App\Models;
 
-use App\Http\Controllers\ProductionController;
 use App\Models\Staff;
-use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
@@ -19,13 +17,20 @@ class Production extends Model
 
     function getProduction($data = [])
     {
+        // Dulu dijalankan inline di tengah loop tampilan di bawah — jadi cuma memproses baris
+        // yang kebetulan lolos filter request GET yang sedang berjalan. Sekarang query
+        // independen lewat ProductionOverdueAutoResolver (juga dipakai
+        // `php artisan production:resolve-overdue`) — comment-out baris ini kalau nanti mau
+        // auto-timeout HANYA berjalan lewat cron, bukan di setiap load halaman list.
+        (new \App\Support\ProductionOverdueAutoResolver())->resolveOverdue();
+
         $data = array_merge([
             "date" => null,
             "report" => null,
             "production_id" => null,
             "created_at" => null,
             "status" => null
-        ], $data);  
+        ], $data);
 
         // status header produksi: 1 = pending, 2 = berhasil, 3 = tolak (4 = menunggu batal — jarang, bukan salah satu tiga utama)
         if ($data["report"] == null) $result = Production::where('status', '>=', 1);
@@ -110,29 +115,6 @@ class Production extends Model
             $value->created_by_name = $value->production_created_by ? ($staffMap[$value->production_created_by] ?? '-') : '-';
             $value->acc_by_name = $value->acc_by ? ($staffMap[$value->acc_by] ?? '-') : '-';
             $value->cancel_requested_by_name = $value->cancel_requested_by ? ($staffMap[$value->cancel_requested_by] ?? '-') : '-';
-
-            // Kalau misal ada yang sudah 3 hari lebih dan statusnya masih menunggu approve, maka auto ACC
-            $productionDate = Carbon::parse($value->production_date);
-            $diffDays = Carbon::now()->diffInDays($productionDate, false); 
-
-            if ($diffDays < -4 && $value->status == 1) {
-                $requestAcc = new \Illuminate\Http\Request();
-                $requestAcc->merge(['production_id' => $value->production_id]);
-
-                $resultAcc = (new ProductionController())->accProduction($requestAcc);
-
-                $isSuccess = $resultAcc === 1
-                    || ($resultAcc instanceof \Illuminate\Http\JsonResponse
-                        && (int) ($resultAcc->getData(true)['status'] ?? 0) === 1);
-                // Jangan auto-tolak kalau ACC gagal (mis. gudang eceran belum dipilih).
-                // Biarkan tetap Pending agar user bisa melengkapi/ACC manual.
-                if ($isSuccess) {
-                    return $this->getProduction($data);
-                }
-            } else if ($diffDays < -4 && $value->status == 4) {
-                $this->accProduction($value);
-                return $this->getProduction($data);
-            }
         }
         return $result;
     }

--- a/app/Support/ProductionOverdueAutoResolver.php
+++ b/app/Support/ProductionOverdueAutoResolver.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace App\Support;
+
+use App\Http\Controllers\ProductionController;
+use App\Models\Production;
+use Carbon\Carbon;
+use Illuminate\Http\Request;
+
+/**
+ * Auto-timeout untuk produksi yang mangkrak lebih dari ~4 hari sejak production_date:
+ * - status = 1 (menunggu ACC) → auto-ACC (accProduction() controller, mutasi stok penuh),
+ *   fallback ke declineProduction() kalau auto-ACC itu sendiri gagal (mis. stok kurang).
+ * - status = 4 (menunggu persetujuan batal) → auto-tolak permintaan batal (kembali ke status 2
+ *   "Berhasil", pure status flip — tidak ada reversal stok karena permintaan batal sendiri belum
+ *   pernah mengubah stok apa pun).
+ *
+ * Extracted dari `Production::getProduction()`, yang dulu menjalankan logika ini inline di tengah
+ * loop tampilan list — jadi perilakunya diam-diam tergantung baris mana yang kebetulan lolos filter
+ * request GET yang sedang berjalan. Sekarang query independen (bukan bergantung ke hasil query GET
+ * manapun), supaya perilakunya sama persis baik dipanggil dari getProduction() maupun dari
+ * `php artisan production:resolve-overdue` (lihat ResolveOverdueProductionsCommand).
+ *
+ * `getProduction()` masih memanggil ini di setiap request hari ini (belum dicabut dari GET) — kalau
+ * nanti mau dipindah supaya HANYA berjalan lewat cron, cukup comment-out satu baris pemanggilnya di
+ * `Production::getProduction()`, logika di sini tidak perlu diubah.
+ */
+class ProductionOverdueAutoResolver
+{
+    private const OVERDUE_AFTER_DAYS = 4;
+
+    /**
+     * @return array{
+     *   pending_checked: int,
+     *   pending_approved: int,
+     *   pending_declined: int,
+     *   cancel_checked: int,
+     *   cancel_timed_out: int,
+     *   details: list<array{production_id: int, production_code: string, action: string}>
+     * }
+     */
+    public function resolveOverdue(?int $overdueAfterDays = null, bool $dryRun = false): array
+    {
+        $overdueAfterDays = $overdueAfterDays ?? self::OVERDUE_AFTER_DAYS;
+
+        $summary = [
+            'pending_checked' => 0,
+            'pending_approved' => 0,
+            'pending_declined' => 0,
+            'cancel_checked' => 0,
+            'cancel_timed_out' => 0,
+            'details' => [],
+        ];
+
+        $pending = Production::where('status', 1)->get();
+        foreach ($pending as $production) {
+            if (!$this->isOverdue($production->production_date, $overdueAfterDays)) {
+                continue;
+            }
+            $summary['pending_checked']++;
+
+            if ($dryRun) {
+                $summary['details'][] = $this->detailRow($production, 'would auto-acc');
+                continue;
+            }
+
+            $request = new Request();
+            $request->merge(['production_id' => $production->production_id]);
+            $result = (new ProductionController())->accProduction($request);
+
+            if ($result === 1) {
+                $summary['pending_approved']++;
+                $summary['details'][] = $this->detailRow($production, 'auto-approved');
+            } else {
+                $declineRequest = new Request();
+                $declineRequest->merge(['production_id' => $production->production_id]);
+                (new ProductionController())->declineProduction($declineRequest);
+                $summary['pending_declined']++;
+                $summary['details'][] = $this->detailRow($production, 'auto-declined (acc failed)');
+            }
+        }
+
+        $cancelRequests = Production::where('status', 4)->get();
+        foreach ($cancelRequests as $production) {
+            if (!$this->isOverdue($production->production_date, $overdueAfterDays)) {
+                continue;
+            }
+            $summary['cancel_checked']++;
+
+            if ($dryRun) {
+                $summary['details'][] = $this->detailRow($production, 'would auto-reject cancel request');
+                continue;
+            }
+
+            (new Production())->accProduction(['production_id' => $production->production_id]);
+            $summary['cancel_timed_out']++;
+            $summary['details'][] = $this->detailRow($production, 'cancel request auto-rejected');
+        }
+
+        return $summary;
+    }
+
+    private function isOverdue(string $productionDate, int $overdueAfterDays): bool
+    {
+        $diffDays = Carbon::now()->diffInDays(Carbon::parse($productionDate), false);
+
+        return $diffDays < -$overdueAfterDays;
+    }
+
+    private function detailRow(Production $production, string $action): array
+    {
+        return [
+            'production_id' => (int) $production->production_id,
+            'production_code' => (string) $production->production_code,
+            'action' => $action,
+        ];
+    }
+}

--- a/app/Support/ProductionOverdueAutoResolver.php
+++ b/app/Support/ProductionOverdueAutoResolver.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\ProductionController;
 use App\Models\Production;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Schema;
 
 /**
  * Auto-timeout untuk produksi yang mangkrak lebih dari ~4 hari sejak production_date:
@@ -69,12 +70,14 @@ class ProductionOverdueAutoResolver
             $result = (new ProductionController())->accProduction($request);
 
             if ($result === 1) {
+                $this->markResolvedBySystem($production);
                 $summary['pending_approved']++;
                 $summary['details'][] = $this->detailRow($production, 'auto-approved');
             } else {
                 $declineRequest = new Request();
                 $declineRequest->merge(['production_id' => $production->production_id]);
                 (new ProductionController())->declineProduction($declineRequest);
+                $this->markResolvedBySystem($production);
                 $summary['pending_declined']++;
                 $summary['details'][] = $this->detailRow($production, 'auto-declined (acc failed)');
             }
@@ -93,11 +96,34 @@ class ProductionOverdueAutoResolver
             }
 
             (new Production())->accProduction(['production_id' => $production->production_id]);
+            $this->markResolvedBySystem($production);
             $summary['cancel_timed_out']++;
             $summary['details'][] = $this->detailRow($production, 'cancel request auto-rejected');
         }
 
         return $summary;
+    }
+
+    /**
+     * Tandai produksi ini sebagai diproses OTOMATIS oleh sistem, bukan aksi staf sungguhan —
+     * accProduction()/declineProduction() di atas tetap mengisi acc_by dari Session::get('user')
+     * kalau kebetulan ada session aktif (mis. auto-timeout ini terpicu lewat GET /getProduction
+     * saat seorang staf sedang membuka halaman list), jadi acc_by SENDIRI tidak bisa dipercaya
+     * untuk membedakan "staf yang benar-benar approve" dari "cuma kebetulan lagi buka halaman".
+     * Kolom ini eksplisit menandai itu, terlepas dari isi acc_by.
+     *
+     * Dibungkus Schema::hasColumn() supaya tetap aman kalau migration kolom ini belum ter-merge di
+     * branch/environment yang menjalankan kode ini — lihat migration
+     * 2026_08_05_010000_add_resolved_by_system_to_productions_table.
+     */
+    private function markResolvedBySystem(Production $production): void
+    {
+        if (!Schema::hasColumn('productions', 'resolved_by_system')) {
+            return;
+        }
+
+        $production->resolved_by_system = true;
+        $production->save();
     }
 
     private function isOverdue(string $productionDate, int $overdueAfterDays): bool

--- a/app/Support/ProductionOverdueAutoResolver.php
+++ b/app/Support/ProductionOverdueAutoResolver.php
@@ -69,7 +69,17 @@ class ProductionOverdueAutoResolver
             $request->merge(['production_id' => $production->production_id]);
             $result = (new ProductionController())->accProduction($request);
 
-            if ($result === 1) {
+            // accProduction() doesn't always return bare 1 on success on this branch — when the
+            // production's output stays in the same warehouse it produced in (no Stock Transfer
+            // needed), it returns a JsonResponse with status:1 instead. A strict `=== 1` check
+            // (correct on main, where accProduction() has no Stock Transfer branching) misreads
+            // that as a failure and falls through to auto-decline. Same check this branch's own
+            // now-removed inline predecessor used in Production::getProduction().
+            $isSuccess = $result === 1
+                || ($result instanceof \Illuminate\Http\JsonResponse
+                    && (int) ($result->getData(true)['status'] ?? 0) === 1);
+
+            if ($isSuccess) {
                 $this->markResolvedBySystem($production);
                 $summary['pending_approved']++;
                 $summary['details'][] = $this->detailRow($production, 'auto-approved');

--- a/database/migrations/2026_08_05_010000_add_resolved_by_system_to_productions_table.php
+++ b/database/migrations/2026_08_05_010000_add_resolved_by_system_to_productions_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Membedakan produksi yang di-ACC/tolak lewat aksi staf sungguhan dari yang di-auto-timeout oleh
+ * ProductionOverdueAutoResolver (lihat KNOWN_ISSUES.md "GET /getProduction can silently trigger
+ * real stock mutations") — tanpa ini, acc_by bisa salah menunjuk ke staf yang kebetulan sedang
+ * membuka halaman list saat auto-timeout terjadi (Session::get('user') masih ada), padahal staf itu
+ * tidak melakukan apa-apa.
+ *
+ * Kode yang membaca/menulis kolom ini SELALU dibungkus Schema::hasColumn() dulu — migration ini
+ * belum tentu sudah ter-merge/dijalankan di semua branch/environment.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasColumn('productions', 'resolved_by_system')) {
+            return;
+        }
+
+        Schema::table('productions', function (Blueprint $table) {
+            $table->boolean('resolved_by_system')->default(false)->after('acc_by');
+        });
+    }
+
+    public function down(): void
+    {
+        if (! Schema::hasColumn('productions', 'resolved_by_system')) {
+            return;
+        }
+
+        Schema::table('productions', function (Blueprint $table) {
+            $table->dropColumn('resolved_by_system');
+        });
+    }
+};

--- a/public/Custom_js/Backoffice/Production/Production.js
+++ b/public/Custom_js/Backoffice/Production/Production.js
@@ -1234,14 +1234,34 @@ $(document).on("click", ".btn_view", function () {
     $("#production_date").val(data.production_date);
     $("#production_desc").val(data.production_desc).attr("disabled", true);
 
-    // Tampilkan siapa yang approve/tolak hanya kalau memang sudah diputuskan (status 2/3) dan
-    // ada nama untuk ditampilkan — acc_by_name juga bisa berisi "Sistem (Auto-Timeout)" kalau
-    // produksi ini di-auto-timeout, bukan diputuskan staf sungguhan.
-    if ((data.status == 2 || data.status == 3) && data.acc_by_name && data.acc_by_name !== '-') {
+    // Info umum (Kode Produksi/Dibuat Oleh) — selalu tampil di mode lihat detail. Status
+    // ditampilkan sebagai badge di header modal, bukan field terpisah.
+    $('#production_code_display').val(data.production_code);
+    $('#production_created_by_display').val(data.created_by_name || '-');
+    $('#row-production-detail-info').show();
+    $('#production_status_badge_header').html(data.status_text || '').show();
+
+    // "Dibatalkan" dibedakan dari sekadar "Tolak" lewat cancel_requested_by — hanya terisi
+    // kalau produksi ini pernah lewat alur pengajuan batal (status 4) lalu disetujui
+    // pembatalannya (berakhir di status 3 juga, sama seperti tolak langsung dari pending, tapi
+    // beda alur). Notes Pembatalan pakai kolom `notes` yang sama dipakai declineProduction().
+    var isDibatalkan = data.status == 3 && data.cancel_requested_by;
+
+    // Diapprove Oleh: HANYA untuk status Berhasil (2) — acc_by_name bisa berisi "Sistem
+    // (Auto-Timeout)" kalau produksi ini di-auto-timeout, bukan diputuskan staf sungguhan.
+    if (data.status == 2 && data.acc_by_name && data.acc_by_name !== '-') {
         $('#production_acc_by_name').val(data.acc_by_name);
         $('#row-production-acc-by').show();
     } else {
         $('#row-production-acc-by').hide();
+    }
+
+    if (isDibatalkan) {
+        $('#production_cancel_requested_by_display').val(data.cancel_requested_by_name || '-');
+        $('#production_cancel_notes_display').val(data.notes || '-');
+        $('#row-production-cancel-info').show();
+    } else {
+        $('#row-production-cancel-info').hide();
     }
 
     var total_dos = 0;

--- a/public/Custom_js/Backoffice/Production/Production.js
+++ b/public/Custom_js/Backoffice/Production/Production.js
@@ -435,6 +435,7 @@ $(document).on("click", ".btnAdd", function () {
     $(".dos").hide();
     $("#production_date").val(getTodayStr()).prop("disabled", true);
     $("#addProduction").removeAttr("revision_source_production_id");
+    $("#row-production-acc-by").hide();
 });
 
 $(document).on("keyup", "#production_qty", function () {
@@ -882,6 +883,7 @@ function openProductionRevisionFromDashboardLink() {
             "revision_source_production_id",
             rowData.production_id,
         );
+        $("#row-production-acc-by").hide();
         $("#addProduction").modal("show");
 
         params.delete("rev_production_id");
@@ -1231,6 +1233,16 @@ $(document).on("click", ".btn_view", function () {
     $("#unit_id").html("");
     $("#production_date").val(data.production_date);
     $("#production_desc").val(data.production_desc).attr("disabled", true);
+
+    // Tampilkan siapa yang approve/tolak hanya kalau memang sudah diputuskan (status 2/3) dan
+    // ada nama untuk ditampilkan — acc_by_name juga bisa berisi "Sistem (Auto-Timeout)" kalau
+    // produksi ini di-auto-timeout, bukan diputuskan staf sungguhan.
+    if ((data.status == 2 || data.status == 3) && data.acc_by_name && data.acc_by_name !== '-') {
+        $('#production_acc_by_name').val(data.acc_by_name);
+        $('#row-production-acc-by').show();
+    } else {
+        $('#row-production-acc-by').hide();
+    }
 
     var total_dos = 0;
 

--- a/resources/views/components/modals/production/add-production.blade.php
+++ b/resources/views/components/modals/production/add-production.blade.php
@@ -8,9 +8,10 @@
             <i class="fe fe-layers"></i>
           </div>
           <div>
-            <h5 class="mb-0 fw-bold text-white modal-title" style="font-size:16px;letter-spacing:.2px;">Tambah
+            <h5 class="mb-0 fw-bold text-white modal-title d-inline-block" style="font-size:16px;letter-spacing:.2px;">Tambah
               Produksi</h5>
-            <small class="text-white-50">Kelola hasil produksi dan daftar produk</small>
+            <span id="production_status_badge_header" class="ms-2" style="display:none;"></span>
+            <small class="d-block text-white-50">Kelola hasil produksi dan daftar produk</small>
           </div>
         </div>
         <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
@@ -33,12 +34,48 @@
                 <input type="text" class="form-control" id="production_desc"
                   placeholder="Masukkan Keterangan" style="font-size:14px;border-radius:8px;height:42px;">
               </div>
-              <div class="col-12" id="row-production-acc-by" style="display:none;">
+              <div class="col-12" id="row-production-detail-info" style="display:none;">
+                <div class="row g-4">
+                  <div class="col-lg-6 col-12">
+                    <label class="text-muted mb-2"
+                      style="font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:.4px;">Kode
+                      Produksi</label>
+                    <input type="text" class="form-control" id="production_code_display" disabled
+                      style="font-size:14px;border-radius:8px;height:42px;">
+                  </div>
+                  <div class="col-lg-6 col-12">
+                    <label class="text-muted mb-2"
+                      style="font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:.4px;">Dibuat
+                      Oleh</label>
+                    <input type="text" class="form-control" id="production_created_by_display" disabled
+                      style="font-size:14px;border-radius:8px;height:42px;">
+                  </div>
+                </div>
+              </div>
+              <div class="col-lg-6 col-12" id="row-production-acc-by" style="display:none;">
                 <label class="text-muted mb-2"
-                  style="font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:.4px;">Disetujui/Ditolak
+                  style="font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:.4px;">Diapprove
                   Oleh</label>
                 <input type="text" class="form-control" id="production_acc_by_name" disabled
                   style="font-size:14px;border-radius:8px;height:42px;">
+              </div>
+              <div class="col-12" id="row-production-cancel-info" style="display:none;">
+                <div class="row g-4">
+                  <div class="col-lg-6 col-12">
+                    <label class="text-muted mb-2"
+                      style="font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:.4px;">Pengajuan
+                      Batal Oleh</label>
+                    <input type="text" class="form-control" id="production_cancel_requested_by_display" disabled
+                      style="font-size:14px;border-radius:8px;height:42px;">
+                  </div>
+                  <div class="col-lg-6 col-12">
+                    <label class="text-muted mb-2"
+                      style="font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:.4px;">Notes
+                      Pembatalan</label>
+                    <input type="text" class="form-control" id="production_cancel_notes_display" disabled
+                      style="font-size:14px;border-radius:8px;height:42px;">
+                  </div>
+                </div>
               </div>
             </div>
           </div>

--- a/resources/views/components/modals/production/add-production.blade.php
+++ b/resources/views/components/modals/production/add-production.blade.php
@@ -33,6 +33,13 @@
                 <input type="text" class="form-control" id="production_desc"
                   placeholder="Masukkan Keterangan" style="font-size:14px;border-radius:8px;height:42px;">
               </div>
+              <div class="col-12" id="row-production-acc-by" style="display:none;">
+                <label class="text-muted mb-2"
+                  style="font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:.4px;">Disetujui/Ditolak
+                  Oleh</label>
+                <input type="text" class="form-control" id="production_acc_by_name" disabled
+                  style="font-size:14px;border-radius:8px;height:42px;">
+              </div>
             </div>
           </div>
 

--- a/resources/views/layout/partials/footer-scripts.blade.php
+++ b/resources/views/layout/partials/footer-scripts.blade.php
@@ -1442,6 +1442,7 @@ https://cdn.jsdelivr.net/npm/toastr@2.1.4/toastr.min.js
   let camRotation = 0; // rotasi kamera
   let photoData = "";
   let currentStream = null;
+  let cameraRequestId = 0; // invalidates stale/overlapping getUserMedia() calls
   var modeCamera = 1; //1= upload, 2 = savefile
   var inputFile = null;
   var cameraReturnModal = null;
@@ -1481,6 +1482,7 @@ https://cdn.jsdelivr.net/npm/toastr@2.1.4/toastr.min.js
   }
 
   function stopCameraStream() {
+    cameraRequestId++; // invalidate any getUserMedia() call still in flight
     if (currentStream) {
       currentStream.getTracks().forEach(function(t) {
         t.stop();
@@ -1489,6 +1491,26 @@ https://cdn.jsdelivr.net/npm/toastr@2.1.4/toastr.min.js
     }
     var video = document.getElementById("video");
     if (video) video.srcObject = null;
+  }
+
+  function getCameraErrorMessage(err) {
+    switch (err && err.name) {
+      case "NotAllowedError":
+      case "PermissionDeniedError":
+        return "Akses kamera ditolak. Aktifkan izin kamera untuk situs ini di pengaturan browser.";
+      case "NotFoundError":
+      case "DevicesNotFoundError":
+        return "Kamera tidak ditemukan pada perangkat ini.";
+      case "NotReadableError":
+      case "TrackStartError":
+        return "Kamera sedang dipakai aplikasi atau tab lain. Tutup aplikasi/tab lain yang memakai kamera lalu coba lagi.";
+      case "OverconstrainedError":
+        return "Kamera tidak mendukung konfigurasi yang diminta.";
+      case "SecurityError":
+        return "Akses kamera diblokir browser karena halaman ini dibuka lewat koneksi HTTP (tidak aman), bukan HTTPS. Ini bukan masalah di perangkat Anda — minta tim IT/developer mengaktifkan HTTPS untuk domain ini.";
+      default:
+        return "Tidak bisa akses kamera. Pastikan izin kamera aktif.";
+    }
   }
 
   function resetCameraModalUi() {
@@ -1541,14 +1563,17 @@ https://cdn.jsdelivr.net/npm/toastr@2.1.4/toastr.min.js
     }
 
     if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
-      notifikasi("error", "Gagal Kamera", "Browser/perangkat tidak mendukung akses kamera.");
+      var reason = (window.isSecureContext === false)
+        ? "Akses kamera diblokir browser karena halaman ini dibuka lewat koneksi HTTP (tidak aman), bukan HTTPS. Ini bukan masalah di perangkat Anda — minta tim IT/developer mengaktifkan HTTPS untuk domain ini."
+        : "Browser/perangkat tidak mendukung akses kamera.";
+      notifikasi("error", "Gagal Kamera", reason);
       return Promise.resolve(false);
     }
 
-    // Stop camera old stream
-    if (currentStream) {
-      currentStream.getTracks().forEach(t => t.stop());
-    }
+    // Stop any previous stream and invalidate any getUserMedia() call that is
+    // still pending, so it can't clobber/leak past this new request.
+    stopCameraStream();
+    var requestId = ++cameraRequestId;
 
     return navigator.mediaDevices.getUserMedia({
         video: {
@@ -1562,12 +1587,20 @@ https://cdn.jsdelivr.net/npm/toastr@2.1.4/toastr.min.js
         });
       })
       .then(stream => {
+        // A newer startCamera()/stopCameraStream() happened while this
+        // request was in flight (double click, modal closed, retake, ...).
+        // Release this stream instead of leaking it or overwriting the
+        // stream that's actually in use.
+        if (requestId !== cameraRequestId) {
+          stream.getTracks().forEach(t => t.stop());
+          return false;
+        }
         currentStream = stream;
         video.srcObject = stream;
       })
       .catch(function(err) {
         console.error("Tidak bisa akses kamera:", err);
-        notifikasi("error", "Gagal Kamera", "Tidak bisa akses kamera. Pastikan izin kamera aktif.");
+        notifikasi("error", "Gagal Kamera", getCameraErrorMessage(err));
         return false;
       });
   }

--- a/routes/console.php
+++ b/routes/console.php
@@ -2,7 +2,16 @@
 
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Schedule;
 
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote');
+
+// Auto-timeout produksi yang mangkrak (lihat ProductionOverdueAutoResolver) — dijalankan sekali
+// sehari saat traffic rendah. Server masih perlu satu crontab entry yang menjalankan
+// `php artisan schedule:run` tiap menit; Laravel yang menentukan kapan job ini sendiri due.
+Schedule::command('production:resolve-overdue')
+    ->dailyAt('01:00')
+    ->withoutOverlapping()
+    ->onOneServer();

--- a/tests/Workflow/ProductionOverdueAutoResolverTest.php
+++ b/tests/Workflow/ProductionOverdueAutoResolverTest.php
@@ -13,6 +13,7 @@ use App\Models\ProductionDetails;
 use App\Models\Supplies;
 use App\Models\SuppliesStock;
 use App\Support\ProductionOverdueAutoResolver;
+use Illuminate\Support\Facades\Artisan;
 use Tests\Support\ActingAsStaff;
 use Tests\TestCase;
 
@@ -140,6 +141,7 @@ class ProductionOverdueAutoResolverTest extends TestCase
 
         $production->refresh();
         $this->assertSame(2, (int) $production->status, 'an overdue, resolvable production must be auto-approved');
+        $this->assertTrue((bool) $production->resolved_by_system, 'must be flagged as system-resolved, not attributed to a real staff action');
 
         $fx['productStock']->refresh();
         $this->assertSame(10, $fx['productStock']->ps_stock, 'the real accProduction() logic must have run, crediting finished-goods stock');
@@ -174,6 +176,7 @@ class ProductionOverdueAutoResolverTest extends TestCase
 
         $production->refresh();
         $this->assertSame(3, (int) $production->status, 'a resolvable-check failure must fall back to auto-decline, not stay stuck pending');
+        $this->assertTrue((bool) $production->resolved_by_system, 'the auto-decline fallback must also be flagged as system-resolved');
     }
 
     public function test_an_overdue_cancel_request_is_auto_timed_out_back_to_approved(): void
@@ -192,6 +195,50 @@ class ProductionOverdueAutoResolverTest extends TestCase
 
         $production->refresh();
         $this->assertSame(2, (int) $production->status, 'an overdue cancel-request must time out back to approved, not stay pending forever');
+        $this->assertTrue((bool) $production->resolved_by_system, 'a timed-out cancel-request must also be flagged as system-resolved');
+    }
+
+    /**
+     * ✅ ADDED (2026-08-05): acc_by alone can't distinguish a real staff decision from an
+     * auto-timeout — accProduction()/declineProduction() still fill it from Session::get('user')
+     * if a session happens to be active (e.g. this auto-timeout fired while a staff member had the
+     * Produksi list open), which used to misattribute the automatic action to whoever was merely
+     * viewing the page. getProduction()'s acc_by_name now shows "Sistem (Auto-Timeout)" whenever
+     * resolved_by_system is set, regardless of whatever acc_by ended up holding.
+     */
+    public function test_getProduction_shows_system_auto_timeout_label_instead_of_the_viewing_staffs_name(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $fx = $this->createFixture();
+        $production = $this->createPendingProduction($fx, now()->subDays(5)->toDateString());
+
+        // Simulates the misattribution scenario directly: an active session exists (this staff),
+        // yet the resolution is still a system auto-timeout.
+        (new ProductionOverdueAutoResolver())->resolveOverdue();
+        $production->refresh();
+        $this->assertNotNull($production->acc_by, 'acc_by is still filled from the active session, same as before — this is the raw value the fix must not rely on for display');
+
+        $rows = (new Production())->getProduction(['production_id' => $production->production_id]);
+        $row = $rows->firstOrFail();
+        $this->assertSame('Sistem (Auto-Timeout)', $row->acc_by_name, 'display must show the system label, not the session staff\'s real name, even though acc_by points at them');
+    }
+
+    public function test_getProduction_still_shows_the_real_staff_name_for_a_genuine_manual_decision(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $fx = $this->createFixture();
+        $production = $this->createPendingProduction($fx, now()->toDateString());
+
+        $this->post('/accProduction', ['production_id' => $production->production_id])->assertOk();
+
+        $production->refresh();
+        $this->assertFalse((bool) $production->resolved_by_system, 'a real, on-time manual approval must not be flagged as system-resolved');
+
+        $rows = (new Production())->getProduction(['production_id' => $production->production_id]);
+        $row = $rows->firstOrFail();
+        $this->assertNotSame('Sistem (Auto-Timeout)', $row->acc_by_name, 'a genuine manual approval must show the real staff name, not the system label');
     }
 
     public function test_getProduction_still_triggers_the_same_auto_timeout_as_a_side_effect(): void
@@ -207,5 +254,41 @@ class ProductionOverdueAutoResolverTest extends TestCase
 
         $production->refresh();
         $this->assertSame(2, (int) $production->status, 'GET /getProduction must still auto-resolve overdue productions as a side effect');
+    }
+
+    /**
+     * ✅ FIXED (2026-08-05): the console command's dry-run summary line used to unconditionally
+     * print "(0 approved, 0 declined)" even when the table above correctly showed a "would
+     * auto-acc" row — dry-run never actually calls accProduction(), so it has no way to know
+     * whether an item would really succeed or get declined, and the 0/0 looked like a real (and
+     * wrong) outcome instead of "not attempted." The summary line now only reports how many
+     * overdue items were FOUND in dry-run mode, deferring outcome detail to the table's own
+     * per-row "action" column.
+     */
+    public function test_dry_run_summary_does_not_claim_a_fake_approved_declined_outcome(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $fx = $this->createFixture();
+        $production = $this->createPendingProduction($fx, now()->subDays(5)->toDateString());
+
+        Artisan::call('production:resolve-overdue', ['--dry-run' => true]);
+        $dryRunOutput = Artisan::output();
+
+        $this->assertStringContainsString('would auto-acc', $dryRunOutput, 'the per-row table must still say what would happen');
+        $this->assertStringNotContainsString('approved', $dryRunOutput, 'dry-run must not claim a fake approved/declined outcome it never actually attempted');
+        $this->assertStringContainsString('1 ditemukan overdue', $dryRunOutput);
+
+        $production->refresh();
+        $this->assertSame(1, (int) $production->status, 'dry-run must never mutate anything');
+
+        Artisan::call('production:resolve-overdue');
+        $realRunOutput = Artisan::output();
+
+        $this->assertStringContainsString('auto-approved', $realRunOutput);
+        $this->assertStringContainsString('1 approved, 0 declined', $realRunOutput, 'a real run must still report the actual outcome');
+
+        $production->refresh();
+        $this->assertSame(2, (int) $production->status);
     }
 }

--- a/tests/Workflow/ProductionOverdueAutoResolverTest.php
+++ b/tests/Workflow/ProductionOverdueAutoResolverTest.php
@@ -130,6 +130,7 @@ class ProductionOverdueAutoResolverTest extends TestCase
     public function test_an_overdue_pending_production_with_enough_stock_is_auto_approved(): void
     {
         $this->actingAsSuperAdminStaff();
+        $this->withActiveWarehouse(self::WAREHOUSE_ID);
 
         $fx = $this->createFixture();
         $production = $this->createPendingProduction($fx, now()->subDays(5)->toDateString());
@@ -150,6 +151,7 @@ class ProductionOverdueAutoResolverTest extends TestCase
     public function test_a_pending_production_not_yet_overdue_is_left_untouched(): void
     {
         $this->actingAsSuperAdminStaff();
+        $this->withActiveWarehouse(self::WAREHOUSE_ID);
 
         $fx = $this->createFixture();
         $production = $this->createPendingProduction($fx, now()->subDays(2)->toDateString());
@@ -165,6 +167,7 @@ class ProductionOverdueAutoResolverTest extends TestCase
     public function test_an_overdue_pending_production_with_insufficient_stock_is_auto_declined(): void
     {
         $this->actingAsSuperAdminStaff();
+        $this->withActiveWarehouse(self::WAREHOUSE_ID);
 
         $fx = $this->createFixture(startingSuppliesStock: 1); // far short of the 20 needed for pdQty=10
         $production = $this->createPendingProduction($fx, now()->subDays(5)->toDateString());
@@ -182,6 +185,7 @@ class ProductionOverdueAutoResolverTest extends TestCase
     public function test_an_overdue_cancel_request_is_auto_timed_out_back_to_approved(): void
     {
         $this->actingAsSuperAdminStaff();
+        $this->withActiveWarehouse(self::WAREHOUSE_ID);
 
         $fx = $this->createFixture();
         $production = $this->createPendingProduction($fx, now()->subDays(5)->toDateString());
@@ -209,6 +213,7 @@ class ProductionOverdueAutoResolverTest extends TestCase
     public function test_getProduction_shows_system_auto_timeout_label_instead_of_the_viewing_staffs_name(): void
     {
         $this->actingAsSuperAdminStaff();
+        $this->withActiveWarehouse(self::WAREHOUSE_ID);
 
         $fx = $this->createFixture();
         $production = $this->createPendingProduction($fx, now()->subDays(5)->toDateString());
@@ -227,6 +232,7 @@ class ProductionOverdueAutoResolverTest extends TestCase
     public function test_getProduction_still_shows_the_real_staff_name_for_a_genuine_manual_decision(): void
     {
         $this->actingAsSuperAdminStaff();
+        $this->withActiveWarehouse(self::WAREHOUSE_ID);
 
         $fx = $this->createFixture();
         $production = $this->createPendingProduction($fx, now()->toDateString());
@@ -244,6 +250,7 @@ class ProductionOverdueAutoResolverTest extends TestCase
     public function test_getProduction_still_triggers_the_same_auto_timeout_as_a_side_effect(): void
     {
         $this->actingAsSuperAdminStaff();
+        $this->withActiveWarehouse(self::WAREHOUSE_ID);
 
         $fx = $this->createFixture();
         $production = $this->createPendingProduction($fx, now()->subDays(5)->toDateString());
@@ -268,6 +275,7 @@ class ProductionOverdueAutoResolverTest extends TestCase
     public function test_dry_run_summary_does_not_claim_a_fake_approved_declined_outcome(): void
     {
         $this->actingAsSuperAdminStaff();
+        $this->withActiveWarehouse(self::WAREHOUSE_ID);
 
         $fx = $this->createFixture();
         $production = $this->createPendingProduction($fx, now()->subDays(5)->toDateString());

--- a/tests/Workflow/ProductionOverdueAutoResolverTest.php
+++ b/tests/Workflow/ProductionOverdueAutoResolverTest.php
@@ -1,0 +1,211 @@
+<?php
+
+namespace Tests\Workflow;
+
+use App\Models\Bom;
+use App\Models\BomDetail;
+use App\Models\Category;
+use App\Models\Product;
+use App\Models\ProductStock;
+use App\Models\ProductVariant;
+use App\Models\Production;
+use App\Models\ProductionDetails;
+use App\Models\Supplies;
+use App\Models\SuppliesStock;
+use App\Support\ProductionOverdueAutoResolver;
+use Tests\Support\ActingAsStaff;
+use Tests\TestCase;
+
+/**
+ * See cdocs/docs/flows/production/FLOW.md and cdocs/testing/KNOWN_ISSUES.md's "GET /getProduction
+ * can silently trigger real stock mutations" entry.
+ *
+ * REFACTORED (2026-08-05): the ~4-day auto-timeout for overdue pending productions/cancel-requests
+ * used to run inline inside `Production::getProduction()`'s per-row display loop — only ever
+ * processing whichever rows happened to pass the current GET request's own filters, and recursing
+ * back into itself on every match. Kept as an explicit product decision (still triggers on every
+ * page load, for now), but extracted into `App\Support\ProductionOverdueAutoResolver` — a single,
+ * independently-testable, non-recursive pass over ALL overdue rows regardless of any list filter —
+ * now shared between `getProduction()` and the new `php artisan production:resolve-overdue` command
+ * (for eventually running this only via cron, without touching this logic again).
+ */
+class ProductionOverdueAutoResolverTest extends TestCase
+{
+    use ActingAsStaff;
+
+    private const UNIT_ID = 9; // "Piece"
+    private const WAREHOUSE_ID = 1;
+    private const BOM_QTY = 1;
+    private const BOM_DETAIL_QTY = 2;
+
+    /** @return array{variant: ProductVariant, productStock: ProductStock, suppliesStock: SuppliesStock, bom: Bom} */
+    private function createFixture(int $startingSuppliesStock = 1000): array
+    {
+        $category = new Category();
+        $category->category_name = 'Overdue Resolver Test Category';
+        $category->status = 1;
+        $category->save();
+
+        $product = new Product();
+        $product->product_name = 'Overdue Resolver Test Product';
+        $product->category_id = $category->category_id;
+        $product->product_unit = json_encode([self::UNIT_ID]);
+        $product->unit_id = self::UNIT_ID;
+        $product->status = 1;
+        $product->save();
+
+        $variant = new ProductVariant();
+        $variant->product_id = $product->product_id;
+        $variant->product_variant_name = 'Overdue Resolver Test Variant';
+        $variant->product_variant_sku = 'WF-OVERDUE-'.uniqid();
+        $variant->product_variant_price = 0;
+        $variant->status = 1;
+        $variant->save();
+
+        $productStock = new ProductStock();
+        $productStock->product_id = $product->product_id;
+        $productStock->product_variant_id = $variant->product_variant_id;
+        $productStock->unit_id = self::UNIT_ID;
+        $productStock->warehouse_id = self::WAREHOUSE_ID;
+        $productStock->ps_stock = 0;
+        $productStock->status = 1;
+        $productStock->save();
+
+        $supplies = new Supplies();
+        $supplies->supplies_name = 'Overdue Resolver Test Supplies';
+        $supplies->supplies_unit = json_encode([self::UNIT_ID]);
+        $supplies->supplies_default_unit = self::UNIT_ID;
+        $supplies->status = 1;
+        $supplies->save();
+
+        $suppliesStock = new SuppliesStock();
+        $suppliesStock->supplies_id = $supplies->supplies_id;
+        $suppliesStock->unit_id = self::UNIT_ID;
+        $suppliesStock->warehouse_id = self::WAREHOUSE_ID;
+        $suppliesStock->ss_stock = $startingSuppliesStock;
+        $suppliesStock->status = 1;
+        $suppliesStock->save();
+
+        $bom = new Bom();
+        $bom->product_id = $variant->product_variant_id;
+        $bom->bom_qty = self::BOM_QTY;
+        $bom->unit_id = self::UNIT_ID;
+        $bom->status = 1;
+        $bom->save();
+
+        $bomDetail = new BomDetail();
+        $bomDetail->bom_id = $bom->bom_id;
+        $bomDetail->supplies_id = $supplies->supplies_id;
+        $bomDetail->bom_detail_qty = self::BOM_DETAIL_QTY;
+        $bomDetail->unit_id = self::UNIT_ID;
+        $bomDetail->status = 1;
+        $bomDetail->save();
+
+        return compact('variant', 'productStock', 'suppliesStock', 'bom');
+    }
+
+    private function createPendingProduction(array $fx, string $productionDate, int $pdQty = 10): Production
+    {
+        $production = new Production();
+        $production->production_date = $productionDate;
+        $production->production_code = 'PRV'.substr(uniqid(), -6);
+        $production->production_desc = 'Overdue resolver test production';
+        $production->production_created_by = 1;
+        $production->status = 1;
+        $production->save();
+
+        $detail = new ProductionDetails();
+        $detail->production_id = $production->production_id;
+        $detail->product_variant_id = $fx['variant']->product_variant_id;
+        $detail->pd_qty = $pdQty;
+        $detail->unit_id = self::UNIT_ID;
+        $detail->bom_id = $fx['bom']->bom_id;
+        $detail->status = 1;
+        $detail->save();
+
+        return $production;
+    }
+
+    public function test_an_overdue_pending_production_with_enough_stock_is_auto_approved(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $fx = $this->createFixture();
+        $production = $this->createPendingProduction($fx, now()->subDays(5)->toDateString());
+
+        $summary = (new ProductionOverdueAutoResolver())->resolveOverdue();
+
+        $this->assertSame(1, $summary['pending_approved']);
+        $this->assertSame(0, $summary['pending_declined']);
+
+        $production->refresh();
+        $this->assertSame(2, (int) $production->status, 'an overdue, resolvable production must be auto-approved');
+
+        $fx['productStock']->refresh();
+        $this->assertSame(10, $fx['productStock']->ps_stock, 'the real accProduction() logic must have run, crediting finished-goods stock');
+    }
+
+    public function test_a_pending_production_not_yet_overdue_is_left_untouched(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $fx = $this->createFixture();
+        $production = $this->createPendingProduction($fx, now()->subDays(2)->toDateString());
+
+        $summary = (new ProductionOverdueAutoResolver())->resolveOverdue();
+
+        $this->assertSame(0, $summary['pending_checked'], 'a production only 2 days old must not be considered overdue yet');
+
+        $production->refresh();
+        $this->assertSame(1, (int) $production->status, 'must remain pending');
+    }
+
+    public function test_an_overdue_pending_production_with_insufficient_stock_is_auto_declined(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $fx = $this->createFixture(startingSuppliesStock: 1); // far short of the 20 needed for pdQty=10
+        $production = $this->createPendingProduction($fx, now()->subDays(5)->toDateString());
+
+        $summary = (new ProductionOverdueAutoResolver())->resolveOverdue();
+
+        $this->assertSame(0, $summary['pending_approved']);
+        $this->assertSame(1, $summary['pending_declined']);
+
+        $production->refresh();
+        $this->assertSame(3, (int) $production->status, 'a resolvable-check failure must fall back to auto-decline, not stay stuck pending');
+    }
+
+    public function test_an_overdue_cancel_request_is_auto_timed_out_back_to_approved(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $fx = $this->createFixture();
+        $production = $this->createPendingProduction($fx, now()->subDays(5)->toDateString());
+        $production->status = 4; // pending cancel-request, as if already approved once
+        $production->cancel_requested_by = 1;
+        $production->save();
+
+        $summary = (new ProductionOverdueAutoResolver())->resolveOverdue();
+
+        $this->assertSame(1, $summary['cancel_timed_out']);
+
+        $production->refresh();
+        $this->assertSame(2, (int) $production->status, 'an overdue cancel-request must time out back to approved, not stay pending forever');
+    }
+
+    public function test_getProduction_still_triggers_the_same_auto_timeout_as_a_side_effect(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $fx = $this->createFixture();
+        $production = $this->createPendingProduction($fx, now()->subDays(5)->toDateString());
+
+        // Confirms the refactor preserved the (deliberately kept, for now) side effect: merely
+        // loading/refreshing the Produksi list still resolves overdue productions.
+        $this->get('/getProduction')->assertStatus(200);
+
+        $production->refresh();
+        $this->assertSame(2, (int) $production->status, 'GET /getProduction must still auto-resolve overdue productions as a side effect');
+    }
+}


### PR DESCRIPTION
Part of the `main` → `fase2/main` batch merge plan (`cdocs/docs/fase2-merge-plan.md`).

## What this brings in
Cherry-picked from `main`: `26260df`, `c7899b3`, `b1ae49f`, `70c4ecb` (production overdue auto-timeout feature, extracted into `ProductionOverdueAutoResolver` + a new `production:resolve-overdue` cron command), and `145635e` (camera error-message improvements — landed on `main` mid-session, folded in here per the merge plan's "Batch 8" note).

**Skipped:** `7f7324c` — confirmed all 37 modal partial files it would create already exist on fase2 (it was main catching up to a componentization pattern fase2 already had). No hold needed for this batch; none of these touch `accProduction`/`accDeleteProduction`.

## Conflicts
Every conflict here was the same shape as Batch 1: git pulling in large stale-context blocks from main's older, pre-componentized modal/JS structure. Resolved by keeping fase2's real, already-existing functions/handlers and surgically inserting main's actual new lines (status badge, cancel-info fields, `cameraRequestId` guard, HTTPS-aware camera error messages) into their real locations. Verified no duplicate declarations after each resolve.

## Two real bugs found by running this batch's own new tests (not by conflict markers)
1. **`ProductionOverdueAutoResolver` misread `accProduction()` success as failure.** It checked `$result === 1` (correct on main, where `accProduction()` always returns bare `1`). On this branch, `accProduction()` can legitimately return a `JsonResponse` with `status:1` instead (no-Stock-Transfer-needed case) — the strict check misclassified that as failure, silently auto-declining every resolvable overdue production. Fixed using the same JsonResponse-aware check fase2's own (now-removed) inline predecessor already had.
2. Local `pegasus_testing` DB was missing several recent migrations, masking bug #1 behind an earlier "Migrasi Belum Dijalankan" guard, and was also the real cause of the `customer_product_returns`/`customer_supply_returns` `SchemaConsistencyTest` failures previously assumed to be baseline noise. Ran `php artisan migrate --env=testing`.

## ⚠️ Flagged for your review — same territory as the accProduction hold
`activeMainProductionWarehouse()` has no fallback when no session is active. This batch also activates `routes/console.php`'s new daily cron schedule for `production:resolve-overdue`. An unattended cron run has no web session, so it will always fail that guard and fall through to auto-decline — it will never auto-approve. The web-triggered path (`GET /getProduction`, real staff session) works fine; only the new cron path is affected. Not fixed here — needs a design decision on the fallback behavior, adjacent to the standing `accProduction` hold.

## Testing
Ran Smoke/Health/Workflow/Regression/DatabaseTransaction, diffed failing-test-name lists against a fresh baseline worktree (after the migration catch-up, for an apples-to-apples comparison) — zero new failures. Current suite state (368 tests, 2 errors, 25 failures) is 100% pre-existing, unrelated to this batch — confirmed via the same baseline diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)