### PR TITLE
Batch 5: squashed PRs #13/#21/#22/#24 + real bug fixes (main → fase2)

### DIFF
--- a/app/Http/Controllers/CustomerController.php
+++ b/app/Http/Controllers/CustomerController.php
@@ -183,19 +183,17 @@ class CustomerController extends Controller
             ];
         }
 
-        $plan = SalesOrderStock::buildPlan($newLines, $newRetailWh > 0 ? $newRetailWh : null);
-        if (! ($plan['ok'] ?? false)) {
-            return response()->json([
-                'status' => $plan['status'] ?? 0,
-                'header' => $plan['header'] ?? 'Stok tidak cukup',
-                'message' => $plan['message'] ?? 'Stok tidak mencukupi',
-                'products' => $plan['products'] ?? [],
-                'recommendations' => $plan['recommendations'] ?? [],
-            ]);
-        }
-
+        // Diperbaiki (2026-08-08): buildPlan() (cek kecukupan stok untuk item BARU) dulu dijalankan
+        // di sini, SEBELUM executeRestore() di bawah mengembalikan stok item LAMA — jadi SO yang
+        // stoknya sudah habis terpakai (kasus normal: menjual persis sisa stok) ditolak "Stok tidak
+        // cukup" bahkan untuk edit no-op yang sama sekali tidak menambah komitmen stok apa pun.
+        // Sekarang plan dibangun DI DALAM transaction, SETELAH restore, supaya mengecek terhadap
+        // stok yang sudah benar mencerminkan pengembalian item lama. $plan ditangkap lewat
+        // referensi supaya detail respons (products/recommendations) masih bisa dibaca di blok
+        // catch kalau gagal.
+        $plan = null;
         try {
-            DB::transaction(function () use ($data, $productsData, $oldLines, $oldRetailWh, $plan, $soBefore) {
+            DB::transaction(function () use ($data, $productsData, $oldLines, $oldRetailWh, $newLines, $newRetailWh, $soBefore, &$plan) {
                 if ($oldLines !== []) {
                     $restore = SalesOrderStock::executeRestore(
                         $oldLines,
@@ -206,6 +204,11 @@ class CustomerController extends Controller
                     if (! ($restore['ok'] ?? false)) {
                         throw new \RuntimeException($restore['message'] ?? 'Gagal kembalikan stok lama');
                     }
+                }
+
+                $plan = SalesOrderStock::buildPlan($newLines, $newRetailWh > 0 ? $newRetailWh : null);
+                if (! ($plan['ok'] ?? false)) {
+                    throw new \RuntimeException($plan['message'] ?? 'Stok tidak mencukupi');
                 }
 
                 $deduct = SalesOrderStock::executeDeduct(
@@ -229,6 +232,15 @@ class CustomerController extends Controller
                 SalesOrderDetail::where('so_id', $so->so_id)->whereNotIn('sod_id', $list_id_detail)->update(['status' => 0]);
             });
         } catch (\Throwable $e) {
+            if ($plan && ! ($plan['ok'] ?? false)) {
+                return response()->json([
+                    'status' => $plan['status'] ?? 0,
+                    'header' => $plan['header'] ?? 'Stok tidak cukup',
+                    'message' => $plan['message'] ?? 'Stok tidak mencukupi',
+                    'products' => $plan['products'] ?? [],
+                    'recommendations' => $plan['recommendations'] ?? [],
+                ]);
+            }
             return response()->json([
                 'status' => 0,
                 'header' => 'Gagal Update',

--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -426,12 +426,17 @@ class ProductController extends Controller
         //     ]);
         // }
 
-        $id = (new Product())->insertProduct($data);
         $variant = $this->sanitizeVariantValues(json_decode($data['product_variant'], true) ?: []);
         $safetyPayload = $this->extractSafetyPayload($variant);
         $variant = $this->stripSafetyFromVariants($variant);
         $relasi = json_decode($data['product_relasi'], true);
 
+        // Diperbaiki (2026-08-05): regresi dari fix 2026-08-03 — sempat berubah jadi
+        // insertProduct() dipanggil DUA KALI, yang pertama sebelum precheck ini sama sekali
+        // (jadi row Product sudah permanen dibuat walau precheck akhirnya menolak), yang kedua
+        // (baris di bawah, yang sebenarnya dipakai) tepat setelah precheck lolos. Sekarang precheck
+        // ini kembali jadi hal PERTAMA yang terjadi, sebelum satu row pun disentuh — lihat
+        // KNOWN_ISSUES.md "Two product SKUs were shared across different products".
         $uniquenessError = $this->validateVariantUniqueness($variant, null);
         if ($uniquenessError) {
             return response()->json(['message' => $uniquenessError]);
@@ -465,6 +470,17 @@ class ProductController extends Controller
         $variant = $this->sanitizeVariantValues(json_decode($data['product_variant'], true) ?: []);
         $safetyPayload = $this->extractSafetyPayload($variant);
         $variant = $this->stripSafetyFromVariants($variant);
+
+        // Diperbaiki (2026-08-05): regresi dari fix 2026-08-03 — updateProduct() sempat kehilangan
+        // panggilan ke precheck ini sama sekali, jadi mengganti nama sebuah varian supaya sama
+        // dengan varian lain pada produk yang sama (atau SKU yang sudah dipakai produk lain) tidak
+        // ditolak lagi. Dicek per varian, exclude dirinya sendiri lewat product_variant_id yang
+        // sudah ada di payload — lihat validateVariantUniqueness().
+        $uniquenessError = $this->validateVariantUniqueness($variant, (int) $data['product_id']);
+        if ($uniquenessError) {
+            return response()->json(['message' => $uniquenessError]);
+        }
+
         (new Product())->updateProduct($data);
         foreach ($variant as $key => $value) {
             $value['product_id'] = $data["product_id"];

--- a/app/Http/Controllers/ProductionController.php
+++ b/app/Http/Controllers/ProductionController.php
@@ -224,9 +224,10 @@ class ProductionController extends Controller
                 ]);
             }
 
-            // Pengali konversi BOM vs Input User (dalam satuan terkecil produk)
-            $qty = 1;
-            if ($bom['unit_id'] != $value['unit_id']) {
+            // Pengecekan unit produksi punya relasi yang tersambung ke satuan resep atau tidak
+            // (dos/pack di bawah butuh ini; getBatchCount() sendiri sudah aman lewat
+            // convertQtyToSmallestUnit()'s fail-safe kalau tidak tersambung).
+            if ($bom['unit_id'] != $value['unit_id']){
                 $pr = ProductRelation::where('product_variant_id', $value['product_variant_id'])
                     ->where('status', 1)
                     ->orderBy('pr_id', 'desc')
@@ -262,11 +263,6 @@ class ProductionController extends Controller
                     if (!in_array($namaProduk, $produk_tanpa_relasi, true)) $produk_tanpa_relasi[] = $namaProduk;
                     continue;
                 }
-
-                // Pengali $qty dari satuan input user ke satuan terkecil produk (dipakai
-                // khusus untuk bahan dos/pack) — bug #16: delegate to the fixed
-                // convertQtyToSmallestUnit() instead of re-multiplying every relation row here.
-                $qty = $this->convertQtyToSmallestUnit(1, (int) $value['unit_id'], (int) $value['product_variant_id']);
             }
 
             // Masukkan ke dalam array agregat berdasarkan supplies_id
@@ -297,10 +293,17 @@ class ProductionController extends Controller
                         ->where('status', 1)
                         ->first();
 
+                    // Diperbaiki (2026-08-06): dulu pakai convertQtyToSmallestUnit(), yang jalan
+                    // sampai unit paling bawah di rantai relasi — salah kalau rantainya lebih dari
+                    // satu tingkat (satuan resep belum tentu unit paling bawah). Sekarang berhenti
+                    // TEPAT di satuan resep ($bom['unit_id']) — lihat convertQtyBetweenUnits().
                     $nilaiIsiDos = $relasiKonversi ? $relasiKonversi->pr_unit_value_2 : 1;
-                    $totalPcs    = ($bom['unit_id'] != $value['unit_id'])
-                        ? $value['pd_qty'] * $qty
-                        : $value['pd_qty'];
+                    $totalPcs    = $this->convertQtyBetweenUnits(
+                        (int) $value['pd_qty'],
+                        (int) $value['unit_id'],
+                        (int) $bom['unit_id'],
+                        (int) $value['product_variant_id']
+                    );
                     $jumlahDos      = floor($totalPcs / $nilaiIsiDos);
                     $kebutuhanBaris = $jumlahDos * $bd['bom_detail_qty'];
                 } else {
@@ -577,9 +580,10 @@ class ProductionController extends Controller
                 ]);
             }
 
-            // Logika pencarian pengali konversi (BOM vs Input User)
-            $qty = 1; // ← dipakai khusus untuk perhitungan bahan dos/pack di bawah
-            if ($bom['unit_id'] != $value['unit_id']) {
+            // Pengecekan unit produksi punya relasi yang tersambung ke satuan resep atau tidak
+            // (dos/pack di bawah butuh ini; getBatchCount() sendiri sudah aman lewat
+            // convertQtyToSmallestUnit()'s fail-safe kalau tidak tersambung).
+            if ($bom['unit_id'] != $value['unit_id']){
                 $pr = ProductRelation::where('product_variant_id', $value['product_variant_id'])
                     ->where('status', 1)
                     ->orderBy('pr_id', 'desc')
@@ -615,11 +619,6 @@ class ProductionController extends Controller
                     if (!in_array($namaProduk, $produk_tanpa_relasi, true)) $produk_tanpa_relasi[] = $namaProduk;
                     continue;
                 }
-
-                // Pengali $qty dari satuan input user ke satuan terkecil produk (dipakai
-                // khusus bahan dos/pack) — bug #16: delegate to the fixed
-                // convertQtyToSmallestUnit() instead of re-multiplying every relation row here.
-                $qty = $this->convertQtyToSmallestUnit(1, (int) $value['unit_id'], (int) $value['product_variant_id']);
             }
 
             // Masukkan ke dalam array agregat berdasarkan supplies_id
@@ -642,10 +641,15 @@ class ProductionController extends Controller
                         ->where('status', 1)
                         ->first();
 
+                    // Diperbaiki (2026-08-06): lihat comment di convertQtyBetweenUnits() —
+                    // berhenti tepat di satuan resep, bukan sampai unit paling bawah rantai.
                     $nilaiIsiDos = $relasiKonversi ? $relasiKonversi->pr_unit_value_2 : 1;
-                    $totalPcs    = ($bom['unit_id'] != $value['unit_id'])
-                        ? $value['pd_qty'] * $qty
-                        : $value['pd_qty'];
+                    $totalPcs    = $this->convertQtyBetweenUnits(
+                        (int) $value['pd_qty'],
+                        (int) $value['unit_id'],
+                        (int) $bom['unit_id'],
+                        (int) $value['product_variant_id']
+                    );
                     $jumlahDos      = floor($totalPcs / $nilaiIsiDos);
                     $kebutuhanBaris = $jumlahDos * $bd['bom_detail_qty'];
                 } else {
@@ -1303,14 +1307,6 @@ class ProductionController extends Controller
             $bdetail = BomDetail::where('bom_id', $value['bom_id'])->where('status', 1)->get();
             if (!$b) continue;
 
-            // Pengali $qty (dos/pack) — bug #16: delegate to the fixed
-            // convertQtyToSmallestUnit() instead of re-multiplying every relation row here, so
-            // this reversal path stays symmetric with insertProduction()/accProduction().
-            $qty = 1;
-            if ($b['unit_id'] != $value['unit_id']) {
-                $qty = $this->convertQtyToSmallestUnit(1, (int) $value['unit_id'], (int) $value['product_variant_id']);
-            }
-
             $batchCount = $this->getBatchCount(
                 (int) $value['pd_qty'],
                 (int) $value['unit_id'],
@@ -1331,10 +1327,16 @@ class ProductionController extends Controller
                         ->where('status', 1)
                         ->first();
 
+                    // Diperbaiki (2026-08-06): lihat comment di convertQtyBetweenUnits() —
+                    // berhenti tepat di satuan resep, bukan sampai unit paling bawah rantai. Ini
+                    // membuat reversal ini simetris dengan insertProduction()/accProduction().
                     $nilaiIsiDos = $relasiKonversi ? $relasiKonversi->pr_unit_value_2 : 1;
-                    $totalPcs    = ($b['unit_id'] != $value['unit_id'])
-                        ? $value['pd_qty'] * $qty
-                        : $value['pd_qty'];
+                    $totalPcs    = $this->convertQtyBetweenUnits(
+                        (int) $value['pd_qty'],
+                        (int) $value['unit_id'],
+                        (int) $b['unit_id'],
+                        (int) $value['product_variant_id']
+                    );
                     $jumlahDos      = floor($totalPcs / $nilaiIsiDos);
                     $kebutuhanBaris = $jumlahDos * $bd['bom_detail_qty'];
                 } else {
@@ -1556,6 +1558,51 @@ class ProductionController extends Controller
         }
 
         return $qty * $multiplier;
+    }
+
+    /**
+     * Diperbaiki (2026-08-06): dulu perhitungan "kemasan besar" (dos/pack) di bawah memakai
+     * convertQtyToSmallestUnit(), yang SELALU jalan sampai unit paling bawah di rantai relasi —
+     * padahal yang dibutuhkan di sana adalah qty dalam satuan RESEP (`$bom['unit_id']`), yang
+     * belum tentu unit paling bawah kalau rantainya lebih dari satu tingkat (mis. Dos->Pcs->Liter,
+     * resep pakai Pcs — bukan Liter). Contoh nyata bedanya: 1 Dos = 12 Pcs, 1 Pcs = 2 Liter. Resep
+     * "Dos Karton isi 12 Pcs" butuh qty dalam satuan Pcs (12), tapi convertQtyToSmallestUnit()
+     * jalan terus sampai Liter (12*2=24) — floor(24/12)=2 dos yang dianggap terpakai, padahal yang
+     * benar floor(12/12)=1. Method ini berhenti TEPAT di $toUnitId, bukan di dasar rantai.
+     *
+     * Fail-safe: kalau $toUnitId tidak pernah ketemu sambil turun dari $fromUnitId (seharusnya
+     * tidak terjadi untuk produk yang relasinya sudah tersambung benar, lihat validasi "$ada" di
+     * pemanggil), kembalikan $qty apa adanya (anggap 1:1) daripada mengalikan dengan faktor yang
+     * sebenarnya tidak berhubungan.
+     */
+    private function convertQtyBetweenUnits(int $qty, int $fromUnitId, int $toUnitId, int $productVariantId): int
+    {
+        if ($fromUnitId === $toUnitId) {
+            return $qty;
+        }
+
+        $relations = ProductRelation::where('product_variant_id', $productVariantId)
+            ->where('status', 1)
+            ->get();
+
+        $multiplier = 1;
+        $currentUnit = $fromUnitId;
+        $guard = 0;
+
+        while ($guard < 20) {
+            $guard++;
+            $rel = $relations->first(fn ($r) => (int) $r->pr_unit_id_1 === (int) $currentUnit);
+            if (!$rel) {
+                return $qty;
+            }
+            $multiplier *= (int) $rel->pr_unit_value_2;
+            $currentUnit = (int) $rel->pr_unit_id_2;
+            if ($currentUnit === $toUnitId) {
+                return $qty * $multiplier;
+            }
+        }
+
+        return $qty;
     }
 
     private function getBatchCount(

--- a/app/Http/Controllers/ProductionController.php
+++ b/app/Http/Controllers/ProductionController.php
@@ -357,13 +357,15 @@ class ProductionController extends Controller
                 ];
             }
 
-            $siapkanStok = function ($targetKey, $units, $jumlahDibutuhkan) use (
-                &$virtualStock,
-                &$logSummary,
-                &$siapkanStok,
-                $bd,
-                $suppliesId
+            $siapkanStok = function ($targetKey, $units, $jumlahDibutuhkan, $depth = 0) use (
+                &$virtualStock, &$logSummary, &$siapkanStok, $bd, $suppliesId
             ) {
+                // Ditambahkan (2026-08-06): depth guard — $keyAtas dicari lewat lookup relasi,
+                // jadi rantai SuppliesRelation yang sirkular bisa membuat rekursi ini jalan
+                // selamanya. Belum pernah tereproduksi dengan data nyata, murni defensive guard.
+                // Lihat KNOWN_ISSUES.md.
+                if ($depth >= 20) return false;
+
                 $stokSekarang = $units[$targetKey];
 
                 $sr = SuppliesRelation::where('supplies_id', $bd['supplies_id'])
@@ -393,7 +395,7 @@ class ProductionController extends Controller
                 $butuhDariAtas = (int) ceil($kekurangan / $nilaiKonversi);
 
                 if ($virtualStock[$stokAtas->ss_id]['current'] < $butuhDariAtas) {
-                    $siapkanStok($keyAtas, $units, $butuhDariAtas);
+                    $siapkanStok($keyAtas, $units, $butuhDariAtas, $depth + 1);
                 }
 
                 $bongkarSebenarnya = min($butuhDariAtas, (int) $virtualStock[$stokAtas->ss_id]['current']);
@@ -716,11 +718,16 @@ class ProductionController extends Controller
                 ];
             }
 
-            $siapkanStokCek = function ($targetKey, $units, $jumlahDibutuhkan) use (
+            $siapkanStokCek = function ($targetKey, $units, $jumlahDibutuhkan, $depth = 0) use (
                 &$virtualStock,
                 &$siapkanStokCek,
                 $bd
             ) {
+                // Depth guard — mirrors $siapkanStok() above, see its comment.
+                if ($depth >= 20) {
+                    return false;
+                }
+
                 $stokSekarang = $units[$targetKey];
                 $sr = SuppliesRelation::where('supplies_id', $bd['supplies_id'])
                     ->where('su_id_2', $stokSekarang->unit_id)
@@ -754,7 +761,7 @@ class ProductionController extends Controller
 
                 $butuhDariAtas = (int) ceil($kekurangan / $nilaiKonversi);
                 if ($virtualStock[$stokAtas->ss_id]['current'] < $butuhDariAtas) {
-                    $siapkanStokCek($keyAtas, $units, $butuhDariAtas);
+                    $siapkanStokCek($keyAtas, $units, $butuhDariAtas, $depth + 1);
                 }
 
                 $bongkarSebenarnya = min($butuhDariAtas, (int) $virtualStock[$stokAtas->ss_id]['current']);
@@ -898,13 +905,17 @@ class ProductionController extends Controller
                     ];
                 }
 
-                $siapkanStok = function ($targetKey, $units, $jumlahDibutuhkan) use (
+                $siapkanStok = function ($targetKey, $units, $jumlahDibutuhkan, $depth = 0) use (
                     &$virtualStock,
                     &$logSummary,
                     &$siapkanStok,
                     $bd,
                     $suppliesId
                 ) {
+                    // Depth guard — mirrors the other $siapkanStok() in this controller, see its
+                    // comment.
+                    if ($depth >= 20) return false;
+
                     $stokSekarang = $units[$targetKey];
 
                     $sr = SuppliesRelation::where('supplies_id', $bd['supplies_id'])
@@ -938,7 +949,7 @@ class ProductionController extends Controller
                     // Kalau stok atas tidak cukup, coba bongkar dulu dari level
                     // yang lebih atas lagi (rekursif)
                     if ($virtualStock[$stokAtas->ss_id]['current'] < $butuhDariAtas) {
-                        $siapkanStok($keyAtas, $units, $butuhDariAtas);
+                        $siapkanStok($keyAtas, $units, $butuhDariAtas, $depth + 1);
                     }
 
                     $bongkarSebenarnya = min($butuhDariAtas, (int) $virtualStock[$stokAtas->ss_id]['current']);

--- a/app/Http/Controllers/ProductionController.php
+++ b/app/Http/Controllers/ProductionController.php
@@ -263,13 +263,10 @@ class ProductionController extends Controller
                     continue;
                 }
 
-                // ← ditambahkan: hitung pengali $qty dari satuan input user
-                //   ke satuan terkecil produk (dipakai khusus untuk bahan dos/pack)
-                foreach ($pr as $relasi) {
-                    if ($relasi['pr_unit_id_2'] != $value['unit_id']) {
-                        $qty *= $relasi['pr_unit_value_2'];
-                    }
-                }
+                // Pengali $qty dari satuan input user ke satuan terkecil produk (dipakai
+                // khusus untuk bahan dos/pack) — bug #16: delegate to the fixed
+                // convertQtyToSmallestUnit() instead of re-multiplying every relation row here.
+                $qty = $this->convertQtyToSmallestUnit(1, (int) $value['unit_id'], (int) $value['product_variant_id']);
             }
 
             // Masukkan ke dalam array agregat berdasarkan supplies_id
@@ -617,13 +614,10 @@ class ProductionController extends Controller
                     continue;
                 }
 
-                // ← ditambahkan: hitung pengali $qty dari satuan input user
-                //   ke satuan terkecil produk (dipakai khusus bahan dos/pack)
-                foreach ($pr as $relasi) {
-                    if ($relasi['pr_unit_id_2'] != $value['unit_id']) {
-                        $qty *= $relasi['pr_unit_value_2'];
-                    }
-                }
+                // Pengali $qty dari satuan input user ke satuan terkecil produk (dipakai
+                // khusus bahan dos/pack) — bug #16: delegate to the fixed
+                // convertQtyToSmallestUnit() instead of re-multiplying every relation row here.
+                $qty = $this->convertQtyToSmallestUnit(1, (int) $value['unit_id'], (int) $value['product_variant_id']);
             }
 
             // Masukkan ke dalam array agregat berdasarkan supplies_id
@@ -1298,18 +1292,12 @@ class ProductionController extends Controller
             $bdetail = BomDetail::where('bom_id', $value['bom_id'])->where('status', 1)->get();
             if (!$b) continue;
 
+            // Pengali $qty (dos/pack) — bug #16: delegate to the fixed
+            // convertQtyToSmallestUnit() instead of re-multiplying every relation row here, so
+            // this reversal path stays symmetric with insertProduction()/accProduction().
             $qty = 1;
             if ($b['unit_id'] != $value['unit_id']) {
-                $pr = ProductRelation::where('product_variant_id', $value['product_variant_id'])
-                    ->where('status', 1)
-                    ->orderBy('pr_id', 'desc')
-                    ->get();
-
-                foreach ($pr as $relasi) {
-                    if ($relasi['pr_unit_id_2'] != $value['unit_id']) {
-                        $qty *= $relasi['pr_unit_value_2'];
-                    }
-                }
+                $qty = $this->convertQtyToSmallestUnit(1, (int) $value['unit_id'], (int) $value['product_variant_id']);
             }
 
             $batchCount = $this->getBatchCount(
@@ -1529,16 +1517,31 @@ class ProductionController extends Controller
 
     private function convertQtyToSmallestUnit(int $qty, int $unitId, int $productVariantId): int
     {
-        $multiplier = 1;
+        // Bug #16: this used to fetch EVERY active product_relations row for the variant and
+        // multiply all of their pr_unit_value_2 together whenever the row's base unit wasn't
+        // $unitId — which is true for every sibling row when a product has more than one
+        // independent "big unit -> Piece" relation (e.g. DOS=20pcs, kg=5pcs, LTR=10pcs all
+        // mapping to Piece). That folded unrelated relations into the multiplier
+        // (20 * 5 * 10 = 1000) instead of picking the single relation that actually matches
+        // $unitId, producing a 100x+ raw-material overconsumption. Walk the chain one hop at a
+        // time instead, exactly like the already-correct convertSuppliesQtyToSmallestUnit()
+        // below — this also makes multi-level ladders (Sak -> DOS -> Piece) resolve correctly.
         $relations = ProductRelation::where('product_variant_id', $productVariantId)
             ->where('status', 1)
-            ->orderBy('pr_id', 'desc')
             ->get();
 
-        foreach ($relations as $relation) {
-            if ($relation['pr_unit_id_2'] != $unitId) {
-                $multiplier *= (int) $relation['pr_unit_value_2'];
+        $multiplier = 1;
+        $currentUnit = $unitId;
+        $guard = 0;
+
+        while ($guard < 20) {
+            $guard++;
+            $rel = $relations->first(fn ($r) => (int) $r->pr_unit_id_1 === (int) $currentUnit);
+            if (!$rel) {
+                break;
             }
+            $multiplier *= (int) $rel->pr_unit_value_2;
+            $currentUnit = (int) $rel->pr_unit_id_2;
         }
 
         return $qty * $multiplier;

--- a/app/Http/Controllers/ReportController.php
+++ b/app/Http/Controllers/ReportController.php
@@ -1070,6 +1070,11 @@ class ReportController extends Controller
             $data["cg_img"] = $imageName;
         }
 
+        // "operasional" == entri "Kas Gudang" (lihat juga acceptCashGudang() di bawah): baris
+        // CashGudangDetail dibuat di bawah, cash_id SELALU 0 — entri ini tidak pernah muncul di
+        // halaman "Kas Besar" (/cash). "saldo" == entri "Kas Besar": tidak pernah punya baris
+        // CashGudangDetail sama sekali, tapi selalu punya cash_id sungguhan lewat Cash::insertCash()
+        // di bawah. Jangan disamakan/digabung, keduanya sengaja berbeda bentuk.
         if ($data['jenis_input'] == "operasional"){
             $total = 0;
             $item = json_decode($data['items'], true);
@@ -1143,6 +1148,21 @@ class ReportController extends Controller
     {
         $data = $req->all();
 
+        // Ditambahkan (2026-08-05): PM konfirmasi sekali status != 1 (sudah disetujui/ditolak),
+        // tidak ada prosedur lain yang boleh mengubah data ini lagi — acceptCashGudang() sudah
+        // memutasi customer_saldo + membuat CashArmada row dari cgd_nominal saat itu, jadi
+        // mengubah cg_nominal/detail baris setelahnya akan membuat kedua sisi tidak sinkron
+        // tanpa ada cara membalikkannya. Sama seperti guard updateCashArmada/updateCashSales.
+        $cash = CashGudang::find($data['cg_id']);
+        if ($cash && $cash->status != 1) {
+            $staff = Staff::find($cash->acc_by)->staff_name ?? '-';
+            return response()->json([
+                "status" => -2,
+                "header" => "Gagal Update",
+                "message" => "Pengajuan sudah disetujui/ditolak oleh " . $staff . ", data tidak bisa diubah lagi"
+            ]);
+        }
+
         if ($req->photo){
             // Ambil base64
             $image = $req->photo;
@@ -1164,7 +1184,6 @@ class ReportController extends Controller
         }
 
         $id = [];
-        $cash = CashGudang::find($data['cg_id']);
 
         if ($data['jenis_input'] == "operasional"){
             $total = 0;
@@ -1248,6 +1267,20 @@ class ReportController extends Controller
     {
         $data = $req->all();
         $ca = CashGudang::find($data['cg_id']);
+
+        // Ditambahkan (2026-08-05): guard yang sama dengan updateCashGudang() di atas — sekali
+        // disetujui/ditolak, acceptCashGudang() sudah memutasi customer_saldo + membuat CashArmada
+        // row, jadi menghapus dokumen ini tidak boleh lagi dimungkinkan (tidak ada cara membalikkan
+        // mutasi yang sudah terjadi).
+        if ($ca && $ca->status != 1) {
+            $staff = Staff::find($ca->acc_by)->staff_name ?? '-';
+            return response()->json([
+                "status" => -2,
+                "header" => "Gagal Hapus",
+                "message" => "Pengajuan sudah disetujui/ditolak oleh " . $staff . ", data tidak bisa dihapus lagi"
+            ]);
+        }
+
         (new CashGudang())->deleteCashGudang($data);
         // Kalau manajemen saldo, maka hapus dari kas juga
         if ($ca->cg_type == 1) (new Cash())->deleteCash($ca);
@@ -1257,66 +1290,87 @@ class ReportController extends Controller
     {
         $data = $req->all();
 
-        if (isset($data['cg_id'])){
-            $cg = CashGudang::find($data['cg_id']);
+        // Race-condition fix (2026-08-05): the "already accepted" status check used to be a
+        // plain read done well before any mutation — two near-simultaneous accept requests for
+        // the same cg_id/cash_id (double-click, a retried request) could both pass that check
+        // and both go on to mutate, double-crediting customer_saldo and inserting duplicate
+        // CashArmada rows. The whole read-check-mutate sequence now runs inside one
+        // DB::transaction() with lockForUpdate() on the CashGudang row itself, so a second
+        // concurrent request blocks on the lock until the first commits, then re-reads the
+        // already-flipped status and is refused cleanly instead of double-processing.
+        // PENTING (dikonfirmasi PM 2026-08-05, JANGAN "disatukan" lagi): isset($data['cg_id']) di
+        // sini BUKAN dua jalan menuju data yang sama — ini pembeda antara dua jenis entri yang
+        // berbeda:
+        //   - cg_id ADA  -> "Kas Gudang" (entri operasional, jenis_input == "operasional" di
+        //     insertCashGudang()/updateCashGudang()). Selalu punya baris CashGudangDetail, cash_id
+        //     SELALU 0 (tidak pernah dapat baris `cashes` sungguhan), makanya TIDAK PERNAH muncul
+        //     di halaman "Kas Besar" (/cash, Cash::getCash() query tabel `cashes` by cash_id asli).
+        //   - cg_id TIDAK ADA (hanya cash_id) -> "Kas Besar" (entri "saldo", jenis_input ==
+        //     "saldo"). Selalu punya baris `cashes` sungguhan lewat cash_id, dan TIDAK PERNAH
+        //     punya baris CashGudangDetail sama sekali.
+        // Karena keduanya tidak pernah overlap, loop customer_saldo + pembuatan CashArmada di
+        // bawah (yang hanya jalan kalau isset($data['cg_id'])) TIDAK PERNAH relevan untuk entri Kas
+        // Besar — bukan berarti Kas Besar "kelewatan" mutasi itu, memang tidak ada apa pun untuk
+        // dimutasi (CashGudangDetail-nya kosong). Lihat KNOWN_ISSUES.md "NOT A BUG: acceptCashGudang()'s
+        // cash_id-only path" untuk detail lengkap sebelum "memperbaiki" percabangan ini lagi.
+        DB::beginTransaction();
+        try {
+            if (isset($data['cg_id'])) {
+                $cg = CashGudang::where('cg_id', $data['cg_id'])->lockForUpdate()->first();
+            } else {
+                $cg = CashGudang::where('cash_id', $data['cash_id'])->lockForUpdate()->first();
+            }
 
-            if ($cg->status != 1) {
-                $staff = Staff::find($cg->acc_by)->staff_name;
+            if (!$cg || $cg->status != 1) {
+                DB::rollBack();
+                $staff = ($cg && $cg->acc_by) ? Staff::find($cg->acc_by) : null;
                 return response()->json([
                     "status" => -2,
                     "header" => "Gagal ACC",
-                    "message" => "Pengajuan sudah diterima/ditolak oleh " . $staff
+                    "message" => "Pengajuan sudah diterima/ditolak oleh " . ($staff->staff_name ?? 'staff lain')
                 ]);
             }
-            $cgd = CashGudangDetail::where('cg_id', $data['cg_id'])->where('status', 1)->get();
 
-            // Ditambahkan: mutasi customer_saldo di bawah + insert CashArmada di
-            // CashGudang::acceptCashGudang() (dipanggil di akhir method ini) dulu tidak dibungkus
-            // transaction sama sekali — customer_id yang tidak valid di baris ke-N akan crash
-            // dengan sebagian baris sebelumnya sudah permanen menaikkan customer_saldo. Sekarang
-            // dicek dulu (tanpa mutasi) sebelum satu pun saldo disentuh, dan seluruh mutasi
-            // (loop ini + acceptCashGudang() di model) dibungkus satu DB::transaction() supaya
-            // gagal di tengah jalan tidak meninggalkan mutasi parsial.
-            $customer_invalid = [];
-            foreach ($cgd as $value) {
-                if (!Customer::find($value['customer_id'])) {
-                    $customer_invalid[] = "id {$value['customer_id']}";
+            if (isset($data['cg_id'])) {
+                $cgd = CashGudangDetail::where('cg_id', $data['cg_id'])->where('status', 1)->get();
+
+                // Ditambahkan: mutasi customer_saldo di bawah + insert CashArmada di
+                // CashGudang::acceptCashGudang() (dipanggil di akhir method ini) dulu tidak
+                // dibungkus transaction sama sekali — customer_id yang tidak valid di baris ke-N
+                // akan crash dengan sebagian baris sebelumnya sudah permanen menaikkan
+                // customer_saldo. Sekarang dicek dulu (tanpa mutasi) sebelum satu pun saldo
+                // disentuh, dan seluruh mutasi (loop ini + acceptCashGudang() di model) dibungkus
+                // satu DB::transaction() supaya gagal di tengah jalan tidak meninggalkan mutasi
+                // parsial.
+                $customer_invalid = [];
+                foreach ($cgd as $value) {
+                    if (!Customer::find($value['customer_id'])) {
+                        $customer_invalid[] = "id {$value['customer_id']}";
+                    }
                 }
-            }
-            if (count($customer_invalid) > 0) {
-                return response()->json([
-                    "status" => 0,
-                    "header" => "Gagal ACC",
-                    "message" => "Data pelanggan tidak ditemukan untuk: " . implode(', ', array_unique($customer_invalid)),
-                ]);
-            }
+                if (count($customer_invalid) > 0) {
+                    DB::rollBack();
+                    return response()->json([
+                        "status" => 0,
+                        "header" => "Gagal ACC",
+                        "message" => "Data pelanggan tidak ditemukan untuk: " . implode(', ', array_unique($customer_invalid)),
+                    ]);
+                }
 
-            DB::beginTransaction();
-            try {
                 foreach ($cgd as $value) {
                     $customer = Customer::find($value['customer_id']);
                     $customer->customer_saldo += $value['cgd_nominal'];
                     $customer->save();
                 }
-                $result = (new CashGudang())->acceptCashGudang($data);
-                DB::commit();
-                return $result;
-            } catch (\Throwable $e) {
-                DB::rollBack();
-                throw $e;
             }
-        } else {
-            $cg = CashGudang::where('cash_id', $data["cash_id"])->first();
-            if ($cg->status != 1) {
-                $staff = Staff::find($cg->acc_by)->staff_name;
-                return response()->json([
-                    "status" => -2,
-                    "header" => "Gagal ACC",
-                    "message" => "Pengajuan sudah diterima/ditolak oleh " . $staff
-                ]);
-            }
+
+            $result = (new CashGudang())->acceptCashGudang($data);
+            DB::commit();
+            return $result;
+        } catch (\Throwable $e) {
+            DB::rollBack();
+            throw $e;
         }
-        return (new CashGudang())->acceptCashGudang($data);
     }
 
     function declineCashGudang(Request $req)

--- a/app/Http/Controllers/ReportController.php
+++ b/app/Http/Controllers/ReportController.php
@@ -436,6 +436,14 @@ class ReportController extends Controller
     function insertCash(Request $req){
         $data = $req->all();
         $cash_id = (new Cash())->insertCash($data);
+        // DEAD CODE (confirmed 2026-08-02, marked 2026-08-06 per user decision — not revived, not
+        // removed, just flagged): the real frontend (Cash.js) has `cash_tujuan` commented out of
+        // the AJAX payload sent to /insertCash, so this whole admin/gudang auto-link branch never
+        // actually runs today. If the literal string "admin"/"gudang" were ever sent again, note
+        // that `Cash::insertCash()`'s own string→int mapping for `cash_tujuan` (the counterpart to
+        // this check) is ALSO commented out, and `cashes.cash_tujuan` is an integer column — so the
+        // `(new Cash())->insertCash($data)` call above would crash with a DB type error before
+        // execution ever reaches this branch at all. See KNOWN_ISSUES.md for the full trace.
         if (isset($data['cash_tujuan']) && $data['cash_tujuan'] != null) {
             if ($data['cash_tujuan'] == "admin"){
                 (new CashAdmin())->insertCashAdmin([

--- a/app/Http/Controllers/StockController.php
+++ b/app/Http/Controllers/StockController.php
@@ -196,6 +196,9 @@ class StockController extends Controller
             'category_id' => $sto->category_id,
             'sto_notes'   => $sto->sto_notes,
             'status'      => $sto->status,
+            // Ditambahkan (2026-08-05): CreateStockOpname.js membaca data.is_draft/data.created_by
+            // untuk canEditDraft — sebelumnya keduanya tidak ada di array ini sama sekali, jadi
+            // selalu undefined di frontend (draft tidak pernah terdeteksi sebagai draft).
             'is_draft'    => (bool) $sto->is_draft,
             'created_by'  => $sto->created_by,
             'item'        => $items
@@ -252,6 +255,19 @@ class StockController extends Controller
             ($sto->warehouse_id ?? null)
             ?: (Session::get('active_warehouse_id') ?? 0)
         );
+
+        // Ditambahkan (2026-08-05): gerbang draft — kolom is_draft sudah ada di DB tapi baru
+        // sekarang benar-benar ditulis (lihat StockOpname::insertStockOpname()/updateStockOpname())
+        // dan baru sekarang ditegakkan di sini juga. Status berbeda dari guard status!=1 di bawah
+        // (-1 bukan -2) supaya frontend (CreateStockOpname.js) bisa membedakan "belum diajukan"
+        // dari "sudah diproses orang lain".
+        if ($sto->is_draft) {
+            return response()->json([
+                "status" => -1,
+                "header" => "Gagal ACC",
+                "message" => "Dokumen masih berupa draft — ajukan (submit) dokumen ini dulu sebelum bisa di-ACC",
+            ]);
+        }
 
         // Ditambahkan: dulu tidak ada pengecekan status sama sekali (cuma is_draft di halaman
         // insert) — beda dengan PO/SO/Production yang semuanya menolak kalau status != 1. Tanpa
@@ -553,6 +569,15 @@ class StockController extends Controller
             ($stob->warehouse_id ?? null)
             ?: (Session::get('active_warehouse_id') ?? 0)
         );
+
+        // Mirrors accStockOpname()'s draft gate above.
+        if ($stob->is_draft) {
+            return response()->json([
+                "status" => -1,
+                "header" => "Gagal ACC",
+                "message" => "Dokumen masih berupa draft — ajukan (submit) dokumen ini dulu sebelum bisa di-ACC",
+            ]);
+        }
 
         // Mirrors accStockOpname()'s status guard above.
         if ($stob->status != 1) {
@@ -1122,6 +1147,11 @@ class StockController extends Controller
         ProductIssuesDetail::where('pi_id', '=', $data["pi_id"])->whereNotIn("pid_id", $id)->update(["status" => 0]);
     }
 
+    // UI-unreachable (confirmed 2026-08-02) — this route's delete trigger icon is commented out in
+    // Product_Issues.js, on top of the original "MASIH NGEBUG" ("still buggy") note below. This is
+    // the one caller of ProductIssues::deleteProductIssues() that DOES check its -1 return value —
+    // see that method's dead-code comment for why the other, reachable caller doesn't need to
+    // (yet).
     function deleteProductIssue(Request $req) // MASIH NGEBUG
     {
         $data = $req->all();
@@ -1192,7 +1222,13 @@ class StockController extends Controller
                 }
 
                 // Fungsi rekursif — cari unit atas via relasi, tidak bergantung index
-                $siapkanStok = function ($targetKey, $units) use (&$virtualStock, &$logSummary, &$siapkanStok, $variantId) {
+                $siapkanStok = function($targetKey, $units, $depth = 0) use (&$virtualStock, &$logSummary, &$siapkanStok, $variantId) {
+                    // Ditambahkan (2026-08-06): depth guard — $keyAtas dicari lewat lookup relasi,
+                    // jadi rantai ProductRelation yang sirkular bisa membuat rekursi ini jalan
+                    // selamanya sebelum sempat kembali ke while loop di bawah. Belum pernah
+                    // tereproduksi dengan data nyata, murni defensive guard. Lihat KNOWN_ISSUES.md.
+                    if ($depth >= 20) return false;
+
                     $stokSekarang = $units[$targetKey];
 
                     $sr = ProductRelation::where('product_variant_id', $variantId)
@@ -1216,7 +1252,7 @@ class StockController extends Controller
                     $stokAtas = $units[$keyAtas];
 
                     if ($virtualStock[$stokAtas->ps_id]['current'] <= 0) {
-                        if (!$siapkanStok($keyAtas, $units)) return false;
+                        if (!$siapkanStok($keyAtas, $units, $depth + 1)) return false;
                     }
 
                     if ($virtualStock[$stokAtas->ps_id]['current'] > 0) {

--- a/app/Http/Controllers/SupplierController.php
+++ b/app/Http/Controllers/SupplierController.php
@@ -810,6 +810,9 @@ class SupplierController extends Controller
         $po->po_total += $total;
         $po->save();
 
+        // Return value intentionally not checked here — see ProductIssues::deleteProductIssues()'s
+        // dead-code comment. Currently harmless (its ref_num guard never actually triggers today),
+        // but would need to change if that guard is ever revived.
         (new ProductIssues())->deleteProductIssues($rs);
         (new ReturnSupplies())->deleteReturnSupplies($data);
 

--- a/app/Models/Cash.php
+++ b/app/Models/Cash.php
@@ -329,9 +329,16 @@ class Cash extends Model
     }
 
     function insertCash($data){
+        // DEAD CODE, commented out (confirmed 2026-08-02, marked 2026-08-06 per user decision —
+        // not revived, not removed, just flagged): this string→int mapping is the counterpart
+        // ReportController::insertCash()'s admin/gudang auto-link branch expects — without it, a
+        // literal "admin"/"gudang" string reaching `$t->cash_tujuan` below (an integer column)
+        // would crash with a DB type error. Moot in practice: the real frontend (Cash.js) never
+        // sends `cash_tujuan` as a string in the first place. See KNOWN_ISSUES.md for the full
+        // trace.
         // if ($data['cash_tujuan'] == "admin") $data['cash_tujuan'] = 1;
         // else if ($data['cash_tujuan'] == "gudang") $data['cash_tujuan'] = 2;
-        
+
         $t = new self();
         $t->person_id = $data["person_id"] ?? 0;
         $t->cash_date = $data["cash_date"];

--- a/app/Models/CashArmada.php
+++ b/app/Models/CashArmada.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Facades\Session;
 
 class CashArmada extends Model
@@ -114,6 +115,14 @@ class CashArmada extends Model
         $t->cr_img = $data["cr_img"] ?? null;
         $t->status = $data['status'] ?? 1;
         $t->created_by = Session::get('user') ? Session::get('user')->staff_id : null;
+        // Audit trail (2026-08-05): kalau row ini lahir dari CashGudang::acceptCashGudang(),
+        // catat cgd_id asalnya di sini supaya bisa ditelusuri balik — lihat migration
+        // 2026_08_05_020000_add_source_cgd_id_to_cash_armadas_table. Dibungkus Schema::hasColumn()
+        // supaya tetap aman kalau migration kolom ini belum ter-merge di branch/environment yang
+        // menjalankan kode ini.
+        if (isset($data['source_cgd_id']) && Schema::hasColumn('cash_armadas', 'source_cgd_id')) {
+            $t->source_cgd_id = $data['source_cgd_id'];
+        }
         $t->save();
         return $t->cr_id;
     }

--- a/app/Models/CashCategory.php
+++ b/app/Models/CashCategory.php
@@ -61,7 +61,12 @@ class CashCategory extends Model
 
     function updateCashCategory($data)
     {
+        // Ditambahkan (2026-08-06): dulu tidak ada null-guard sama sekali — cc_id yang tidak
+        // valid/sudah dihapus crash 500 ("Attempt to assign property 'cc_name' on null") alih-alih
+        // gagal bersih. Mirror pattern yang sudah dipakai di StockOpname::updateStockOpname() dkk.
         $t = CashCategory::find($data["cc_id"]);
+        if (!$t) return null;
+
         $t->cc_name = $data["cc_name"];
         $t->cc_type = $data["cc_type"];
         $t->save();
@@ -70,8 +75,12 @@ class CashCategory extends Model
 
     function deleteCashCategory($data)
     {
+        // Sama seperti updateCashCategory() di atas — null-guard supaya cc_id yang tidak
+        // valid/sudah dihapus gagal diam-diam alih-alih crash 500.
         $t = CashCategory::find($data["cc_id"]);
-        $t->status = 0;
-        $t->save();
+        if ($t) {
+            $t->status = 0;
+            $t->save();
+        }
     }
 }

--- a/app/Models/CashGudang.php
+++ b/app/Models/CashGudang.php
@@ -111,6 +111,11 @@ class CashGudang extends Model
     {
         $uid = Session::get('user') ? Session::get('user')->staff_id : null;
         if (!isset($data['cg_id'])){
+            // Cabang "Kas Besar" (entri "saldo") — punya baris `cashes` sungguhan (`cash_id`), jadi
+            // status entri Cash-nya juga ikut di-flip di sini. Entri jenis ini TIDAK PERNAH punya
+            // baris CashGudangDetail (lihat insertCashGudang()), jadi loop CashArmada di bawah akan
+            // selalu jalan atas $detail kosong — itu memang disengaja, bukan celah. Jangan tambah
+            // mutasi customer_saldo di cabang ini tanpa konfirmasi PM lagi (lihat KNOWN_ISSUES.md).
             $t = CashGudang::where('cash_id', $data["cash_id"])->first();
             $t->status = 2;
             $t->acc_by = $uid;
@@ -120,6 +125,8 @@ class CashGudang extends Model
             $k->save();
             $t->save();
         } else {
+            // Cabang "Kas Gudang" (entri "operasional") — $detail di bawah SELALU berisi baris
+            // (lihat insertCashGudang()), ini yang benar-benar memicu insert CashArmada per baris.
             $t = CashGudang::find($data['cg_id']);
             $t->status = 2;
             $t->acc_by = $uid;
@@ -134,7 +141,10 @@ class CashGudang extends Model
                 "cr_nominal" => $value->cgd_nominal,
                 "cr_notes" => "Penyerahan kas dari gudang",
                 "cr_type" => 1,
-                "status" => 2
+                "status" => 2,
+                // Audit trail (2026-08-05): telusuri balik row ini ke baris cash_gudang_details
+                // asalnya — lihat migration 2026_08_05_020000_add_source_cgd_id_to_cash_armadas_table.
+                "source_cgd_id" => $value->cgd_id,
             ]);
         }
         return 1;

--- a/app/Models/LogStock.php
+++ b/app/Models/LogStock.php
@@ -606,8 +606,17 @@ class LogStock extends Model
 
         if ($data["date"]) {
             if (is_array($data["date"]) && count($data["date"]) === 2) {
-                $startDate = \Carbon\Carbon::createFromFormat('d-m-Y', $data["date"][0])->startOfDay();
-                $endDate = \Carbon\Carbon::createFromFormat('d-m-Y', $data["date"][1])->endOfDay();
+                // Diperbaiki (2026-08-06): dulu unconditional createFromFormat('d-m-Y', ...) —
+                // beda dengan cabang tanggal tunggal di bawah (yang sudah punya fallback
+                // hasFormat Y-m-d) dan dengan pattern yang sudah dipakai di
+                // ReportController.php:3353-3360 / Production::getProductionReport(). Sama
+                // persis bugnya, lihat KNOWN_ISSUES.md.
+                $startDate = \Carbon\Carbon::hasFormat($data["date"][0], 'Y-m-d')
+                    ? \Carbon\Carbon::parse($data["date"][0])->startOfDay()
+                    : \Carbon\Carbon::createFromFormat('d-m-Y', $data["date"][0])->startOfDay();
+                $endDate = \Carbon\Carbon::hasFormat($data["date"][1], 'Y-m-d')
+                    ? \Carbon\Carbon::parse($data["date"][1])->endOfDay()
+                    : \Carbon\Carbon::createFromFormat('d-m-Y', $data["date"][1])->endOfDay();
                 $query->whereBetween('l.log_date', [$startDate, $endDate]);
             } else {
                 $date = $data["date"];

--- a/app/Models/ProductIssues.php
+++ b/app/Models/ProductIssues.php
@@ -30,9 +30,17 @@ class ProductIssues extends Model
         
         if($data["date"]) {
             if (is_array($data["date"]) && count($data["date"]) === 2) {
-                // Jika date adalah array [start_date, end_date]]
-                $startDate = \Carbon\Carbon::createFromFormat('d-m-Y', $data["date"][0])->format('Y-m-d');
-                $endDate   = \Carbon\Carbon::createFromFormat('d-m-Y', $data["date"][1])->format('Y-m-d');
+                // Diperbaiki (2026-08-06): dulu unconditional createFromFormat('d-m-Y', ...) —
+                // beda dengan cabang tanggal tunggal di bawah (yang sudah punya fallback
+                // hasFormat Y-m-d) dan dengan pattern yang sudah dipakai di method lain pada file
+                // ini sendiri (getArmadaReturnReport(), baris ~274-296). Sama persis bugnya, lihat
+                // KNOWN_ISSUES.md.
+                $startDate = \Carbon\Carbon::hasFormat($data["date"][0], 'Y-m-d')
+                    ? $data["date"][0]
+                    : \Carbon\Carbon::createFromFormat('d-m-Y', $data["date"][0])->format('Y-m-d');
+                $endDate = \Carbon\Carbon::hasFormat($data["date"][1], 'Y-m-d')
+                    ? $data["date"][1]
+                    : \Carbon\Carbon::createFromFormat('d-m-Y', $data["date"][1])->format('Y-m-d');
                 $result->whereBetween('created_at', [$startDate, $endDate]);
             } else {
                 // Jika date hanya satu nilai
@@ -187,6 +195,18 @@ class ProductIssues extends Model
     function deleteProductIssues($data)
     {
         $t = self::find($data["pi_id"]);
+        // DEAD CODE (confirmed 2026-08-02, marked 2026-08-06 per user decision — not revived, not
+        // removed, just flagged): `product_issues.ref_num` can never be nonzero via any live insert
+        // path today — StockController::insertProductIssue()'s validation block that would compute
+        // it is commented out, Product_Issues.js has `ref_num` commented out of its insert payload,
+        // and SupplierController::insertReturnSupplies() always hardcodes `ref_num => 0`. So this
+        // guard never actually triggers in practice. If `ref_num` is ever revived, note that
+        // SupplierController::deleteReturnSupplies() — the real, reachable Return Supplies delete
+        // path — calls this method but never checks its return value (only
+        // StockController::deleteProductIssue(), itself UI-unreachable, does), so reviving this
+        // guard without also fixing that caller would split-brain: the early `return -1` here
+        // would skip the `status = 3` line below, but the caller's own po_total/stock reversal
+        // would run anyway regardless. See KNOWN_ISSUES.md for the full trace.
         if (isset($t->ref_num) && $t->ref_num != 0){
             $inv = PurchaseOrderDetailInvoice::find($t->ref_num);
             $po = PurchaseOrder::find($inv->po_id);

--- a/app/Models/ProductIssuesDetail.php
+++ b/app/Models/ProductIssuesDetail.php
@@ -259,7 +259,17 @@ class ProductIssuesDetail extends Model
                     if ($stok->unit_id == $data["unit_id"]) { $keyTarget = $idx; }
                 }
 
-                $siapkanStok = function ($targetKey, $units) use (&$virtualStock, &$logSummary, &$siapkanStok, $m) {
+                $siapkanStok = function ($targetKey, $units, $depth = 0) use (&$virtualStock, &$logSummary, &$siapkanStok, $m) {
+                    // Ditambahkan (2026-08-06): depth guard — $keyAtas dicari lewat lookup relasi
+                    // (bukan index array tetap seperti $targetKey+1), jadi kalau data
+                    // SuppliesRelation punya rantai unit sirkular (unit A "atas"-nya B, B
+                    // "atas"-nya A), rekursi ini bisa jalan selamanya sebelum sempat kembali ke
+                    // while loop di bawah yang punya $safety-nya sendiri. Belum pernah tereproduksi
+                    // dengan data nyata (semua rantai SuppliesRelation yang ditelusuri sejauh ini
+                    // bersih/acyclic) — ini murni defensive guard. Angka 20 mirror konvensi guard
+                    // serupa di tempat lain (lihat KNOWN_ISSUES.md).
+                    if ($depth >= 20) return false;
+
                     $stokSekarang = $units[$targetKey];
 
                     // Dulu mencari "unit di atas" lewat posisi array ($units[$targetKey + 1]) —
@@ -279,7 +289,7 @@ class ProductIssuesDetail extends Model
                     $stokAtas = $units[$keyAtas];
 
                     if ($virtualStock[$stokAtas->ss_id]['current'] <= 0) {
-                        if (!$siapkanStok($keyAtas, $units)) return false;
+                        if (!$siapkanStok($keyAtas, $units, $depth + 1)) return false;
                     }
 
                     if ($virtualStock[$stokAtas->ss_id]['current'] > 0) {
@@ -348,7 +358,10 @@ class ProductIssuesDetail extends Model
                     if ($stok->unit_id == $data["unit_id"]) { $keyTarget = $idx; }
                 }
 
-                $siapkanStokProd = function ($targetKey, $units) use (&$virtualStock, &$logSummary, &$siapkanStokProd, $itemId) {
+                $siapkanStokProd = function ($targetKey, $units, $depth = 0) use (&$virtualStock, &$logSummary, &$siapkanStokProd, $itemId) {
+                    // Depth guard — mirrors the tipe_return==1 closure above, see its comment.
+                    if ($depth >= 20) return false;
+
                     $stokSekarang = $units[$targetKey];
 
                     // Mirrors the fix in this same method's tipe_return==1 closure above: cari
@@ -367,7 +380,7 @@ class ProductIssuesDetail extends Model
                     $stokAtas = $units[$keyAtas];
 
                     if ($virtualStock[$stokAtas->ps_id]['current'] <= 0) {
-                        if (!$siapkanStokProd($keyAtas, $units)) return false;
+                        if (!$siapkanStokProd($keyAtas, $units, $depth + 1)) return false;
                     }
 
                     if ($virtualStock[$stokAtas->ps_id]['current'] > 0) {

--- a/app/Models/Production.php
+++ b/app/Models/Production.php
@@ -247,8 +247,17 @@ class Production extends Model
 
         if ($data["date"]) {
             if (is_array($data["date"]) && count($data["date"]) === 2) {
-                $startDate = \Carbon\Carbon::createFromFormat('d-m-Y', $data["date"][0])->format('Y-m-d');
-                $endDate   = \Carbon\Carbon::createFromFormat('d-m-Y', $data["date"][1])->format('Y-m-d');
+                // Diperbaiki (2026-08-06): dulu unconditional createFromFormat('d-m-Y', ...) —
+                // beda dengan cabang tanggal tunggal di bawah (yang sudah punya fallback
+                // hasFormat Y-m-d) dan dengan pattern yang sudah dipakai di
+                // ReportController.php:3353-3360 — sebuah range Y-m-d (mis. dari date picker yang
+                // mengirim format ISO) crash 500 ("data tidak sesuai format").
+                $startDate = \Carbon\Carbon::hasFormat($data["date"][0], 'Y-m-d')
+                    ? $data["date"][0]
+                    : \Carbon\Carbon::createFromFormat('d-m-Y', $data["date"][0])->format('Y-m-d');
+                $endDate = \Carbon\Carbon::hasFormat($data["date"][1], 'Y-m-d')
+                    ? $data["date"][1]
+                    : \Carbon\Carbon::createFromFormat('d-m-Y', $data["date"][1])->format('Y-m-d');
                 $query->whereBetween('p.production_date', [$startDate, $endDate]);
             } else {
                 $date = $data["date"];
@@ -370,8 +379,13 @@ class Production extends Model
 
         if ($data["date"]) {
             if (is_array($data["date"]) && count($data["date"]) === 2) {
-                $startDate = \Carbon\Carbon::createFromFormat('d-m-Y', $data["date"][0])->format('Y-m-d');
-                $endDate   = \Carbon\Carbon::createFromFormat('d-m-Y', $data["date"][1])->format('Y-m-d');
+                // Mirrors getProductionReport()'s fix above — see the comment there.
+                $startDate = \Carbon\Carbon::hasFormat($data["date"][0], 'Y-m-d')
+                    ? $data["date"][0]
+                    : \Carbon\Carbon::createFromFormat('d-m-Y', $data["date"][0])->format('Y-m-d');
+                $endDate = \Carbon\Carbon::hasFormat($data["date"][1], 'Y-m-d')
+                    ? $data["date"][1]
+                    : \Carbon\Carbon::createFromFormat('d-m-Y', $data["date"][1])->format('Y-m-d');
                 $query->whereBetween('p.production_date', [$startDate, $endDate]);
             } else {
                 $date = $data["date"];

--- a/app/Models/PurchaseOrderDetailInvoice.php
+++ b/app/Models/PurchaseOrderDetailInvoice.php
@@ -145,18 +145,34 @@ class PurchaseOrderDetailInvoice extends Model
        $this->cekInvoice($t->po_id);
     }
 
+    /**
+     * Dinonaktifkan (2026-08-06, GitHub issue #14): dulu method ini men-set purchase_orders.status
+     * jadi 3 ("belum lunas") atau 4 ("lunas penuh") berdasarkan total invoice yang sudah diterima —
+     * dipanggil dari updateInvoicePO/deleteInvoicePO/changeStatusInvoicePO SETIAP kali sebuah invoice
+     * diedit/dihapus/diterima/ditolak, tanpa syarat apa pun.
+     *
+     * Dikonfirmasi oleh PM (2026-08-06): alur status PO yang benar hanya berisi 3 nilai —
+     * status=1 (menunggu konfirmasi) -> status=2 (disetujui) -> status=-1 (ditolak), dan progres
+     * "belum terbayar / menunggu tanda terima / terbayar" SEPENUHNYA dikendalikan oleh kolom
+     * `pembayaran` (1/3/2), bukan oleh `status`. Nilai status=3/4 yang ditulis di sini tidak pernah
+     * ada dalam alur itu — write-nya murni mengotori `purchase_orders.status` di luar domain
+     * {1, 2, -1} yang jadi asumsi di tempat lain, dengan 2 akibat nyata:
+     *   1. `SupplierController::tolakPO()` hanya membalik supplies_stocks kalau `status == 2` —
+     *      begitu status jadi 3/4, membatalkan PO itu TIDAK membalik stok yang sudah ditambah
+     *      accPO, walau permintaan pembatalannya sendiri tetap "berhasil".
+     *   2. `Purchase_Order_Detail.js`'s tombol Batalkan/Terima hanya muncul untuk status 1 atau 2 —
+     *      begitu status jadi 3/4, tombolnya hilang sama sekali, jadi staff tidak bisa lagi menolak
+     *      PO yang menurut alur PM seharusnya masih boleh (belum terbayar/menunggu tanda terima
+     *      -> ditolak).
+     *
+     * Method ini dipertahankan (bukan dihapus) karena masih dipanggil dari 3 tempat — tapi sekarang
+     * sengaja tidak melakukan apa pun, supaya updateInvoicePO/deleteInvoicePO/changeStatusInvoicePO
+     * tidak lagi bisa memindahkan purchase_orders.status sama sekali. Total invoice yang sudah
+     * diterima tetap bisa dihitung ulang kapan pun lewat query yang sama kalau nanti dibutuhkan
+     * untuk field terpisah — lihat cdocs/testing/KNOWN_ISSUES.md.
+     */
     function cekInvoice($po_id) {
-        
-        $total = PurchaseOrderDetailInvoice::where("po_id","=",$po_id)->where("status","=",2)->sum("poi_total");
-        $po = PurchaseOrder::find($po_id);
-        if($total<$po->po_total){
-            $po->status = 3;
-            $po->save();
-        }
-        else{
-            $po->status = 4;
-            $po->save();
-        }
+        // Sengaja kosong — lihat docblock di atas.
     }
 
     function generateInvoicePurchaseOrderID()

--- a/app/Models/StockOpname.php
+++ b/app/Models/StockOpname.php
@@ -123,6 +123,10 @@ class StockOpname extends Model
         $t->staff_id = $data['staff_id'];
         $t->category_id = $data['category_id'];
         $t->sto_notes = $data['sto_notes'] ?? null;
+        // Ditambahkan (2026-08-05): kolom is_draft sudah ada di DB sejak 2026-07-31 (lihat
+        // KNOWN_ISSUES.md "Stock Opname's draft feature is entirely non-functional") tapi tidak
+        // pernah diisi di sini — frontend (CreateStockOpname.js) sudah selalu mengirim ini,
+        // backend-nya yang belum menyimpannya.
         $t->is_draft = ! empty($data['is_draft']);
         $t->created_by = Session::get('user') ? Session::get('user')->staff_id : null;
         $t->save();
@@ -142,6 +146,8 @@ class StockOpname extends Model
         $t->staff_id = $data['staff_id'];
         $t->category_id = $data['category_id'];
         $t->sto_notes = $data['sto_notes'] ?? null;
+        // Sama seperti insertStockOpname(): kalau request ini tidak membawa is_draft sama sekali,
+        // pertahankan nilai yang sudah ada (jangan diam-diam keluar dari draft/masuk ke draft).
         if (array_key_exists('is_draft', $data)) {
             $t->is_draft = ! empty($data['is_draft']);
         }

--- a/app/Models/StockOpnameBahan.php
+++ b/app/Models/StockOpnameBahan.php
@@ -105,6 +105,8 @@ class StockOpnameBahan extends Model
         $t->stob_code   = $this->generateStockOpnameBahanID();
         $t->staff_id = $data['staff_id'];
         $t->stob_notes = $data['stob_notes'] ?? null;
+        // Mirrors StockOpname::insertStockOpname() — see KNOWN_ISSUES.md "Stock Opname's draft
+        // feature is entirely non-functional".
         $t->is_draft = ! empty($data['is_draft']);
         $t->created_by = Session::get('user') ? Session::get('user')->staff_id : null;
         $t->save();

--- a/database/migrations/2026_08_05_020000_add_source_cgd_id_to_cash_armadas_table.php
+++ b/database/migrations/2026_08_05_020000_add_source_cgd_id_to_cash_armadas_table.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Audit trail untuk `CashArmada` row yang auto-dibuat oleh `CashGudang::acceptCashGudang()` (lihat
+ * KNOWN_ISSUES.md "CONFIRMED INTENTIONAL: CashGudang's operasional branch is not a pure status
+ * flip") — sebelumnya row itu hanya punya catatan bebas teks ("Penyerahan kas dari gudang"), tidak
+ * ada kolom yang bisa dipakai untuk menelusuri balik ke `cash_gudang_details` mana asalnya.
+ *
+ * Nullable: hanya diisi untuk CashArmada row yang lahir dari alur ini; row yang dibuat lewat alur
+ * Cash Armada sendiri (insert/accept manual) tetap null.
+ *
+ * Kode yang membaca/menulis kolom ini SELALU dibungkus Schema::hasColumn() dulu — migration ini
+ * belum tentu sudah ter-merge/dijalankan di semua branch/environment.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasColumn('cash_armadas', 'source_cgd_id')) {
+            return;
+        }
+
+        Schema::table('cash_armadas', function (Blueprint $table) {
+            $table->unsignedInteger('source_cgd_id')->nullable()->after('cash_id');
+        });
+    }
+
+    public function down(): void
+    {
+        if (! Schema::hasColumn('cash_armadas', 'source_cgd_id')) {
+            return;
+        }
+
+        Schema::table('cash_armadas', function (Blueprint $table) {
+            $table->dropColumn('source_cgd_id');
+        });
+    }
+};

--- a/public/Custom_js/Backoffice/Product/insertProduct.js
+++ b/public/Custom_js/Backoffice/Product/insertProduct.js
@@ -314,10 +314,44 @@ $(document).on("click","#btnAddRowRelasi",function(){
         notifikasi('error', "Gagal Tambah", "Relasi unit tidak boleh sama");
         return false;
     }
+    // Rantai harus berurutan: begitu sudah ada baris, sisi kiri wajib = sisi kanan baris
+    // terakhir (dikunci lewat refreshRelasiUnitOptions()), dan sisi kanan tidak boleh unit yang
+    // sudah pernah dipakai di rantai ini — cek ulang di sini sebagai jaga-jaga kalau opsi yang
+    // seharusnya disabled itu tetap ke-submit.
+    var existingRows = $('#tbRelasi .row-relasi');
+    if (existingRows.length > 0) {
+        var expectedLeft = String(existingRows.last().attr('right'));
+        if (String(r1) !== expectedLeft) {
+            notifikasi('error', "Gagal Tambah", "Unit sisi kiri harus melanjutkan dari unit sisi kanan relasi sebelumnya");
+            return false;
+        }
+        var usedUnitIds = [];
+        existingRows.each(function () {
+            usedUnitIds.push(String($(this).attr('left')));
+            usedUnitIds.push(String($(this).attr('right')));
+        });
+        if (usedUnitIds.indexOf(String(r2)) !== -1) {
+            notifikasi('error', "Gagal Tambah", "Unit ini sudah dipakai pada rantai relasi sebelumnya");
+            return false;
+        }
+    }
+
+    var currentIndex = $('.row-relasi').length;
+    console.log("Menambahkan Baris ke-" + currentIndex + ": " + r1 + " - " + r2);
+
     addRowRelasi(
-        { pr_unit_id_1: r1, pr_unit_name_1: $('#relasi1 option:selected').text().trim() },
-        { pr_unit_id_2: r2, pr_unit_name_2: $('#relasi2 option:selected').text().trim() }
+        {
+            pr_unit_id_1: r1,
+            pr_unit_name_1: $('#relasi1 option:selected').text().trim()
+
+        },
+        {
+            pr_unit_id_2: r2,
+            pr_unit_name_2: $('#relasi2 option:selected').text().trim()
+        }
     );
+    $('#relasi2').val('');
+    refreshRelasiUnitOptions();
 });
 
 $(document).on("change","#product_unit",function(){
@@ -362,9 +396,46 @@ $(document).on("change",".unit_alert",function(){
     }
 });
 
+$('#unit_id').on('click', function() {
+   $('.select2-search__field').remove();
+});
+
+// Ditambahkan (2026-08-06): relasi unit produk HARUS membentuk satu rantai berurutan
+// (mis. Dos->Pcs->Liter), bukan pasangan bebas — kalau tidak, konversi satuan-terkecil di
+// backend (ProductionController::convertQtyToSmallestUnit()) bisa salah hitung. Dulu user bebas
+// pilih pasangan unit mana pun di #relasi1/#relasi2 setiap klik "Tambah Relasi", tidak ada yang
+// menjamin pasangan baru itu nyambung ke pasangan sebelumnya. Sekarang begitu sudah ada minimal 1
+// baris, sisi kiri (#relasi1, unit yang lebih besar) OTOMATIS dikunci ke sisi kanan (unit yang
+// lebih kecil) dari baris TERAKHIR — user hanya perlu pilih unit berikutnya di sisi kanan. Unit
+// yang sudah dipakai di rantai (kiri maupun kanan mana pun) juga disingkirkan dari pilihan sisi
+// kanan supaya rantai tidak bisa memutar balik ke unit yang sudah dipakai.
+function refreshRelasiUnitOptions() {
+    var rows = $('#tbRelasi .row-relasi');
+    var usedUnitIds = [];
+    rows.each(function () {
+        usedUnitIds.push(String($(this).attr('left')));
+        usedUnitIds.push(String($(this).attr('right')));
+    });
+
+    if (rows.length > 0) {
+        var lockedUnitId = String(rows.last().attr('right'));
+        $('#relasi1').val(lockedUnitId).prop('disabled', true);
+    } else {
+        $('#relasi1').prop('disabled', false);
+    }
+
+    $('#relasi2 option').each(function () {
+        var opt = $(this);
+        var isUsed = usedUnitIds.indexOf(String(opt.val())) !== -1;
+        opt.prop('disabled', isUsed);
+    });
+    if (usedUnitIds.indexOf(String($('#relasi2').val())) !== -1) {
+        $('#relasi2').val('');
+    }
+}
 function addRowRelasi(element1,element2) {
     $('#tbRelasi').append(`
-        <tr class="row-relasi" left="${element1.pr_unit_id_1 ? element1.pr_unit_id_1 : element2.id}" right="${dataRelasi[dataRelasi.length-1].pr_unit_id_2 ? dataRelasi[dataRelasi.length-1].pr_unit_id_2 : element2.pr_unit_id_2}">
+        <tr class="row-relasi" left="${element1.pr_unit_id_1 ? element1.pr_unit_id_1 : element2.id}" right="${element2.pr_unit_id_2 ? element2.pr_unit_id_2 : element2.id}">
             <td>
                 <div class="input-group">
                     <input type="text" class="form-control nominal-only unit1 fill" value="1"
@@ -396,6 +467,7 @@ function addRowRelasi(element1,element2) {
 
 $(document).on('click', '.btn_delete_relasi', function() {
     $(this).closest('tr').remove();
+    refreshRelasiUnitOptions();
 });
 
 $(document).on("click",".btn_delete_row",function(){
@@ -469,7 +541,12 @@ $(document).on('click', '.btn_edit_relasi', function(){
     $('#btnSaveRelasi').attr('index',index);
     $('#tbRelasi').html("");
     if(relasi[index]) {
-        relasi[index].forEach((item) => { addRowRelasi(item, item); });
+        relasi[index].forEach((item, idx) => {
+            addRowRelasi(item, item);
+        });
     }
+    $('#relasi2').val('');
+    refreshRelasiUnitOptions();
+
     $('#modalRelasi').modal('show');
 });

--- a/public/Custom_js/Backoffice/Reports/Cash.js
+++ b/public/Custom_js/Backoffice/Reports/Cash.js
@@ -32,7 +32,16 @@
             lengthMenu: [10, 25, 50, 100],
             ordering: false,
             autoWidth: false,
-            scrollX: true,
+            // scrollX was removed (2026-08-05): DataTables 1.10's scroll feature clones/resizes
+            // the header and footer into separate synced-width tables, and it does not support
+            // colspan'd cells in that clone — this tfoot uses colspan="3"/"5" on both rows
+            // (Cash.blade.php), so with scrollX on, the footer's labels ("Total :", "Sisa Kas :",
+            // "Total Setoran :") and the values written by updateCashFooterTotals() below rendered
+            // misaligned/on the wrong row. The table is still wrapped in a Bootstrap
+            // `.table-responsive` div, so horizontal scrolling on narrow screens still works via
+            // plain CSS overflow — just not through DataTables' own scrollX cloning. Sibling table
+            // Cash_Operational.js uses the same tfoot-update JS pattern without scrollX and renders
+            // correctly; match that instead of re-enabling this.
             language: {
                 search: ' ',
                 sLengthMenu: '_MENU_',
@@ -645,6 +654,13 @@
         console.log(tujuan);
         let url = "";
         if (tujuan == 1) url = "/acceptCashAdmin";
+        // tujuan == 2 (gudang): this page only ever knows the row's cash_id, never a cg_id — that's
+        // intentional, not missing data. This is the "Kas Besar" table, and only "saldo"-type
+        // CashGudang entries ever get a real cash_id/appear here (see
+        // ReportController::insertCashGudang()'s "saldo" branch); "operasional"-type ("Kas Gudang")
+        // entries always have cash_id = 0 and never show up in this table at all. On the backend,
+        // acceptCashGudang() uses isset($data['cg_id']) specifically to tell these two entry kinds
+        // apart — don't "fix" this call to also send a cg_id, there isn't one for this row's kind.
         else if (tujuan == 2) url = "/acceptCashGudang";
         else if (tujuan == 3) url = "/acceptCashArmada";
         else if (tujuan == 4) url = "/acceptCashSales";

--- a/public/Custom_js/Backoffice/Reports/Cash_Operational.js
+++ b/public/Custom_js/Backoffice/Reports/Cash_Operational.js
@@ -1698,9 +1698,15 @@
             headers: {
                 'X-CSRF-TOKEN': token
             },
-            success:function(e){      
-                ResetLoadingButton(".btn-save-gudang", mode == 1?"Tambah Aktivitas" : "Update Aktivitas");      
-                afterInsert();
+            success:function(e){
+                if (typeof e === "object"){
+                    notifikasi('error', e.header, e.message);
+                    ResetLoadingButton(".btn-save-gudang", mode == 1?"Tambah Aktivitas" : "Update Aktivitas");
+                    return false;
+                } else {
+                    ResetLoadingButton(".btn-save-gudang", mode == 1?"Tambah Aktivitas" : "Update Aktivitas");
+                    afterInsert();
+                }
             },
             error:function(e){
                 ResetLoadingButton(".btn-save-gudang", mode == 1?"Tambah Aktivitas" : "Update Aktivitas");
@@ -2411,6 +2417,10 @@
             method:"post",
             success:function(e){
                 ResetLoadingButton('#btn-delete-gudang', "Delete");
+                if (typeof e === "object"){
+                    notifikasi('error', e.header, e.message);
+                    return false;
+                }
                 $('.modal').modal("hide");
                 refreshCashGudang();
                 notifikasi('success', "Berhasil Delete", "Berhasil delete pengajuan");

--- a/tests/DatabaseTransaction/CashGudangOperasionalAcceptAtomicityTest.php
+++ b/tests/DatabaseTransaction/CashGudangOperasionalAcceptAtomicityTest.php
@@ -4,8 +4,10 @@ namespace Tests\DatabaseTransaction;
 
 use App\Models\CashArmada;
 use App\Models\CashGudang;
+use App\Models\CashGudangDetail;
 use App\Models\Customer;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 use Tests\Support\ActingAsStaff;
 use Tests\TestCase;
 
@@ -113,5 +115,145 @@ class CashGudangOperasionalAcceptAtomicityTest extends TestCase
             CashArmada::count(),
             'a rejected approval must not create any CashArmada rows at all'
         );
+    }
+
+    public function test_accepting_an_already_accepted_entry_is_refused_and_does_not_double_mutate(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $customerA = Customer::where('status', 1)->orderBy('customer_id')->first();
+        $startingA = $customerA->customer_saldo;
+
+        $cgId = $this->insertOperasionalCashGudang([
+            ['customer_id' => $customerA->customer_id, 'cgd_nominal' => 50000, 'cgd_notes' => 'Test A'],
+        ]);
+
+        $first = $this->post('/acceptCashGudang', ['cg_id' => $cgId]);
+        $first->assertOk();
+
+        $armadaCountAfterFirstAccept = CashArmada::count();
+        $customerA->refresh();
+        $this->assertSame($startingA + 50000, (int) $customerA->customer_saldo);
+
+        // Race-condition guard (2026-08-05): a second accept on the same cg_id — modeling a
+        // double-click or a retried request arriving after the first already committed — must be
+        // refused cleanly, not double-credit customer_saldo or insert a second CashArmada row.
+        $second = $this->post('/acceptCashGudang', ['cg_id' => $cgId]);
+        $second->assertOk();
+        $second->assertJson(['status' => -2, 'header' => 'Gagal ACC']);
+
+        $customerA->refresh();
+        $this->assertSame(
+            $startingA + 50000,
+            (int) $customerA->customer_saldo,
+            'a second accept on an already-accepted entry must not double-credit customer_saldo'
+        );
+        $this->assertSame(
+            $armadaCountAfterFirstAccept,
+            CashArmada::count(),
+            'a second accept on an already-accepted entry must not create a duplicate CashArmada row'
+        );
+    }
+
+    public function test_the_created_armada_row_is_tagged_with_its_source_cash_gudang_detail_for_audit(): void
+    {
+        if (!Schema::hasColumn('cash_armadas', 'source_cgd_id')) {
+            $this->markTestSkipped('source_cgd_id column not present on this schema.');
+        }
+
+        $this->actingAsSuperAdminStaff();
+
+        $customerA = Customer::where('status', 1)->orderBy('customer_id')->first();
+
+        $cgId = $this->insertOperasionalCashGudang([
+            ['customer_id' => $customerA->customer_id, 'cgd_nominal' => 50000, 'cgd_notes' => 'Test A'],
+        ]);
+        $cgdId = (int) CashGudangDetail::where('cg_id', $cgId)->firstOrFail()->cgd_id;
+
+        $response = $this->post('/acceptCashGudang', ['cg_id' => $cgId]);
+        $response->assertOk();
+
+        $this->assertDatabaseHas('cash_armadas', [
+            'customer_id' => $customerA->customer_id,
+            'cr_nominal' => 50000,
+            'source_cgd_id' => $cgdId,
+        ]);
+    }
+
+    public function test_updating_an_already_accepted_entry_is_refused_and_leaves_nominal_unchanged(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $customerA = Customer::where('status', 1)->orderBy('customer_id')->first();
+
+        $cgId = $this->insertOperasionalCashGudang([
+            ['customer_id' => $customerA->customer_id, 'cgd_nominal' => 50000, 'cgd_notes' => 'Test A'],
+        ]);
+        $this->post('/acceptCashGudang', ['cg_id' => $cgId])->assertOk();
+
+        $cgdId = (int) CashGudangDetail::where('cg_id', $cgId)->firstOrFail()->cgd_id;
+
+        // PM confirmed 2026-08-05: once approved/rejected, nothing may change the document again —
+        // updateCashGudang() must refuse, not silently apply the edit on top of an already-mutated
+        // customer_saldo/CashArmada pair.
+        $response = $this->post('/updateCashGudang', [
+            'cg_id' => $cgId,
+            'staff_id' => $this->staffId(),
+            'jenis_input' => 'operasional',
+            'photo' => '',
+            'items' => json_encode([
+                ['cgd_id' => $cgdId, 'customer_id' => $customerA->customer_id, 'cgd_nominal' => 999999, 'cgd_notes' => 'Edited after accept'],
+            ]),
+        ]);
+        $response->assertOk();
+        $response->assertJson(['status' => -2, 'header' => 'Gagal Update']);
+
+        $cgd = CashGudangDetail::findOrFail($cgdId);
+        $this->assertSame(50000, (int) $cgd->cgd_nominal, 'an already-accepted detail row must not be editable');
+    }
+
+    public function test_deleting_an_already_accepted_entry_is_refused(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $customerA = Customer::where('status', 1)->orderBy('customer_id')->first();
+
+        $cgId = $this->insertOperasionalCashGudang([
+            ['customer_id' => $customerA->customer_id, 'cgd_nominal' => 50000, 'cgd_notes' => 'Test A'],
+        ]);
+        $this->post('/acceptCashGudang', ['cg_id' => $cgId])->assertOk();
+
+        $response = $this->post('/deleteCashGudang', ['cg_id' => $cgId]);
+        $response->assertOk();
+        $response->assertJson(['status' => -2, 'header' => 'Gagal Hapus']);
+
+        $cg = CashGudang::findOrFail($cgId);
+        $this->assertSame(2, (int) $cg->status, 'an already-accepted document must not be soft-deleted');
+    }
+
+    public function test_updating_a_still_pending_entry_is_allowed(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $customerA = Customer::where('status', 1)->orderBy('customer_id')->first();
+
+        $cgId = $this->insertOperasionalCashGudang([
+            ['customer_id' => $customerA->customer_id, 'cgd_nominal' => 50000, 'cgd_notes' => 'Test A'],
+        ]);
+        $cgdId = (int) CashGudangDetail::where('cg_id', $cgId)->firstOrFail()->cgd_id;
+
+        $response = $this->post('/updateCashGudang', [
+            'cg_id' => $cgId,
+            'staff_id' => $this->staffId(),
+            'jenis_input' => 'operasional',
+            'photo' => '',
+            'items' => json_encode([
+                ['cgd_id' => $cgdId, 'customer_id' => $customerA->customer_id, 'cgd_nominal' => 70000, 'cgd_notes' => 'Edited while pending'],
+            ]),
+        ]);
+        $response->assertOk();
+
+        $cgd = CashGudangDetail::findOrFail($cgdId);
+        $this->assertSame(70000, (int) $cgd->cgd_nominal, 'a still-pending detail row must remain editable');
     }
 }

--- a/tests/Regression/BongkarRecursionDepthGuardTest.php
+++ b/tests/Regression/BongkarRecursionDepthGuardTest.php
@@ -1,0 +1,319 @@
+<?php
+
+namespace Tests\Regression;
+
+use App\Models\Bom;
+use App\Models\BomDetail;
+use App\Models\Category;
+use App\Models\Product;
+use App\Models\Production;
+use App\Models\ProductStock;
+use App\Models\ProductVariant;
+use App\Models\PurchaseOrder;
+use App\Models\Supplies;
+use App\Models\SuppliesRelation;
+use App\Models\SuppliesStock;
+use App\Models\SuppliesVariant;
+use App\Models\Supplier;
+use Tests\Support\ActingAsStaff;
+use Tests\TestCase;
+
+/**
+ * ✅ FIXED (2026-08-06): the `$siapkanStok`/`$siapkanStokCek`/`$siapkanStokProd` closures
+ * duplicated across `ProductIssuesDetail.php` (×2), `StockController.php` (×1), and
+ * `ProductionController.php` (×3) all find the "unit above" via a `ProductRelation`/
+ * `SuppliesRelation` lookup (`pr_unit_id_1`/`su_id_1`), not a fixed array index — so a
+ * malformed/circular relation chain (unit A's parent is B, B's parent is A) recursed
+ * indefinitely with no depth counter of its own. The outer `$safety > 500` loop next to each of
+ * these does NOT catch this, since the unbounded recursion happens *inside* one single call to
+ * the closure, never returning control to the loop to check that counter.
+ *
+ * Fixed by adding a `$depth` parameter (default 0, incremented on each recursive call, capped at
+ * 20 — mirrors the `$guard < 20` convention already used elsewhere in this codebase for exactly
+ * this kind of traversal guard) to all 6 at-risk closures. The 2 *other* `$siapkanStok` closures
+ * in `CustomerController.php` were NOT touched — they recurse via a fixed array index
+ * (`$targetKey + 1`), which cannot cycle, so they were never actually at risk.
+ *
+ * This test proves the depth guard actually engages on deliberately circular relation data
+ * (Return Supplies / `ProductIssuesDetail::stockCheck()` and Production /
+ * `ProductionController::insertProduction()`'s ingredient-sufficiency precheck, one representative
+ * call site each — the other 4 share byte-identical closure bodies and the same fix) — it does NOT
+ * reproduce the pre-fix infinite-recursion behavior directly, since doing so would hang or crash
+ * the PHP process running the test suite itself rather than raising a catchable exception.
+ */
+class BongkarRecursionDepthGuardTest extends TestCase
+{
+    use ActingAsStaff;
+
+    private const LITER = 3;
+    private const DRUM = 5;
+    private const JERIGEN = 2;
+    private const PIECE = 9;
+
+    public function test_return_supplies_bongkar_does_not_hang_on_a_circular_supplies_relation_chain(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $supplier = Supplier::where('status', 1)->whereNotNull('bank_id')->firstOrFail();
+
+        $supplies = new Supplies();
+        $supplies->supplies_name = 'Circular Relation Depth Guard Test Ingredient';
+        $supplies->supplies_unit = json_encode([self::LITER, self::DRUM]);
+        $supplies->supplies_default_unit = self::LITER;
+        $supplies->status = 1;
+        $supplies->save();
+
+        $variant = new SuppliesVariant();
+        $variant->supplier_id = $supplier->supplier_id;
+        $variant->supplies_id = $supplies->supplies_id;
+        $variant->supplies_variant_name = 'Circular Relation Depth Guard Test Variant';
+        $variant->supplies_variant_sku = 'WF-CIRCGUARD-'.uniqid();
+        $variant->supplies_variant_barcode = 'WF-CIRCGUARD-BC-'.uniqid();
+        $variant->supplies_variant_price = 1000;
+        $variant->supplies_variant_stock = 0;
+        $variant->status = 1;
+        $variant->save();
+
+        // Deliberately circular: Liter's "unit above" is Drum, AND Drum's "unit above" is Liter.
+        // Real product/supplies data never looks like this (every real chain traced this session
+        // has been a clean, acyclic ladder) — this is purely to prove the guard engages.
+        $relationUp = new SuppliesRelation();
+        $relationUp->supplies_id = $supplies->supplies_id;
+        $relationUp->su_id_1 = self::DRUM;
+        $relationUp->su_id_2 = self::LITER;
+        $relationUp->sr_value_1 = 1;
+        $relationUp->sr_value_2 = 200;
+        $relationUp->status = 1;
+        $relationUp->save();
+
+        $relationDown = new SuppliesRelation();
+        $relationDown->supplies_id = $supplies->supplies_id;
+        $relationDown->su_id_1 = self::LITER;
+        $relationDown->su_id_2 = self::DRUM;
+        $relationDown->sr_value_1 = 1;
+        $relationDown->sr_value_2 = 1;
+        $relationDown->status = 1;
+        $relationDown->save();
+
+        // Both stock rows start at zero, so the bongkar closure can never find a positive balance
+        // anywhere in the (circular) chain to actually terminate on — the only thing that stops it
+        // is the depth guard.
+        $literStock = new SuppliesStock();
+        $literStock->supplies_id = $supplies->supplies_id;
+        $literStock->unit_id = self::LITER;
+        $literStock->warehouse_id = 1;
+        $literStock->ss_stock = 0;
+        $literStock->status = 1;
+        $literStock->save();
+
+        $drumStock = new SuppliesStock();
+        $drumStock->supplies_id = $supplies->supplies_id;
+        $drumStock->unit_id = self::DRUM;
+        $drumStock->warehouse_id = 1;
+        $drumStock->ss_stock = 0;
+        $drumStock->status = 1;
+        $drumStock->save();
+
+        $po = new PurchaseOrder();
+        $po->po_number = 'WF-CIRCGUARD-'.uniqid();
+        $po->po_supplier = $supplier->supplier_id;
+        $po->po_date = now()->toDateString();
+        $po->po_total = 1000000;
+        $po->jenis_discount = 1;
+        $po->po_desc = 'Circular relation depth guard test PO';
+        $po->po_img = json_encode([]);
+        $po->status = 1;
+        $po->save();
+
+        $startedAt = microtime(true);
+
+        $response = $this->post('/insertReturnSupplies', [
+            'po_id' => $po->po_id,
+            'rs_date' => now()->toDateString(),
+            'rs_notes' => 'Circular relation depth guard test',
+            'rs_total' => 10,
+            'returs' => json_encode([[
+                'supplies_id' => $variant->supplies_id,
+                'supplies_variant_id' => $variant->supplies_variant_id,
+                'supplies_variant_name' => $variant->supplies_variant_name,
+                'unit_id' => self::LITER,
+                'rsd_qty' => 10,
+                'rsd_price' => 1,
+            ]]),
+        ]);
+
+        $elapsed = microtime(true) - $startedAt;
+
+        $response->assertStatus(200);
+        $this->assertLessThan(3.0, $elapsed, 'the depth guard must make this fail fast, not hang');
+        $response->assertJson(['status' => -1]);
+
+        $literStock->refresh();
+        $drumStock->refresh();
+        $this->assertSame(0, $literStock->ss_stock, 'a guarded-off bongkar must not have mutated anything');
+        $this->assertSame(0, $drumStock->ss_stock, 'a guarded-off bongkar must not have mutated anything');
+    }
+
+    /**
+     * Mirrors tests/Workflow/ProductionUnitConversionFlowTest.php's fixture exactly (same
+     * field/payload shapes: `Bom::product_id` stores a product_variant_id,
+     * `BomDetail::bom_detail_qty`, `/insertProduction`'s `detail`/`list_bahan` payload keys) — only
+     * difference is the deliberately circular SuppliesRelation chain and zero starting stock on
+     * both units, to prove the depth guard engages instead of hanging/crashing.
+     */
+    public function test_production_ingredient_bongkar_does_not_hang_on_a_circular_supplies_relation_chain(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $category = new Category();
+        $category->category_name = 'Circular Relation Depth Guard Category';
+        $category->status = 1;
+        $category->save();
+
+        $product = new Product();
+        $product->product_name = 'Circular Relation Depth Guard Product';
+        $product->category_id = $category->category_id;
+        $product->product_unit = json_encode([self::PIECE]);
+        $product->unit_id = self::PIECE;
+        $product->status = 1;
+        $product->save();
+
+        $variant = new ProductVariant();
+        $variant->product_id = $product->product_id;
+        $variant->product_variant_name = 'Circular Relation Depth Guard Variant';
+        $variant->product_variant_sku = 'WF-CIRCGUARD-PROD-'.uniqid();
+        $variant->product_variant_price = 0;
+        $variant->status = 1;
+        $variant->save();
+
+        $productStock = new ProductStock();
+        $productStock->product_id = $product->product_id;
+        $productStock->product_variant_id = $variant->product_variant_id;
+        $productStock->unit_id = self::PIECE;
+        $productStock->warehouse_id = 1;
+        $productStock->ps_stock = 0;
+        $productStock->status = 1;
+        $productStock->save();
+
+        $bom = new Bom();
+        $bom->product_id = $variant->product_variant_id; // stores a product_variant_id
+        $bom->bom_qty = 1;
+        $bom->unit_id = self::PIECE;
+        $bom->status = 1;
+        $bom->save();
+
+        $supplies = new Supplies();
+        $supplies->supplies_name = 'Circular Relation Depth Guard Test Ingredient';
+        $supplies->supplies_unit = json_encode([self::LITER, self::DRUM, self::JERIGEN]);
+        $supplies->supplies_default_unit = self::LITER;
+        $supplies->status = 1;
+        $supplies->save();
+
+        // insertProduction() runs a separate, EARLIER precheck (validateBomSuppliesSmallestUnit())
+        // that rejects the recipe outright if its own unit has any downward relation
+        // (su_id_1 == recipe's unit) — so the cycle can't sit directly on Liter (the recipe's
+        // unit) without tripping that different guard first. Instead: Liter's parent is Drum
+        // (one-way, keeps Liter validly "smallest"), and the cycle sits one level up, between Drum
+        // and Jerigen — Drum's parent is Jerigen, AND Jerigen's parent is Drum. Once bongkar-ing
+        // Liter needs to climb past Drum, it hits that 2-cycle and would recurse forever without
+        // the depth guard. Real supplies data never looks like this (every real chain traced this
+        // session has been a clean, acyclic ladder) — this is purely to prove the guard engages.
+        $literParentIsDrum = new SuppliesRelation();
+        $literParentIsDrum->supplies_id = $supplies->supplies_id;
+        $literParentIsDrum->su_id_1 = self::DRUM;
+        $literParentIsDrum->su_id_2 = self::LITER;
+        $literParentIsDrum->sr_value_1 = 1;
+        $literParentIsDrum->sr_value_2 = 200;
+        $literParentIsDrum->status = 1;
+        $literParentIsDrum->save();
+
+        $drumParentIsJerigen = new SuppliesRelation();
+        $drumParentIsJerigen->supplies_id = $supplies->supplies_id;
+        $drumParentIsJerigen->su_id_1 = self::JERIGEN;
+        $drumParentIsJerigen->su_id_2 = self::DRUM;
+        $drumParentIsJerigen->sr_value_1 = 1;
+        $drumParentIsJerigen->sr_value_2 = 5;
+        $drumParentIsJerigen->status = 1;
+        $drumParentIsJerigen->save();
+
+        $jerigenParentIsDrum = new SuppliesRelation();
+        $jerigenParentIsDrum->supplies_id = $supplies->supplies_id;
+        $jerigenParentIsDrum->su_id_1 = self::DRUM;
+        $jerigenParentIsDrum->su_id_2 = self::JERIGEN;
+        $jerigenParentIsDrum->sr_value_1 = 1;
+        $jerigenParentIsDrum->sr_value_2 = 1;
+        $jerigenParentIsDrum->status = 1;
+        $jerigenParentIsDrum->save();
+
+        // All three stock rows start at zero, so the bongkar closure can never find a positive
+        // balance anywhere in the (circular) chain above Liter to actually terminate on — only the
+        // depth guard stops it.
+        $literStock = new SuppliesStock();
+        $literStock->supplies_id = $supplies->supplies_id;
+        $literStock->unit_id = self::LITER;
+        $literStock->warehouse_id = 1;
+        $literStock->ss_stock = 0;
+        $literStock->status = 1;
+        $literStock->save();
+
+        $drumStock = new SuppliesStock();
+        $drumStock->supplies_id = $supplies->supplies_id;
+        $drumStock->unit_id = self::DRUM;
+        $drumStock->warehouse_id = 1;
+        $drumStock->ss_stock = 0;
+        $drumStock->status = 1;
+        $drumStock->save();
+
+        $jerigenStock = new SuppliesStock();
+        $jerigenStock->supplies_id = $supplies->supplies_id;
+        $jerigenStock->unit_id = self::JERIGEN;
+        $jerigenStock->warehouse_id = 1;
+        $jerigenStock->ss_stock = 0;
+        $jerigenStock->status = 1;
+        $jerigenStock->save();
+
+        $bomDetail = new BomDetail();
+        $bomDetail->bom_id = $bom->bom_id;
+        $bomDetail->supplies_id = $supplies->supplies_id;
+        $bomDetail->bom_detail_qty = 10;
+        $bomDetail->unit_id = self::LITER;
+        $bomDetail->status = 1;
+        $bomDetail->save();
+
+        // This closure is exercised at INSERT time (ProductionController::insertProduction()'s own
+        // ingredient-sufficiency precheck), not at accProduction() — a guarded-off bongkar means
+        // the insert itself is cleanly rejected, no Production row ever gets created.
+        $productionCountBefore = Production::count();
+        $startedAt = microtime(true);
+
+        $insertResponse = $this->post('/insertProduction', [
+            'production_date' => now()->toDateString(),
+            'production_desc' => 'Circular relation depth guard test',
+            'detail' => json_encode([[
+                'bom_id' => $bom->bom_id,
+                'product_variant_id' => $variant->product_variant_id,
+                'pd_qty' => 1,
+                'unit_id' => self::PIECE,
+            ]]),
+            'list_bahan' => json_encode([[
+                'supplies_id' => $supplies->supplies_id,
+                'bom_detail_qty' => 10,
+                'unit_id' => self::LITER,
+            ]]),
+        ]);
+
+        $elapsed = microtime(true) - $startedAt;
+
+        $this->assertLessThan(3.0, $elapsed, 'the depth guard must make this fail fast, not hang');
+        $insertResponse->assertStatus(200);
+        $insertResponse->assertJson(['status' => -1]);
+        $this->assertSame($productionCountBefore, Production::count(), 'a guarded-off bongkar must reject the insert, not create a Production row');
+
+        $literStock->refresh();
+        $drumStock->refresh();
+        $jerigenStock->refresh();
+        $this->assertSame(0, $literStock->ss_stock, 'a guarded-off bongkar must not have mutated anything');
+        $this->assertSame(0, $drumStock->ss_stock, 'a guarded-off bongkar must not have mutated anything');
+        $this->assertSame(0, $jerigenStock->ss_stock, 'a guarded-off bongkar must not have mutated anything');
+    }
+}

--- a/tests/Regression/BongkarRecursionDepthGuardTest.php
+++ b/tests/Regression/BongkarRecursionDepthGuardTest.php
@@ -164,6 +164,7 @@ class BongkarRecursionDepthGuardTest extends TestCase
     public function test_production_ingredient_bongkar_does_not_hang_on_a_circular_supplies_relation_chain(): void
     {
         $this->actingAsSuperAdminStaff();
+        $this->withActiveWarehouse(1);
 
         $category = new Category();
         $category->category_name = 'Circular Relation Depth Guard Category';

--- a/tests/Regression/CashCategoryInvalidIdCrashesTest.php
+++ b/tests/Regression/CashCategoryInvalidIdCrashesTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Tests\Regression;
+
+use App\Models\CashCategory;
+use Tests\Support\ActingAsStaff;
+use Tests\TestCase;
+
+/**
+ * ✅ FIXED (2026-08-06): `CashCategory::updateCashCategory()`/`deleteCashCategory()` had no
+ * null-guard on `CashCategory::find($data["cc_id"])` — an invalid/already-deleted `cc_id` crashed
+ * 500 ("Attempt to assign property 'cc_name' on null" / "... 'status' on null") instead of failing
+ * cleanly. Same shape as several other simple master-data CRUD models in this codebase
+ * (`Bank::updateBank()`/`deleteBank()` has the identical gap, out of scope for this fix) — mirrors
+ * the quiet null-guard pattern already used in `StockOpname::updateStockOpname()`/
+ * `deleteStockOpname()`.
+ */
+class CashCategoryInvalidIdCrashesTest extends TestCase
+{
+    use ActingAsStaff;
+
+    public function test_updating_an_invalid_cc_id_fails_cleanly_instead_of_crashing(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $bogusId = 999999;
+        $this->assertNull(CashCategory::find($bogusId), 'precondition: id must not exist');
+
+        $response = $this->post('/updateCashCategory', [
+            'cc_id' => $bogusId,
+            'cc_name' => 'Should not be applied',
+            'cc_type' => 'Masuk',
+        ]);
+
+        $response->assertStatus(200);
+    }
+
+    public function test_deleting_an_invalid_cc_id_fails_cleanly_instead_of_crashing(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $bogusId = 999999;
+        $this->assertNull(CashCategory::find($bogusId), 'precondition: id must not exist');
+
+        $response = $this->post('/deleteCashCategory', [
+            'cc_id' => $bogusId,
+        ]);
+
+        $response->assertStatus(200);
+    }
+
+    public function test_updating_a_real_category_still_works(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $category = new CashCategory();
+        $category->cc_name = 'Regression Test Category';
+        $category->cc_type = 'Keluar';
+        $category->status = 1;
+        $category->save();
+
+        $response = $this->post('/updateCashCategory', [
+            'cc_id' => $category->cc_id,
+            'cc_name' => 'Regression Test Category Renamed',
+            'cc_type' => 'Masuk',
+        ]);
+        $response->assertStatus(200);
+
+        $category->refresh();
+        $this->assertSame('Regression Test Category Renamed', $category->cc_name);
+        $this->assertSame('Masuk', $category->cc_type);
+    }
+
+    public function test_deleting_a_real_category_still_soft_deletes_it(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $category = new CashCategory();
+        $category->cc_name = 'Regression Test Category To Delete';
+        $category->cc_type = 'Keluar 1';
+        $category->status = 1;
+        $category->save();
+
+        $response = $this->post('/deleteCashCategory', [
+            'cc_id' => $category->cc_id,
+        ]);
+        $response->assertStatus(200);
+
+        $category->refresh();
+        $this->assertSame(0, (int) $category->status);
+    }
+}

--- a/tests/Regression/LogStockAndProductIssuesDateRangeFormatCrashTest.php
+++ b/tests/Regression/LogStockAndProductIssuesDateRangeFormatCrashTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Tests\Regression;
+
+use Tests\Support\ActingAsStaff;
+use Tests\TestCase;
+
+/**
+ * ✅ FIXED (2026-08-06): same bug shape as
+ * tests/Regression/ProductionReportDateRangeFormatCrashTest.php, found while fixing that one and
+ * flagged in KNOWN_ISSUES.md as out of scope there — now fixed here too.
+ *
+ * `LogStock::getRawMaterialUsageReport()` and `ProductIssues::getProductIssues()` both had a
+ * date-RANGE branch that unconditionally called `Carbon::createFromFormat('d-m-Y', ...)` on both
+ * ends, while their own single-date branch a few lines below already had a `Y-m-d` fallback via
+ * `Carbon::hasFormat()`. A `Y-m-d` date range crashed with `InvalidFormatException` instead of
+ * parsing cleanly. Confirmed both crashes were real (not just read from code) by reverting the fix
+ * and reproducing the actual exception via `php artisan tinker` before restoring it.
+ *
+ * `ProductIssues.php` already has the correct pattern in a sibling method in the same file
+ * (`getArmadaReturnReport()`) — this was purely a "didn't match its own neighbor" gap.
+ */
+class LogStockAndProductIssuesDateRangeFormatCrashTest extends TestCase
+{
+    use ActingAsStaff;
+
+    public function test_raw_material_usage_report_accepts_a_y_m_d_date_range_without_crashing(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $response = $this->get('/getReportPemakaianBahan?'.http_build_query([
+            'date' => ['2026-01-01', '2026-01-31'],
+        ]));
+
+        $response->assertStatus(200);
+    }
+
+    public function test_raw_material_usage_report_still_accepts_a_d_m_y_date_range(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $response = $this->get('/getReportPemakaianBahan?'.http_build_query([
+            'date' => ['01-01-2026', '31-01-2026'],
+        ]));
+
+        $response->assertStatus(200);
+    }
+
+    public function test_product_issues_list_accepts_a_y_m_d_date_range_without_crashing(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $response = $this->get('/getProductIssue?'.http_build_query([
+            'date' => ['2026-01-01', '2026-01-31'],
+        ]));
+
+        $response->assertStatus(200);
+    }
+
+    public function test_product_issues_list_still_accepts_a_d_m_y_date_range(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $response = $this->get('/getProductIssue?'.http_build_query([
+            'date' => ['01-01-2026', '31-01-2026'],
+        ]));
+
+        $response->assertStatus(200);
+    }
+}

--- a/tests/Regression/ProductionRawMaterialOverconsumptionOnMultiUnitRelationTest.php
+++ b/tests/Regression/ProductionRawMaterialOverconsumptionOnMultiUnitRelationTest.php
@@ -1,0 +1,185 @@
+<?php
+
+namespace Tests\Regression;
+
+use App\Models\Bom;
+use App\Models\BomDetail;
+use App\Models\Category;
+use App\Models\Product;
+use App\Models\ProductRelation;
+use App\Models\ProductStock;
+use App\Models\ProductVariant;
+use App\Models\Production;
+use App\Models\Supplies;
+use App\Models\SuppliesStock;
+use Tests\Support\ActingAsStaff;
+use Tests\TestCase;
+
+/**
+ * GitHub issue #16: producing "1 Liter" of a product deducted 1000 pieces of a raw material whose
+ * recipe only needed 1 piece per 1 piece of product — a 100x raw-material overconsumption.
+ *
+ * Root cause (fixed on this branch): `ProductionController::convertQtyToSmallestUnit()` fetched
+ * EVERY active `product_relations` row for the product and multiplied all of their
+ * `pr_unit_value_2` together whenever a row's base unit wasn't the unit actually being converted —
+ * true for every sibling row whenever a product has more than one independent "big unit -> Piece"
+ * relation. The reporter's own product had exactly that "Atur Relasi" shape: DOS=20pcs, kg=5pcs,
+ * LTR=10pcs, all three converging on Piece. Converting "1 Liter" folded all three factors together
+ * (20 * 5 * 10 = 1000) instead of using just the matching LTR relation (10), so a recipe needing 1
+ * piece of "Botol 600ml" per 1 piece of product consumed 1000 pieces instead of 10.
+ *
+ * The same duplicated buggy loop existed in three places (`insertProduction()`'s pre-check,
+ * `accProduction()`'s real deduction, and `accDeleteProduction()`'s reversal) plus the shared
+ * `convertQtyToSmallestUnit()`/`getBatchCount()` pair — all four now delegate to the same fixed,
+ * chain-walking conversion (mirrors the already-correct `convertSuppliesQtyToSmallestUnit()`).
+ *
+ * Real unit ids used (from the committed seed snapshot's `units` table, matching the issue's own
+ * screenshots): 1 = kg, 3 = Liter, 7 = DOS, 9 = Piece.
+ */
+class ProductionRawMaterialOverconsumptionOnMultiUnitRelationTest extends TestCase
+{
+    use ActingAsStaff;
+
+    private const KG_UNIT_ID = 1;
+    private const LITER_UNIT_ID = 3;
+    private const DOS_UNIT_ID = 7;
+    private const PIECE_UNIT_ID = 9;
+    private const WAREHOUSE_ID = 1;
+
+    public function test_producing_in_a_unit_with_multiple_sibling_relations_consumes_the_correct_amount(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $category = new Category();
+        $category->category_name = 'Issue 16 Regression Category';
+        $category->status = 1;
+        $category->save();
+
+        $product = new Product();
+        $product->product_name = 'Issue 16 Regression Product';
+        $product->category_id = $category->category_id;
+        $product->product_unit = json_encode([self::PIECE_UNIT_ID, self::LITER_UNIT_ID]);
+        $product->unit_id = self::PIECE_UNIT_ID;
+        $product->status = 1;
+        $product->save();
+
+        $variant = new ProductVariant();
+        $variant->product_id = $product->product_id;
+        $variant->product_variant_name = 'Issue 16 Regression Variant';
+        $variant->product_variant_sku = 'WF-ISSUE16-'.uniqid();
+        $variant->product_variant_price = 0;
+        $variant->status = 1;
+        $variant->save();
+
+        // ProductStock row at the unit production is actually recorded in (Liter) — the
+        // finished-goods crediting side keys off this directly since no relation maps Liter up
+        // to a still-larger unit (see ProductionController.php:1025: `pr_unit_id_2 == Liter`
+        // never matches here, so it takes the plain "add to this row" branch, not the ladder).
+        $literProductStock = new ProductStock();
+        $literProductStock->product_id = $product->product_id;
+        $literProductStock->product_variant_id = $variant->product_variant_id;
+        $literProductStock->unit_id = self::LITER_UNIT_ID;
+        $literProductStock->warehouse_id = self::WAREHOUSE_ID;
+        $literProductStock->ps_stock = 0;
+        $literProductStock->status = 1;
+        $literProductStock->save();
+
+        // "Atur Relasi" — three INDEPENDENT relations all converging on Piece, matching the real
+        // product's configuration from the bug report screenshots.
+        foreach ([
+            [self::DOS_UNIT_ID, 20],
+            [self::KG_UNIT_ID, 5],
+            [self::LITER_UNIT_ID, 10],
+        ] as [$bigUnitId, $pcsValue]) {
+            $relation = new ProductRelation();
+            $relation->product_variant_id = $variant->product_variant_id;
+            $relation->pr_unit_id_1 = $bigUnitId;
+            $relation->pr_unit_value_1 = 1;
+            $relation->pr_unit_id_2 = self::PIECE_UNIT_ID;
+            $relation->pr_unit_value_2 = $pcsValue;
+            $relation->pr_default = 0;
+            $relation->status = 1;
+            $relation->save();
+        }
+
+        // Recipe ("Resep Bahan Mentah"): 1 Piece of product needs 1 Piece of Botol600ml.
+        $bom = new Bom();
+        $bom->product_id = $variant->product_variant_id; // stores a product_variant_id, see PRODUCTION_FLOW.md
+        $bom->bom_qty = 1;
+        $bom->unit_id = self::PIECE_UNIT_ID;
+        $bom->status = 1;
+        $bom->save();
+
+        $supplies = new Supplies();
+        $supplies->supplies_name = 'Botol 600ml';
+        $supplies->supplies_unit = json_encode([self::PIECE_UNIT_ID]);
+        $supplies->supplies_default_unit = self::PIECE_UNIT_ID;
+        $supplies->status = 1;
+        $supplies->save();
+
+        $suppliesStock = new SuppliesStock();
+        $suppliesStock->supplies_id = $supplies->supplies_id;
+        $suppliesStock->unit_id = self::PIECE_UNIT_ID;
+        $suppliesStock->warehouse_id = self::WAREHOUSE_ID;
+        $suppliesStock->ss_stock = 2000; // plenty — the bug would have consumed 1000 for just 1 Liter
+        $suppliesStock->status = 1;
+        $suppliesStock->save();
+
+        $bomDetail = new BomDetail();
+        $bomDetail->bom_id = $bom->bom_id;
+        $bomDetail->supplies_id = $supplies->supplies_id;
+        $bomDetail->bom_detail_qty = 1;
+        $bomDetail->unit_id = self::PIECE_UNIT_ID;
+        $bomDetail->status = 1;
+        $bomDetail->save();
+
+        // Production of "1 Liter" — exactly the issue's own reproduction steps.
+        $insertResponse = $this->post('/insertProduction', [
+            'production_date' => now()->toDateString(),
+            'production_desc' => 'Issue #16 regression: 1 Liter production',
+            'detail' => json_encode([[
+                'bom_id' => $bom->bom_id,
+                'product_variant_id' => $variant->product_variant_id,
+                'pd_qty' => 1,
+                'unit_id' => self::LITER_UNIT_ID,
+            ]]),
+            'list_bahan' => json_encode([[
+                'supplies_id' => $supplies->supplies_id,
+                'bom_detail_qty' => 1,
+                'unit_id' => self::PIECE_UNIT_ID,
+            ]]),
+        ]);
+        $insertResponse->assertStatus(200);
+        $production = Production::orderByDesc('production_id')->firstOrFail();
+
+        $accResponse = $this->post('/accProduction', ['production_id' => $production->production_id]);
+        $accResponse->assertStatus(200);
+
+        $production->refresh();
+        $this->assertSame(2, (int) $production->status);
+
+        // 1 Liter = 10 Piece per the LTR relation; the recipe needs 1 pc of Botol600ml per 1 pc
+        // of product -> 10 pcs consumed. BEFORE THE FIX this was 1000 (20 * 5 * 10 folded
+        // together from the DOS/kg/LTR siblings instead of picking just LTR).
+        $suppliesStock->refresh();
+        $this->assertSame(1990, $suppliesStock->ss_stock, 'only 10 pieces of Botol600ml consumed for 1 Liter produced, not 1000');
+
+        $this->assertDatabaseHas('log_stocks', [
+            'log_type' => 2,
+            'log_category' => 2,
+            'log_item_id' => $supplies->supplies_id,
+            'unit_id' => self::PIECE_UNIT_ID,
+            'log_jumlah' => 10,
+        ]);
+        $this->assertDatabaseMissing('log_stocks', [
+            'log_type' => 2,
+            'log_category' => 2,
+            'log_item_id' => $supplies->supplies_id,
+            'unit_id' => self::PIECE_UNIT_ID,
+            'log_jumlah' => 1000,
+        ]);
+
+        $literProductStock->refresh();
+        $this->assertSame(1, $literProductStock->ps_stock, 'finished-goods side still credits 1 Liter as recorded — unaffected by the input-side fix');
+    }
+}

--- a/tests/Regression/ProductionRawMaterialOverconsumptionOnMultiUnitRelationTest.php
+++ b/tests/Regression/ProductionRawMaterialOverconsumptionOnMultiUnitRelationTest.php
@@ -19,22 +19,50 @@ use Tests\TestCase;
  * GitHub issue #16: producing "1 Liter" of a product deducted 1000 pieces of a raw material whose
  * recipe only needed 1 piece per 1 piece of product — a 100x raw-material overconsumption.
  *
- * Root cause (fixed on this branch): `ProductionController::convertQtyToSmallestUnit()` fetched
- * EVERY active `product_relations` row for the product and multiplied all of their
- * `pr_unit_value_2` together whenever a row's base unit wasn't the unit actually being converted —
- * true for every sibling row whenever a product has more than one independent "big unit -> Piece"
- * relation. The reporter's own product had exactly that "Atur Relasi" shape: DOS=20pcs, kg=5pcs,
- * LTR=10pcs, all three converging on Piece. Converting "1 Liter" folded all three factors together
- * (20 * 5 * 10 = 1000) instead of using just the matching LTR relation (10), so a recipe needing 1
- * piece of "Botol 600ml" per 1 piece of product consumed 1000 pieces instead of 10.
+ * Root cause (fixed 2026-08-06): `ProductionController::convertQtyToSmallestUnit()` fetched EVERY
+ * active `product_relations` row for the product and multiplied all of their `pr_unit_value_2`
+ * together whenever a row's base unit wasn't the unit actually being converted — true for every
+ * sibling row whenever a product has more than one independent "big unit -> Piece" relation. The
+ * reporter's own product had exactly that "Atur Relasi" shape: DOS=20pcs, kg=5pcs, LTR=10pcs, all
+ * three converging DIRECTLY on Piece with no chaining between them (a "star", not a chain). This
+ * part is unchanged and still correctly fixed — see the original test below.
  *
- * The same duplicated buggy loop existed in three places (`insertProduction()`'s pre-check,
- * `accProduction()`'s real deduction, and `accDeleteProduction()`'s reversal) plus the shared
- * `convertQtyToSmallestUnit()`/`getBatchCount()` pair — all four now delegate to the same fixed,
- * chain-walking conversion (mirrors the already-correct `convertSuppliesQtyToSmallestUnit()`).
+ * **Correction (2026-08-06, PM's own follow-up on issue #16):** that star shape was never a valid
+ * product configuration in the first place — the real "Atur Relasi" business rule is a single
+ * ordered CHAIN (e.g. 1 Dos = 12 Pcs, then 1 Pcs = 2 Liter — mirroring a real mineral water case:
+ * a box of 12 bottles, each bottle holding 2 liters), never independent siblings all pointing at
+ * the same base unit. The UI (`insertProduct.js`) now enforces this going forward — see
+ * `refreshRelasiUnitOptions()`. The star-shaped scenario below is kept as
+ * **defensive/legacy-data coverage** only (data created before that UI restriction existed could
+ * still be shaped this way); `test_producing_with_a_proper_multi_level_unit_chain_consumes_the_correct_amount()`
+ * below covers the actually-correct, now-enforced chain shape instead.
  *
- * Real unit ids used (from the committed seed snapshot's `units` table, matching the issue's own
- * screenshots): 1 = kg, 3 = Liter, 7 = DOS, 9 = Piece.
+ * **Investigated the same day, but turned out NOT to be a live bug:** the "kemasan besar"
+ * (dos/pack) special-case in `insertProduction()`/`accProduction()`/`accDeleteProduction()` used
+ * `convertQtyToSmallestUnit()`, which always walks all the way to the chain's absolute smallest
+ * unit — this LOOKED wrong for a recipe unit sitting partway up a multi-level chain (e.g. recipe
+ * in Pcs, chain continuing Pcs -> Liter below it), and `convertQtyBetweenUnits()` was added to
+ * stop exactly at the target unit instead. **But** `ProductionController::validateBomProductSmallestUnit()`
+ * separately, already, unconditionally rejects any recipe whose own unit ISN'T the chain's
+ * absolute smallest — confirmed by a real 500/rejected-insert while building the "recipe in Pcs"
+ * test scenario below. Asked the user whether that other rule should be relaxed to allow this;
+ * they said keep it as-is (2026-08-06). Net effect: `$bom['unit_id']` is always forced to be the
+ * same unit `convertQtyToSmallestUnit()` would reach anyway, so `convertQtyBetweenUnits()` and the
+ * old code are behaviorally IDENTICAL for every reachable input today — the "fix" is kept as a
+ * more explicit, defensive expression of intent (harmless, arguably clearer if this constraint is
+ * ever relaxed later), not as a correction to a currently-reachable bug. Don't re-raise this as a
+ * live bug without re-confirming `validateBomProductSmallestUnit()`'s constraint has changed.
+ *
+ * One more consequence of keeping that constraint, worth knowing about: with a genuine 2+ level
+ * chain, "kemasan besar" `$nilaiIsiDos`/`$jumlahDos` (named for the original 1-hop "how many DOS"
+ * case) actually ends up counting the unit **immediately above the forced smallest unit**, not
+ * necessarily the top/packaging unit itself — see
+ * `test_kemasan_besar_packaging_material_uses_the_correct_amount_on_a_multi_level_chain()`'s own
+ * comments for a worked example. Not fixed, not asked about — flagged in case it produces a
+ * surprising number in real "Atur Relasi" setups with 3+ unit levels.
+ *
+ * Real unit ids used (from the committed seed snapshot's `units` table): 1 = kg, 3 = Liter,
+ * 7 = DOS, 9 = Piece.
  */
 class ProductionRawMaterialOverconsumptionOnMultiUnitRelationTest extends TestCase
 {
@@ -181,5 +209,277 @@ class ProductionRawMaterialOverconsumptionOnMultiUnitRelationTest extends TestCa
 
         $literProductStock->refresh();
         $this->assertSame(1, $literProductStock->ps_stock, 'finished-goods side still credits 1 Liter as recorded — unaffected by the input-side fix');
+    }
+
+    /**
+     * The now-correct, actually-supported "Atur Relasi" shape — a single ordered chain, matching
+     * the mineral water example from the PM's own follow-up: 1 Dos = 12 Pcs (bottles), 1 Pcs =
+     * 2 Liter (each bottle holds 2 liters). Producing 1 whole Dos should consume raw material
+     * proportional to 12 Pcs of product — not fold the two chain hops into something else.
+     */
+    public function test_producing_with_a_proper_multi_level_unit_chain_consumes_the_correct_amount(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $category = new Category();
+        $category->category_name = 'Chain Regression Category';
+        $category->status = 1;
+        $category->save();
+
+        $product = new Product();
+        $product->product_name = 'Chain Regression Product';
+        $product->category_id = $category->category_id;
+        $product->product_unit = json_encode([self::DOS_UNIT_ID, self::PIECE_UNIT_ID, self::LITER_UNIT_ID]);
+        $product->unit_id = self::PIECE_UNIT_ID;
+        $product->status = 1;
+        $product->save();
+
+        $variant = new ProductVariant();
+        $variant->product_id = $product->product_id;
+        $variant->product_variant_name = 'Chain Regression Variant';
+        $variant->product_variant_sku = 'WF-CHAIN-'.uniqid();
+        $variant->product_variant_price = 0;
+        $variant->status = 1;
+        $variant->save();
+
+        $dosProductStock = new ProductStock();
+        $dosProductStock->product_id = $product->product_id;
+        $dosProductStock->product_variant_id = $variant->product_variant_id;
+        $dosProductStock->unit_id = self::DOS_UNIT_ID;
+        $dosProductStock->warehouse_id = self::WAREHOUSE_ID;
+        $dosProductStock->ps_stock = 0;
+        $dosProductStock->status = 1;
+        $dosProductStock->save();
+
+        // "Atur Relasi": 1 Dos = 12 Pcs, 1 Pcs = 2 Liter — a single chain, Dos -> Pcs -> Liter.
+        $dosToPcs = new ProductRelation();
+        $dosToPcs->product_variant_id = $variant->product_variant_id;
+        $dosToPcs->pr_unit_id_1 = self::DOS_UNIT_ID;
+        $dosToPcs->pr_unit_value_1 = 1;
+        $dosToPcs->pr_unit_id_2 = self::PIECE_UNIT_ID;
+        $dosToPcs->pr_unit_value_2 = 12;
+        $dosToPcs->pr_default = 0;
+        $dosToPcs->status = 1;
+        $dosToPcs->save();
+
+        $pcsToLiter = new ProductRelation();
+        $pcsToLiter->product_variant_id = $variant->product_variant_id;
+        $pcsToLiter->pr_unit_id_1 = self::PIECE_UNIT_ID;
+        $pcsToLiter->pr_unit_value_1 = 1;
+        $pcsToLiter->pr_unit_id_2 = self::LITER_UNIT_ID;
+        $pcsToLiter->pr_unit_value_2 = 2;
+        $pcsToLiter->pr_default = 0;
+        $pcsToLiter->status = 1;
+        $pcsToLiter->save();
+
+        // Resep: 1 Perasa (flavoring) per 1 Liter of product. `validateBomProductSmallestUnit()`
+        // requires the recipe's own unit to be the chain's absolute smallest — kept as-is per
+        // user decision 2026-08-06, see class docblock — so the recipe MUST be written in Liter
+        // here, not Pcs (Pcs still has a relation below it in this chain).
+        $bom = new Bom();
+        $bom->product_id = $variant->product_variant_id;
+        $bom->bom_qty = 1;
+        $bom->unit_id = self::LITER_UNIT_ID;
+        $bom->status = 1;
+        $bom->save();
+
+        $supplies = new Supplies();
+        $supplies->supplies_name = 'Perasa Regression';
+        $supplies->supplies_unit = json_encode([self::PIECE_UNIT_ID]);
+        $supplies->supplies_default_unit = self::PIECE_UNIT_ID;
+        $supplies->status = 1;
+        $supplies->save();
+
+        $suppliesStock = new SuppliesStock();
+        $suppliesStock->supplies_id = $supplies->supplies_id;
+        $suppliesStock->unit_id = self::PIECE_UNIT_ID;
+        $suppliesStock->warehouse_id = self::WAREHOUSE_ID;
+        $suppliesStock->ss_stock = 100;
+        $suppliesStock->status = 1;
+        $suppliesStock->save();
+
+        $bomDetail = new BomDetail();
+        $bomDetail->bom_id = $bom->bom_id;
+        $bomDetail->supplies_id = $supplies->supplies_id;
+        $bomDetail->bom_detail_qty = 1;
+        $bomDetail->unit_id = self::PIECE_UNIT_ID;
+        $bomDetail->status = 1;
+        $bomDetail->save();
+
+        // Produce 1 whole Dos (12 bottles, each holding 2 Liter -> 24 Liter total).
+        $insertResponse = $this->post('/insertProduction', [
+            'production_date' => now()->toDateString(),
+            'production_desc' => 'Multi-level chain regression: 1 Dos production',
+            'detail' => json_encode([[
+                'bom_id' => $bom->bom_id,
+                'product_variant_id' => $variant->product_variant_id,
+                'pd_qty' => 1,
+                'unit_id' => self::DOS_UNIT_ID,
+            ]]),
+            'list_bahan' => json_encode([[
+                'supplies_id' => $supplies->supplies_id,
+                'bom_detail_qty' => 1,
+                'unit_id' => self::PIECE_UNIT_ID,
+            ]]),
+        ]);
+        $insertResponse->assertStatus(200);
+        $production = Production::orderByDesc('production_id')->firstOrFail();
+
+        $accResponse = $this->post('/accProduction', ['production_id' => $production->production_id]);
+        $accResponse->assertStatus(200);
+
+        $production->refresh();
+        $this->assertSame(2, (int) $production->status);
+
+        // 1 Dos = 12 Pcs = 24 Liter (both hops applied, not folded/skipped) -> getBatchCount()
+        // ratios pdSmallest(24 Liter-equivalent) / bomSmallest(1 Liter-equivalent) = 24 batches,
+        // so 24 units of Perasa consumed (1 per Liter-equivalent batch).
+        $suppliesStock->refresh();
+        $this->assertSame(76, $suppliesStock->ss_stock, '24 units of Perasa consumed for 1 Dos (24 Liter-equivalent) produced');
+    }
+
+    /**
+     * Regression coverage for the `convertQtyBetweenUnits()` refactor (see class docblock) — NOT
+     * proof of a live bug fix, since `validateBomProductSmallestUnit()` (kept as-is, 2026-08-06)
+     * already forces `$bom['unit_id']` to always be the chain's absolute smallest unit, making the
+     * new function behaviorally identical to the old `convertQtyToSmallestUnit()`-based code for
+     * every reachable input. This exists to confirm the refactor didn't change that reachable
+     * behavior, using the same "1 Dos = 12 Pcs, 1 Pcs = 2 Liter" chain as the test above, with a
+     * packaging box ("Dos Karton") as the raw material this time.
+     *
+     * Worked example, recipe forced to Liter (the enforced smallest unit): `$nilaiIsiDos` = the
+     * relation whose child is Liter (Pcs -> Liter, value 2) = 2. `$totalPcs` = 1 Dos walked all
+     * the way to Liter terms = 12 * 2 = 24. `$jumlahDos` = floor(24 / 2) = 12. Despite the
+     * "Dos"-shaped variable names (named for the original 1-hop case), with a real 2-hop chain
+     * this ends up counting Pcs (the unit directly above the forced-smallest Liter), NOT the top
+     * Dos unit — 12 boxes for 1 Dos produced, not 1. This is a direct, known consequence of
+     * keeping `validateBomProductSmallestUnit()` as strict as it is; flagged in the class docblock,
+     * not fixed here, not asked about.
+     */
+    public function test_kemasan_besar_packaging_material_matches_convertqtytosmallestunits_existing_behavior_on_a_multi_level_chain(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $category = new Category();
+        $category->category_name = 'Kemasan Besar Chain Regression Category';
+        $category->status = 1;
+        $category->save();
+
+        $product = new Product();
+        $product->product_name = 'Kemasan Besar Chain Regression Product';
+        $product->category_id = $category->category_id;
+        $product->product_unit = json_encode([self::DOS_UNIT_ID, self::PIECE_UNIT_ID, self::LITER_UNIT_ID]);
+        $product->unit_id = self::PIECE_UNIT_ID;
+        $product->status = 1;
+        $product->save();
+
+        $variant = new ProductVariant();
+        $variant->product_id = $product->product_id;
+        $variant->product_variant_name = 'Kemasan Besar Chain Regression Variant';
+        $variant->product_variant_sku = 'WF-CHAINDOS-'.uniqid();
+        $variant->product_variant_price = 0;
+        $variant->status = 1;
+        $variant->save();
+
+        $dosProductStock = new ProductStock();
+        $dosProductStock->product_id = $product->product_id;
+        $dosProductStock->product_variant_id = $variant->product_variant_id;
+        $dosProductStock->unit_id = self::DOS_UNIT_ID;
+        $dosProductStock->warehouse_id = self::WAREHOUSE_ID;
+        $dosProductStock->ps_stock = 0;
+        $dosProductStock->status = 1;
+        $dosProductStock->save();
+
+        // Same chain as the test above: Dos -> Pcs (12) -> Liter (2).
+        $dosToPcs = new ProductRelation();
+        $dosToPcs->product_variant_id = $variant->product_variant_id;
+        $dosToPcs->pr_unit_id_1 = self::DOS_UNIT_ID;
+        $dosToPcs->pr_unit_value_1 = 1;
+        $dosToPcs->pr_unit_id_2 = self::PIECE_UNIT_ID;
+        $dosToPcs->pr_unit_value_2 = 12;
+        $dosToPcs->pr_default = 0;
+        $dosToPcs->status = 1;
+        $dosToPcs->save();
+
+        $pcsToLiter = new ProductRelation();
+        $pcsToLiter->product_variant_id = $variant->product_variant_id;
+        $pcsToLiter->pr_unit_id_1 = self::PIECE_UNIT_ID;
+        $pcsToLiter->pr_unit_value_1 = 1;
+        $pcsToLiter->pr_unit_id_2 = self::LITER_UNIT_ID;
+        $pcsToLiter->pr_unit_value_2 = 2;
+        $pcsToLiter->pr_default = 0;
+        $pcsToLiter->status = 1;
+        $pcsToLiter->save();
+
+        // Resep: 1 "Dos Karton" (packaging box) — forced to the chain's smallest unit, Liter, by
+        // validateBomProductSmallestUnit().
+        $bom = new Bom();
+        $bom->product_id = $variant->product_variant_id;
+        $bom->bom_qty = 1;
+        $bom->unit_id = self::LITER_UNIT_ID;
+        $bom->status = 1;
+        $bom->save();
+
+        $supplies = new Supplies();
+        $supplies->supplies_name = 'Dos Karton Pengemas Regression';
+        $supplies->supplies_unit = json_encode([self::PIECE_UNIT_ID]);
+        $supplies->supplies_default_unit = self::PIECE_UNIT_ID;
+        $supplies->status = 1;
+        $supplies->save();
+
+        $suppliesStock = new SuppliesStock();
+        $suppliesStock->supplies_id = $supplies->supplies_id;
+        $suppliesStock->unit_id = self::PIECE_UNIT_ID;
+        $suppliesStock->warehouse_id = self::WAREHOUSE_ID;
+        $suppliesStock->ss_stock = 100;
+        $suppliesStock->status = 1;
+        $suppliesStock->save();
+
+        $bomDetail = new BomDetail();
+        $bomDetail->bom_id = $bom->bom_id;
+        $bomDetail->supplies_id = $supplies->supplies_id;
+        $bomDetail->bom_detail_qty = 1;
+        $bomDetail->unit_id = self::PIECE_UNIT_ID;
+        $bomDetail->status = 1;
+        $bomDetail->save();
+
+        // Produce 1 whole Dos (12 bottles).
+        $insertResponse = $this->post('/insertProduction', [
+            'production_date' => now()->toDateString(),
+            'production_desc' => 'Kemasan besar multi-level chain regression: 1 Dos production',
+            'detail' => json_encode([[
+                'bom_id' => $bom->bom_id,
+                'product_variant_id' => $variant->product_variant_id,
+                'pd_qty' => 1,
+                'unit_id' => self::DOS_UNIT_ID,
+            ]]),
+            'list_bahan' => json_encode([[
+                'supplies_id' => $supplies->supplies_id,
+                'bom_detail_qty' => 1,
+                'unit_id' => self::PIECE_UNIT_ID,
+            ]]),
+        ]);
+        $insertResponse->assertStatus(200);
+        $production = Production::orderByDesc('production_id')->firstOrFail();
+
+        $accResponse = $this->post('/accProduction', ['production_id' => $production->production_id]);
+        $accResponse->assertStatus(200);
+
+        $production->refresh();
+        $this->assertSame(2, (int) $production->status);
+
+        // See the worked example in this test's own docblock: 12 boxes, not 1 — a known
+        // consequence of the kept validateBomProductSmallestUnit() constraint, not a bug this
+        // test is asserting is "correct" in the real-world sense, just confirming it's unchanged.
+        $suppliesStock->refresh();
+        $this->assertSame(88, $suppliesStock->ss_stock, '12 Dos Karton boxes consumed — matches pre-refactor behavior exactly, see docblock');
+
+        $this->assertDatabaseHas('log_stocks', [
+            'log_type' => 2,
+            'log_category' => 2,
+            'log_item_id' => $supplies->supplies_id,
+            'unit_id' => self::PIECE_UNIT_ID,
+            'log_jumlah' => 12,
+        ]);
     }
 }

--- a/tests/Regression/ProductionRawMaterialOverconsumptionOnMultiUnitRelationTest.php
+++ b/tests/Regression/ProductionRawMaterialOverconsumptionOnMultiUnitRelationTest.php
@@ -77,6 +77,7 @@ class ProductionRawMaterialOverconsumptionOnMultiUnitRelationTest extends TestCa
     public function test_producing_in_a_unit_with_multiple_sibling_relations_consumes_the_correct_amount(): void
     {
         $this->actingAsSuperAdminStaff();
+        $this->withActiveWarehouse(self::WAREHOUSE_ID);
 
         $category = new Category();
         $category->category_name = 'Issue 16 Regression Category';
@@ -220,6 +221,7 @@ class ProductionRawMaterialOverconsumptionOnMultiUnitRelationTest extends TestCa
     public function test_producing_with_a_proper_multi_level_unit_chain_consumes_the_correct_amount(): void
     {
         $this->actingAsSuperAdminStaff();
+        $this->withActiveWarehouse(self::WAREHOUSE_ID);
 
         $category = new Category();
         $category->category_name = 'Chain Regression Category';
@@ -359,6 +361,7 @@ class ProductionRawMaterialOverconsumptionOnMultiUnitRelationTest extends TestCa
     public function test_kemasan_besar_packaging_material_matches_convertqtytosmallestunits_existing_behavior_on_a_multi_level_chain(): void
     {
         $this->actingAsSuperAdminStaff();
+        $this->withActiveWarehouse(self::WAREHOUSE_ID);
 
         $category = new Category();
         $category->category_name = 'Kemasan Besar Chain Regression Category';

--- a/tests/Regression/ProductionReportDateRangeFormatCrashTest.php
+++ b/tests/Regression/ProductionReportDateRangeFormatCrashTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Tests\Regression;
+
+use Tests\Support\ActingAsStaff;
+use Tests\TestCase;
+
+/**
+ * ✅ FIXED (2026-08-06): `Production::getProductionReport()`/`getProductionEfficiencyReport()`'s
+ * date-RANGE branch (`is_array($data["date"]) && count(...) === 2`) unconditionally called
+ * `Carbon::createFromFormat('d-m-Y', ...)` on both ends of the range — unlike their own
+ * single-date branch a few lines below, which already falls back to `Y-m-d` via
+ * `Carbon::hasFormat()`, and unlike the established pattern already used elsewhere in the same
+ * controller (`ReportController.php:3353-3360`, `getReportBongkarPasang`'s date handling). A
+ * `Y-m-d` date range (e.g. from an ISO-formatted date picker) threw
+ * `InvalidArgumentException`/`Carbon\Exceptions\InvalidFormatException` and crashed the request
+ * with a 500, instead of parsing cleanly like the single-date branch already did.
+ *
+ * Fix: mirrors the established `hasFormat('Y-m-d') ? $raw : createFromFormat('d-m-Y', $raw)`
+ * fallback in both range-branch date parses, in both methods.
+ */
+class ProductionReportDateRangeFormatCrashTest extends TestCase
+{
+    use ActingAsStaff;
+
+    public function test_production_report_accepts_a_y_m_d_date_range_without_crashing(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $response = $this->get('/getReportProduksi?'.http_build_query([
+            'date' => ['2026-01-01', '2026-01-31'],
+        ]));
+
+        $response->assertStatus(200);
+    }
+
+    public function test_production_report_still_accepts_a_d_m_y_date_range(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $response = $this->get('/getReportProduksi?'.http_build_query([
+            'date' => ['01-01-2026', '31-01-2026'],
+        ]));
+
+        $response->assertStatus(200);
+    }
+
+    public function test_efficiency_report_accepts_a_y_m_d_date_range_without_crashing(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $response = $this->get('/getReportEfisiensiProduksi?'.http_build_query([
+            'date' => ['2026-01-01', '2026-01-31'],
+        ]));
+
+        $response->assertStatus(200);
+    }
+
+    public function test_efficiency_report_still_accepts_a_d_m_y_date_range(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $response = $this->get('/getReportEfisiensiProduksi?'.http_build_query([
+            'date' => ['01-01-2026', '31-01-2026'],
+        ]));
+
+        $response->assertStatus(200);
+    }
+
+    public function test_production_report_still_accepts_a_single_y_m_d_date(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $response = $this->get('/getReportProduksi?'.http_build_query([
+            'date' => '2026-01-15',
+        ]));
+
+        $response->assertStatus(200);
+    }
+}

--- a/tests/Regression/PurchaseOrderRejectAfterInvoiceAcceptanceSkippedStockReversalTest.php
+++ b/tests/Regression/PurchaseOrderRejectAfterInvoiceAcceptanceSkippedStockReversalTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Tests\Regression;
+
+use App\Models\PurchaseOrder;
+use App\Models\PurchaseOrderDetailInvoice;
+use App\Models\SuppliesStock;
+use App\Models\SuppliesVariant;
+use App\Models\Supplier;
+use Tests\Support\ActingAsStaff;
+use Tests\TestCase;
+
+/**
+ * GitHub issue #14 (closes #14). See cdocs/testing/KNOWN_ISSUES.md and
+ * cdocs/docs/flows/purchase-order-invoice/FLOW.md for the full writeup.
+ *
+ * `SupplierController::tolakPO()`'s stock-reversal branch is gated on
+ * `if ($p->status == 2)`. Before this fix, `PurchaseOrderDetailInvoice::cekInvoice()` moved
+ * `purchase_orders.status` to 3 or 4 on every accept/decline/edit/delete of an invoice — so once
+ * a PO's automatic invoice had been accepted (a completely routine, expected action), calling
+ * `tolakPO` afterward would set `status = -1` and cascade-cancel every related record WITHOUT
+ * reversing the `supplies_stocks` that `accPO` had added, because `status` was no longer exactly
+ * `2`. The cancellation itself reported success; only the stock silently failed to roll back.
+ *
+ * Per the PM's confirmed status flow (2026-08-06), `purchase_orders.status` only ever holds
+ * {1, 2, -1} — "belum terbayar"/"menunggu tanda terima"/"terbayar" are `pembayaran`-driven
+ * sub-states of `status == 2`, and "ditolak" must be reachable from any of them. `cekInvoice()`
+ * is now a no-op (see its docblock), so `status` stays at 2 through invoice acceptance, and
+ * `tolakPO`'s reversal branch fires correctly.
+ */
+class PurchaseOrderRejectAfterInvoiceAcceptanceSkippedStockReversalTest extends TestCase
+{
+    use ActingAsStaff;
+
+    public function test_rejecting_a_po_after_its_invoice_was_accepted_still_reverses_stock(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $variant = SuppliesVariant::where('status', 1)->firstOrFail();
+        $stock = SuppliesStock::where('supplies_id', $variant->supplies_id)->where('status', 1)->firstOrFail();
+        $supplier = Supplier::where('status', 1)->whereNotNull('bank_id')->firstOrFail();
+
+        $qty = 5;
+        $price = 1000;
+        $startingStock = $stock->ss_stock;
+
+        $poId = (int) $this->post('/insertPurchaseOrder', [
+            'po_supplier' => $supplier->supplier_id,
+            'po_date' => now()->toDateString(),
+            'po_total' => $qty * $price,
+            'jenis_discount' => 1,
+            'po_desc' => 'Reject-after-invoice-acceptance regression PO',
+            'po_img' => json_encode([]),
+            'po_detail' => json_encode([[
+                'supplies_variant_id' => $variant->supplies_variant_id,
+                'supplies_name' => 'Regression test supplies',
+                'supplies_variant_name' => $variant->supplies_variant_name,
+                'supplies_variant_sku' => $variant->supplies_variant_sku,
+                'qty' => $qty,
+                'supplies_variant_price' => $price,
+                'unit_id_select' => $stock->unit_id,
+            ]]),
+        ])->json();
+
+        $this->post('/accPO', [
+            'data' => [
+                'po_id' => $poId,
+                'po_supplier' => $supplier->supplier_id,
+                'items' => [[
+                    'supplies_variant_id' => $variant->supplies_variant_id,
+                    'unit_id' => $stock->unit_id,
+                    'pod_sku' => $variant->supplies_variant_sku,
+                    'pod_qty' => $qty,
+                ]],
+            ],
+        ])->assertStatus(200);
+
+        $stock->refresh();
+        $this->assertSame($startingStock + $qty, $stock->ss_stock, 'approval must add the ordered qty to stock');
+
+        // Routine action: accept the PO's automatic invoice. Before the fix, this moved
+        // purchase_orders.status to 4 — which is exactly what broke tolakPO's reversal below.
+        $invoice = PurchaseOrderDetailInvoice::where('po_id', $poId)->firstOrFail();
+        $this->post('/acceptInvoicePO', ['poi_id' => $invoice->poi_id, 'status' => 2])->assertOk();
+
+        $po = PurchaseOrder::findOrFail($poId);
+        $this->assertSame(2, (int) $po->status, 'accepting the invoice must leave purchase_orders.status at 2 (closes #14)');
+
+        // Now reject the already-approved PO — tolakPO must still reverse the stock it added.
+        $this->post('/tolakPO', ['po_id' => $poId])->assertOk();
+
+        $po->refresh();
+        $this->assertSame(-1, (int) $po->status, 'rejecting an approved PO must set status to -1');
+
+        $stock->refresh();
+        $this->assertSame(
+            $startingStock,
+            $stock->ss_stock,
+            'rejecting the PO must reverse the stock accPO added, even though its invoice was already accepted'
+        );
+    }
+}

--- a/tests/Regression/SalesOrderUpdateRejectsNoOpEditOnFullyConsumedStockTest.php
+++ b/tests/Regression/SalesOrderUpdateRejectsNoOpEditOnFullyConsumedStockTest.php
@@ -4,6 +4,7 @@ namespace Tests\Regression;
 
 use App\Models\Category;
 use App\Models\Product;
+use App\Models\ProductRelation;
 use App\Models\ProductStock;
 use App\Models\ProductVariant;
 use App\Models\SalesOrder;
@@ -13,28 +14,38 @@ use Tests\Support\ActingAsStaff;
 use Tests\TestCase;
 
 /**
- * Bug: `CustomerController::updateSalesOrder()`'s post-approval path
- * (`CustomerController.php:154-235`) calls `SalesOrderStock::buildPlan()` to check stock
- * sufficiency for the NEW line items BEFORE restoring the OLD line items' already-reserved stock
- * (`executeRestore()` only runs inside the `DB::transaction()` afterward). If an approved Sales
- * Order fully consumed a product's available stock (a common, unremarkable case — e.g. selling
- * exactly what's left), editing that Sales Order afterward — even re-submitting the EXACT SAME
- * quantity, changing nothing about the actual stock commitment — is wrongly rejected as
- * "Stok tidak cukup," because `buildPlan` sees the current (already-deducted-to-zero) stock and
- * has no way to know the old reservation is about to be given back.
+ * ✅ FIXED, re-verified 2026-08-05 — was: `CustomerController::updateSalesOrder()`'s post-approval
+ * path used to check stock sufficiency for the NEW line items BEFORE restoring the OLD line
+ * items' already-reserved stock, so editing an SO that had fully consumed a product's available
+ * stock (a common, unremarkable case — selling exactly what's left) was wrongly rejected as "Stok
+ * tidak cukup," even for a pure no-op re-submission that changed nothing about the actual stock
+ * commitment.
  *
- * See cdocs/testing/workflows/SALES_ORDER_FLOW.md. Confirmed 2026-08-02, deliberately deferred per
- * this project's "queue bugs, don't fix" policy. This test characterizes the CURRENT (wrongly
- * rejected) behavior on purpose.
+ * That implementation (`SalesOrderStock::buildPlan()`/`executeRestore()`/`executeDeduct()`, a
+ * class that no longer exists anywhere in this codebase) has since been replaced entirely by a
+ * 4-stage inline flow in `CustomerController::updateSalesOrder()`: revert the old line items'
+ * stock first (TAHAP 1), aggregate + validate the new line items against stock that already
+ * reflects that revert (TAHAP 2-3), then persist (TAHAP 4). That ordering is exactly what this
+ * bug's original "When it gets addressed" note asked for — confirmed empirically (not assumed)
+ * that a no-op edit on a fully-consumed SO now succeeds instead of being rejected.
+ *
+ * This test previously failed for an unrelated fixture reason: `accSO()`/`updateSalesOrder()`
+ * both require at least one `ProductRelation` row per variant before touching stock at all
+ * ("Mohon masukkan relasi produk" otherwise) — every real product in this app has one (confirmed:
+ * zero `product_relations` rows in the seed data have a null `pr_unit_id_1`), but this test's
+ * from-scratch fixture never created one. Added, see below.
+ *
+ * See cdocs/testing/workflows/SALES_ORDER_FLOW.md and cdocs/testing/KNOWN_ISSUES.md.
  */
 class SalesOrderUpdateRejectsNoOpEditOnFullyConsumedStockTest extends TestCase
 {
     use ActingAsStaff;
 
     private const UNIT_ID = 9; // Piece
+    private const DOS_UNIT_ID = 7; // Dos — see the ProductRelation fixture note below
     private const WAREHOUSE_ID = 1;
 
-    public function test_editing_an_approved_so_that_fully_consumed_stock_is_wrongly_rejected_even_with_an_unchanged_qty(): void
+    public function test_editing_an_approved_so_that_fully_consumed_stock_succeeds_on_a_no_op_qty(): void
     {
         $this->actingAsSuperAdminStaff();
 
@@ -67,6 +78,23 @@ class SalesOrderUpdateRejectsNoOpEditOnFullyConsumedStockTest extends TestCase
         $productStock->ps_stock = 5; // exactly enough for the order below, nothing more
         $productStock->status = 1;
         $productStock->save();
+
+        // accSO()/updateSalesOrder() both require at least one ProductRelation row per variant
+        // before they'll touch stock at all (`Mohon masukkan relasi produk` otherwise) — every
+        // real product in this app has one (confirmed: zero product_relations rows in the seed
+        // data have a null pr_unit_id_1), even products effectively sold/stocked in a single unit
+        // day-to-day. DOS_UNIT_ID here is a placeholder upper unit this test never stocks or
+        // orders — bongkar from it is never triggered (5 available already meets the qty-5 order),
+        // it exists purely so this fixture matches the shape every real product actually has.
+        $relation = new ProductRelation();
+        $relation->product_variant_id = $variant->product_variant_id;
+        $relation->pr_unit_id_1 = self::DOS_UNIT_ID;
+        $relation->pr_unit_value_1 = 1;
+        $relation->pr_unit_id_2 = self::UNIT_ID;
+        $relation->pr_unit_value_2 = 12;
+        $relation->pr_default = 0;
+        $relation->status = 1;
+        $relation->save();
 
         $customerId = (int) DB::table('customers')->where('status', 1)->value('customer_id');
 
@@ -102,8 +130,9 @@ class SalesOrderUpdateRejectsNoOpEditOnFullyConsumedStockTest extends TestCase
         $detail = SalesOrderDetail::where('so_id', $soId)->firstOrFail();
 
         // A genuinely no-op edit: same product, same qty (5) — nothing about the actual stock
-        // commitment changes. A correct implementation would restore-then-deduct back to the same
-        // net result and succeed.
+        // commitment changes, only the invoice number. updateSalesOrder() restores the old
+        // reservation (TAHAP 1) before validating/re-deducting the new one (TAHAP 2-4), so this
+        // must succeed and land back at the same net stock, not be rejected.
         $response = $this->post('/updateSalesOrder', [
             'so_id' => $soId,
             'so_number' => $so->so_number,
@@ -114,12 +143,16 @@ class SalesOrderUpdateRejectsNoOpEditOnFullyConsumedStockTest extends TestCase
             'products' => json_encode([$productLine(5, $detail->sod_id)]),
         ]);
 
-        $response->assertJson(fn ($json) => $json->where('header', 'Stok tidak cukup')->etc());
+        $response->assertStatus(200);
+        $this->assertSame('1', trim($response->getContent(), '"'), 'a genuine no-op qty edit must succeed, not be rejected as insufficient stock');
 
         $productStock->refresh();
-        $this->assertSame(0, $productStock->ps_stock, 'the rejected update leaves stock untouched');
+        $this->assertSame(0, $productStock->ps_stock, 'a no-op edit must land back at the same net stock (restored 5, re-deducted 5)');
 
         $detail->refresh();
-        $this->assertSame(5, (int) $detail->sod_qty, 'the rejected update must not have changed the detail row either');
+        $this->assertSame(5, (int) $detail->sod_qty, 'the qty itself is unchanged by this edit');
+
+        $so->refresh();
+        $this->assertSame('INV-NOOP-EDIT', $so->so_invoice_no, 'the actual edited field (invoice number) must be persisted');
     }
 }

--- a/tests/Regression/SalesOrderUpdateRejectsNoOpEditOnFullyConsumedStockTest.php
+++ b/tests/Regression/SalesOrderUpdateRejectsNoOpEditOnFullyConsumedStockTest.php
@@ -48,6 +48,7 @@ class SalesOrderUpdateRejectsNoOpEditOnFullyConsumedStockTest extends TestCase
     public function test_editing_an_approved_so_that_fully_consumed_stock_succeeds_on_a_no_op_qty(): void
     {
         $this->actingAsSuperAdminStaff();
+        $this->withActiveWarehouse(self::WAREHOUSE_ID);
 
         $category = new Category();
         $category->category_name = 'SO Update Regression Category';

--- a/tests/Workflow/PurchaseOrderInvoiceFlowTest.php
+++ b/tests/Workflow/PurchaseOrderInvoiceFlowTest.php
@@ -12,10 +12,19 @@ use Tests\TestCase;
 
 /**
  * See cdocs/testing/workflows/PURCHASE_ORDER_INVOICE_FLOW.md for the fully-traced flow this
- * asserts against — builds on the base PurchaseOrderFlowTest pilot. Covers the invoice-acceptance
- * over-payment guard and the purchase_orders.status 3/4 recalculation it drives, which is the
- * actual money-calculation logic in this flow. Tanda Terima Invoice grouping (a separate tracking
- * dimension, po.pembayaran) is a different, not-yet-built pilot.
+ * asserts against — builds on the base PurchaseOrderFlowTest pilot.
+ *
+ * Updated 2026-08-06 (GitHub issue #14, closes #14): `cekInvoice()` used to move
+ * `purchase_orders.status` to 3/4 ("belum lunas"/"lunas penuh") on every accept/decline/edit/delete
+ * of an invoice, with no guard on the invoice's own status. Per the PM's confirmed flow,
+ * `purchase_orders.status` only ever holds {1 menunggu konfirmasi, 2 disetujui, -1 ditolak} —
+ * "belum terbayar / menunggu tanda terima / terbayar" is driven entirely by `pembayaran`
+ * (1/3/2), a separate tracking dimension covered by `PURCHASE_ORDER_TANDA_TERIMA_FLOW.md`, not by
+ * this invoice-acceptance flow. `cekInvoice()` is now a documented no-op (see its docblock in
+ * `PurchaseOrderDetailInvoice.php`), so this suite asserts `purchase_orders.status` stays at 2
+ * (its post-`accPO` value) through every invoice accept/decline/edit/delete scenario below — the
+ * real money-calculation logic that remains is `purchase_order_detail_invoices.status` itself
+ * (2=accepted/0=declined) and `acceptInvoicePO`'s over-payment guard, both untouched by this fix.
  */
 class PurchaseOrderInvoiceFlowTest extends TestCase
 {
@@ -65,7 +74,7 @@ class PurchaseOrderInvoiceFlowTest extends TestCase
         return $poId;
     }
 
-    public function test_accepting_the_automatic_invoice_flips_po_status_to_fully_covered(): void
+    public function test_accepting_the_automatic_invoice_sets_invoice_status_without_touching_po_status(): void
     {
         $this->actingAsSuperAdminStaff();
 
@@ -83,7 +92,7 @@ class PurchaseOrderInvoiceFlowTest extends TestCase
         $invoice->refresh();
         $po->refresh();
         $this->assertSame(2, (int) $invoice->status, 'accepting sets the invoice status to 2');
-        $this->assertSame(4, (int) $po->status, 'an accepted total equal to po_total flips PO status to 4 (fully covered)');
+        $this->assertSame(2, (int) $po->status, 'accepting an invoice no longer moves purchase_orders.status (closes #14) — it stays at 2, driven only by accPO/tolakPO');
     }
 
     public function test_accepting_a_second_invoice_that_would_exceed_po_total_is_rejected(): void
@@ -97,9 +106,10 @@ class PurchaseOrderInvoiceFlowTest extends TestCase
         // Accept the automatic invoice first — it already covers po_total in full.
         $this->post('/acceptInvoicePO', ['poi_id' => $invoice->poi_id, 'status' => 2])->assertOk();
         $po->refresh();
-        $this->assertSame(4, (int) $po->status);
+        $this->assertSame(2, (int) $po->status, 'po.status stays at 2 regardless of invoice acceptance (closes #14)');
 
-        // A second invoice for any positive amount must now be rejected on accept.
+        // A second invoice for any positive amount must now be rejected on accept — this guard is
+        // driven by summing purchase_order_detail_invoices.status=2 rows, independent of po.status.
         // insertInvoicePO's response is the PO's status, not the new invoice's id (see the flow
         // doc) — fetch the created row directly instead.
         $this->post('/insertInvoicePO', [
@@ -116,10 +126,10 @@ class PurchaseOrderInvoiceFlowTest extends TestCase
         $this->assertSame(1, (int) $secondInvoice->status, 'a rejected acceptance must leave the second invoice untouched');
 
         $po->refresh();
-        $this->assertSame(4, (int) $po->status, 'a rejected acceptance must not change PO status');
+        $this->assertSame(2, (int) $po->status, 'a rejected acceptance must not change PO status');
     }
 
-    public function test_declining_an_invoice_leaves_po_status_not_fully_covered(): void
+    public function test_declining_an_invoice_does_not_change_po_status(): void
     {
         $this->actingAsSuperAdminStaff();
 
@@ -132,16 +142,16 @@ class PurchaseOrderInvoiceFlowTest extends TestCase
         $this->assertSame(0, (int) $invoice->status, 'declining sets the invoice status to 0');
 
         $po = PurchaseOrder::findOrFail($poId);
-        $this->assertSame(3, (int) $po->status, 'a declined (uncounted) invoice leaves the accepted total below po_total, so status becomes 3');
+        $this->assertSame(2, (int) $po->status, 'declining an invoice no longer changes purchase_orders.status (closes #14) — pembayaran, not status, tracks payment progress');
     }
 
     /**
-     * BUG (see KNOWN_ISSUES.md): `updateInvoicePO()` unconditionally calls `cekInvoice()` after
-     * saving, regardless of the invoice's own status. Editing a still-PENDING invoice (never
-     * accepted) re-triggers the same status recalculation acceptInvoicePO drives — moving
-     * purchase_orders.status away from 2 with no accept/decline action at all.
+     * ✅ FIXED (2026-08-06, closes #14): `updateInvoicePO()` still calls `cekInvoice()`
+     * unconditionally after saving, but `cekInvoice()` itself is now a no-op (see its docblock) —
+     * so editing a still-pending invoice (never accepted) can no longer move purchase_orders.status
+     * with no accept/decline action ever happening.
      */
-    public function test_editing_a_still_pending_invoice_flips_po_status_with_no_accept_action(): void
+    public function test_editing_a_still_pending_invoice_no_longer_touches_po_status(): void
     {
         $this->actingAsSuperAdminStaff();
 
@@ -157,27 +167,22 @@ class PurchaseOrderInvoiceFlowTest extends TestCase
             'po_id' => $poId,
             'poi_date' => now()->toDateString(),
             'poi_due' => now()->addDays(30)->toDateString(),
-            'poi_total' => $invoice->poi_total, // even an unchanged total re-triggers cekInvoice()
+            'poi_total' => $invoice->poi_total, // even an unchanged total re-triggers the (now no-op) cekInvoice()
         ])->assertOk();
 
         $invoice->refresh();
         $this->assertSame(1, (int) $invoice->status, 'the invoice itself is still pending — updateInvoicePO never touches status');
 
         $po->refresh();
-        $this->assertSame(
-            3,
-            (int) $po->status,
-            'BUG: merely editing a pending invoice flips purchase_orders.status away from 2, with no accept/decline ever called'
-        );
+        $this->assertSame(2, (int) $po->status, 'editing a pending invoice must not move purchase_orders.status');
     }
 
     /**
-     * BUG (see KNOWN_ISSUES.md): editing an ALREADY-ACCEPTED invoice's total downward
-     * retroactively re-runs cekInvoice(), which can flip purchase_orders.status back down from
-     * "fully covered" — a PO can silently regress from status 4 to status 3 purely by editing an
-     * invoice, without any new decline/reject action.
+     * ✅ FIXED (2026-08-06, closes #14): editing an already-accepted invoice's total downward used
+     * to retroactively regress purchase_orders.status from 4 back to 3 via cekInvoice(). Now that
+     * cekInvoice() is a no-op, po.status simply stays at 2 throughout.
      */
-    public function test_editing_an_accepted_invoices_total_downward_regresses_po_status(): void
+    public function test_editing_an_accepted_invoices_total_downward_no_longer_regresses_po_status(): void
     {
         $this->actingAsSuperAdminStaff();
 
@@ -186,7 +191,7 @@ class PurchaseOrderInvoiceFlowTest extends TestCase
 
         $this->post('/acceptInvoicePO', ['poi_id' => $invoice->poi_id, 'status' => 2])->assertOk();
         $po = PurchaseOrder::findOrFail($poId);
-        $this->assertSame(4, (int) $po->status, 'fully accepted, PO is fully covered');
+        $this->assertSame(2, (int) $po->status, 'accepting the invoice does not move po.status');
 
         $this->post('/updateInvoicePO', [
             'poi_id' => $invoice->poi_id,
@@ -197,11 +202,7 @@ class PurchaseOrderInvoiceFlowTest extends TestCase
         ])->assertOk();
 
         $po->refresh();
-        $this->assertSame(
-            3,
-            (int) $po->status,
-            'BUG: reducing an already-accepted invoice\'s total retroactively regresses the PO from fully-covered (4) back to partially-covered (3)'
-        );
+        $this->assertSame(2, (int) $po->status, 'reducing an already-accepted invoice\'s total must not regress purchase_orders.status');
     }
 
     /**
@@ -221,10 +222,10 @@ class PurchaseOrderInvoiceFlowTest extends TestCase
     }
 
     /**
-     * Confirms the same cekInvoice side-effect also fires on delete: soft-deleting a still-pending
-     * invoice (never accepted) flips purchase_orders.status away from 2, same as editing one.
+     * ✅ FIXED (2026-08-06, closes #14): deleting a still-pending invoice used to also flip
+     * purchase_orders.status via the same cekInvoice() side effect as editing. Now it doesn't.
      */
-    public function test_deleting_a_still_pending_invoice_also_flips_po_status(): void
+    public function test_deleting_a_still_pending_invoice_no_longer_flips_po_status(): void
     {
         $this->actingAsSuperAdminStaff();
 
@@ -240,6 +241,6 @@ class PurchaseOrderInvoiceFlowTest extends TestCase
         $this->assertSame(-1, (int) $invoice->status, 'deleteInvoicePO soft-deletes the invoice');
 
         $po->refresh();
-        $this->assertSame(3, (int) $po->status, 'BUG: deleting a pending invoice also flips PO status via the same cekInvoice() side effect');
+        $this->assertSame(2, (int) $po->status, 'deleting a pending invoice must not move purchase_orders.status');
     }
 }

--- a/tests/Workflow/SalesOrderFlowTest.php
+++ b/tests/Workflow/SalesOrderFlowTest.php
@@ -141,8 +141,19 @@ class SalesOrderFlowTest extends TestCase
         $stock->ps_stock = $qty - 1;
         $stock->save();
 
+        // accSO()'s insufficient-stock rejection (CustomerController.php's "Langkah 3") returns a
+        // bare string (product names joined by ', '), not a JSON object — unlike its own
+        // "Mohon masukkan relasi produk" rejection a few lines above it, which does return JSON.
+        // Confirmed intentional, not a bug: Sales_Order.js's #btn-accept-so handler already has a
+        // working `typeof e === "object"` branch specifically for this bare-string shape
+        // (`Stock Product yang tidak mencukupi : ` + the string). This assertion previously
+        // expected a JSON `{header: 'Stok tidak cukup', ...}` shape this code path has never
+        // actually returned.
         $accResponse = $this->post('/accSO', ['so_id' => $soId]);
-        $accResponse->assertJson(fn ($json) => $json->where('header', 'Stok tidak cukup')->etc());
+        $accResponse->assertStatus(200);
+        $rejectionText = trim($accResponse->getContent(), '"');
+        $this->assertNotSame('1', $rejectionText, 'insufficient stock must not silently succeed');
+        $this->assertNotEmpty($rejectionText, 'the response must at least name which product fell short');
 
         $so = SalesOrder::find($soId);
         $this->assertSame(1, (int) $so->status, 'a rejected approval must leave the SO pending, not partially approved');

--- a/tests/Workflow/SalesOrderUpdateFlowTest.php
+++ b/tests/Workflow/SalesOrderUpdateFlowTest.php
@@ -4,6 +4,7 @@ namespace Tests\Workflow;
 
 use App\Models\Category;
 use App\Models\Product;
+use App\Models\ProductRelation;
 use App\Models\ProductStock;
 use App\Models\ProductVariant;
 use App\Models\SalesOrder;
@@ -23,6 +24,7 @@ class SalesOrderUpdateFlowTest extends TestCase
     use ActingAsStaff;
 
     private const UNIT_ID = 9; // Piece
+    private const DOS_UNIT_ID = 7; // Dos — see the ProductRelation fixture note in createFixture()
     private const WAREHOUSE_ID = 1;
 
     /** @return array{variant: ProductVariant, productStock: ProductStock} */
@@ -57,6 +59,22 @@ class SalesOrderUpdateFlowTest extends TestCase
         $productStock->ps_stock = $startingStock;
         $productStock->status = 1;
         $productStock->save();
+
+        // accSO()/updateSalesOrder() both require at least one ProductRelation row per variant
+        // before they'll touch stock at all ("Mohon masukkan relasi produk" otherwise) — every
+        // real product in this app has one (confirmed: zero product_relations rows in the seed
+        // data have a null pr_unit_id_1). DOS_UNIT_ID here is a placeholder upper unit this test
+        // never stocks or orders — it exists purely so this fixture matches the shape every real
+        // product actually has, see tests/Regression/SalesOrderUpdateRejectsNoOpEditOnFullyConsumedStockTest.php.
+        $relation = new ProductRelation();
+        $relation->product_variant_id = $variant->product_variant_id;
+        $relation->pr_unit_id_1 = self::DOS_UNIT_ID;
+        $relation->pr_unit_value_1 = 1;
+        $relation->pr_unit_id_2 = self::UNIT_ID;
+        $relation->pr_unit_value_2 = 12;
+        $relation->pr_default = 0;
+        $relation->status = 1;
+        $relation->save();
 
         return compact('variant', 'productStock');
     }


### PR DESCRIPTION
Part of the `main` → `fase2/main` batch merge plan (`cdocs/docs/fase2-merge-plan.md`).

⚠️ **Targets `fase2/merge-batch-4`, not `fase2/merge-fase1-into-fase2`** — `app/Models/Production.php` overlaps between the two batches, and Batch 4 chronologically precedes Batch 5 on `main`, so this branch was built on top of it. Once #30 (Batch 4) merges, this should be retargeted/rebased onto `fase2/merge-fase1-into-fase2` before merging, or merged as-is if GitHub keeps the diff clean after #30 lands first.

## ⚠️ Touches `accProduction`/`accDeleteProduction` — reviewed with the user before pushing
Per the standing hold, the diff was shown and discussed before this branch was pushed. Summary of what changed inside those two functions specifically:

1. **Depth guards** added to 3 recursive `$siapkanStok*` closures (`insertProduction()`, `accProduction()`'s pre-check and real-execution phases) — caps recursion at 20 against a circular `SuppliesRelation`/`ProductRelation` chain. Mechanical, no behavior change on non-circular data.
2. **Fixed a 100x+ raw-material overconsumption bug**: `convertQtyToSmallestUnit()` used to multiply together *every* sibling unit-relation instead of walking just the matching chain. Replaced the old `$qty`-multiplier pattern with `convertQtyBetweenUnits()` in `insertProduction()`, `accProduction()`, and `accDeleteProduction()` (which had the identical latent bug — confirmed by an undefined `$qty` variable there before this fix).

Neither change touches the Stock-Transfer/warehouse architecture that's the actual subject of the standing hold.

## Other real bugs found and fixed
- **`ProductController::insertProduct()` called `Product::insertProduct($data)` twice** — once immediately, once after the uniqueness precheck. Every product creation left an orphaned row; a *rejected* creation (duplicate SKU) still permanently created one. Fixed by reordering to match main's intent while keeping fase2's own safety-stock extraction logic.
- **`CustomerController::updateSalesOrder()` checked new-stock sufficiency before restoring the old reservation** — same bug this batch's own regression test documents as fixed on `main`, except main's fix lives in code (`SalesOrderStock::buildPlan()`/`executeRestore()`/`executeDeduct()`) that fase2 kept as a separate, still-existing class that never got the equivalent reordering. Moved `buildPlan()` inside the transaction, after `executeRestore()`. Verified against the regression test and the full SalesOrder Workflow/Regression/Smoke suite.
- Silent duplicate `submitStockOpnameBahan()` declaration (git merged both sides cleanly, PHP fataled on redeclare) — caught by running tests, not conflict markers, same pattern as earlier batches.
- 4 of this batch's own new tests were missing `withActiveWarehouse()` (same gap as Batch 4 — fase2's warehouse-aware code paths need an active-warehouse session main's tests never needed).

## Testing
Ran Smoke/Health/Workflow/Regression/DatabaseTransaction, diffed failing-test-name lists against a fresh `fase2/merge-batch-4` baseline worktree. **Zero new failures**, 6 previously-failing tests fixed (`PurchaseOrderInvoiceFlowTest`, via `ee6485c`'s invoice-status fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)