### PR TITLE
feat: halaman publik Dokumentasi API Eksternal (/api-docs)

### DIFF
--- a/app/Http/Controllers/ExternalApiController.php
+++ b/app/Http/Controllers/ExternalApiController.php
@@ -147,6 +147,28 @@ class ExternalApiController extends Controller
      */
     public function externalApiDocumentation(Request $req, ?string $group = null)
     {
+        return $this->renderApiDocumentation($req, $group, 'Backoffice.ExternalApi.Documentation', [
+            'index' => 'externalApiDocumentation',
+            'group' => 'externalApiDocumentationGroup',
+        ]);
+    }
+
+    /**
+     * Sama seperti externalApiDocumentation(), tapi diakses tanpa login —
+     * untuk pengembang pihak ketiga yang belum/tidak punya akun Pegasus.
+     * View-nya sendiri (Public.ApiDocumentation) yang tidak memuat sidebar
+     * admin; isi (partials doc-nav/doc-general/doc-group) sama persis.
+     */
+    public function publicApiDocumentation(Request $req, ?string $group = null)
+    {
+        return $this->renderApiDocumentation($req, $group, 'Public.ApiDocumentation', [
+            'index' => 'apiDocsPublic',
+            'group' => 'apiDocsPublicGroup',
+        ]);
+    }
+
+    private function renderApiDocumentation(Request $req, ?string $group, string $view, array $docRoute)
+    {
         $versions = $this->docs->versions();
         $version = $req->get('version');
 
@@ -165,7 +187,7 @@ class ExternalApiController extends Controller
             }
         }
 
-        return view('Backoffice.ExternalApi.Documentation', [
+        return view($view, [
             'groups' => $groups,
             'current' => $current,
             'versions' => $versions,
@@ -174,6 +196,7 @@ class ExternalApiController extends Controller
             'baseUrl' => ExternalApiPath::baseUrl($version),
             'keyHeader' => $this->keys->header(),
             'platformErrors' => PlatformErrors::all(),
+            'docRoute' => $docRoute,
         ]);
     }
 

--- a/public/Custom_js/Backoffice/ExternalApi/Documentation.js
+++ b/public/Custom_js/Backoffice/ExternalApi/Documentation.js
@@ -7,8 +7,8 @@ $(document).ready(function () {
 $(document).on('change', '#docVersion', function () {
     var version = encodeURIComponent($(this).val());
     var path = docGroupKey
-        ? '/externalApiDocumentation/' + encodeURIComponent(docGroupKey)
-        : '/externalApiDocumentation';
+        ? docBasePath + '/' + encodeURIComponent(docGroupKey)
+        : docBasePath;
 
     window.location.href = path + '?version=' + version;
 });

--- a/resources/views/Backoffice/ExternalApi/Documentation.blade.php
+++ b/resources/views/Backoffice/ExternalApi/Documentation.blade.php
@@ -58,6 +58,8 @@
     <script>
         // Dipakai pemilih versi untuk tetap berada di modul yang sedang dibuka.
         var docGroupKey = @json($current['key'] ?? null);
+        // Base path rute halaman Umum — beda antara versi admin dan publik.
+        var docBasePath = @json(route('externalApiDocumentation'));
     </script>
     <script src="{{ asset('Custom_js/Backoffice/ExternalApi/Documentation.js') }}"></script>
 @endsection

--- a/resources/views/Backoffice/ExternalApi/partials/doc-general.blade.php
+++ b/resources/views/Backoffice/ExternalApi/partials/doc-general.blade.php
@@ -21,7 +21,7 @@
                 @foreach ($groups as $group)
                     <div class="col-md-6">
                         <a class="extapi-module-card"
-                            href="{{ url('externalApiDocumentation/' . $group['key']) . (count($versions) > 1 ? '?version=' . urlencode($version) : '') }}">
+                            href="{{ route($docRoute['group'], $group['key']) . (count($versions) > 1 ? '?version=' . urlencode($version) : '') }}">
                             <div class="d-flex align-items-center justify-content-between">
                                 <div>
                                     <h6 class="mb-1">{{ $group['title'] }}</h6>

--- a/resources/views/Backoffice/ExternalApi/partials/doc-group.blade.php
+++ b/resources/views/Backoffice/ExternalApi/partials/doc-group.blade.php
@@ -14,7 +14,7 @@
                 <p class="text-muted mb-0">
                     {{ count($current['endpoints']) }} endpoint pada versi {{ $version }}.
                     Seluruhnya memerlukan API Key — lihat
-                    <a href="{{ url('externalApiDocumentation') }}#authentication">Umum → Autentikasi</a>.
+                    <a href="{{ route($docRoute['index']) }}#authentication">Umum → Autentikasi</a>.
                 </p>
             </div>
             <pre class="extapi-code mb-0 mt-2">{{ $baseUrl }}</pre>

--- a/resources/views/Backoffice/ExternalApi/partials/doc-nav.blade.php
+++ b/resources/views/Backoffice/ExternalApi/partials/doc-nav.blade.php
@@ -30,7 +30,7 @@
         <ul class="extapi-toc-list">
             <li>
                 <a class="{{ $isUmum ? 'active' : '' }}"
-                    href="{{ url('externalApiDocumentation') . $versionQuery }}">
+                    href="{{ route($docRoute['index']) . $versionQuery }}">
                     <i class="fe fe-book-open me-1"></i> Umum
                 </a>
             </li>
@@ -38,7 +38,7 @@
                 @php $isActive = $current !== null && $current['key'] === $group['key']; @endphp
                 <li>
                     <a class="{{ $isActive ? 'active' : '' }}"
-                        href="{{ url('externalApiDocumentation/' . $group['key']) . $versionQuery }}">
+                        href="{{ route($docRoute['group'], $group['key']) . $versionQuery }}">
                         <i class="fe fe-layers me-1"></i> {{ $group['title'] }}
                         <span class="badge badge-soft-secondary ms-1">{{ count($group['endpoints']) }}</span>
                     </a>

--- a/resources/views/Public/ApiDocumentation.blade.php
+++ b/resources/views/Public/ApiDocumentation.blade.php
@@ -1,0 +1,89 @@
+<?php $page = 'apiDocsPublic'; ?>
+@extends('layout.mainlayout')
+
+{{--
+    Versi publik dari Backoffice.ExternalApi.Documentation — dipakai pengembang
+    pihak ketiga yang belum/tidak punya akun Pegasus, jadi tanpa login dan tanpa
+    chrome admin (sidebar + topbar). Isinya sama persis (partials doc-nav /
+    doc-general / doc-group), hanya headernya beda: bar minimal berlogo, bukan
+    topbar admin. mainlayout.blade.php sudah diberi tahu untuk menyembunyikan
+    header & sidebar untuk rute 'apiDocsPublic' / 'apiDocsPublicGroup'.
+--}}
+
+@section('custom_css')
+    <link rel="stylesheet" href="{{ asset('Custom_css/external-api.css') }}">
+    <style>
+        /* Tanpa sidebar/topbar admin, .page-wrapper tidak perlu menyisakan
+           ruang untuk keduanya. */
+        .public-docs-wrapper .page-wrapper {
+            margin-left: 0;
+            padding-top: 0;
+        }
+
+        .public-docs-header {
+            display: flex;
+            align-items: center;
+            padding: 16px 24px;
+            border-bottom: 1px solid #e5e9f2;
+            background: #fff;
+        }
+
+        .public-docs-header img {
+            height: 32px;
+        }
+
+        .public-docs-header span {
+            margin-left: 12px;
+            font-weight: 600;
+            font-size: 16px;
+            color: #202c4b;
+        }
+    </style>
+@endsection
+
+@section('content')
+    <div class="public-docs-wrapper">
+        <div class="public-docs-header">
+            <img src="{{ asset('assets/pegasus_banner_small.png') }}" alt="Pegasus">
+            <span>Dokumentasi API Eksternal</span>
+        </div>
+
+        <div class="page-wrapper">
+            <div class="content container-fluid">
+
+                @component('components.page-header')
+                    @slot('title')
+                        Dokumentasi API Eksternal{{ $current ? ' — ' . $current['title'] : '' }}
+                    @endslot
+                @endcomponent
+
+                <div class="row">
+                    {{-- Navigasi antar halaman dokumentasi --}}
+                    <div class="col-xl-3 col-lg-4">
+                        @include('Backoffice.ExternalApi.partials.doc-nav')
+                    </div>
+
+                    {{-- Isi halaman: Umum, atau satu modul --}}
+                    <div class="col-xl-9 col-lg-8">
+                        @if ($current)
+                            @include('Backoffice.ExternalApi.partials.doc-group')
+                        @else
+                            @include('Backoffice.ExternalApi.partials.doc-general')
+                        @endif
+                    </div>
+                </div>
+
+            </div>
+        </div>
+    </div>
+@endsection
+
+@section('custom_js')
+    <script>
+        // Dipakai pemilih versi untuk tetap berada di modul yang sedang dibuka.
+        var docGroupKey = @json($current['key'] ?? null);
+        // Base path rute halaman Umum — beda antara versi admin dan publik.
+        var docBasePath = @json(route('apiDocsPublic'));
+    </script>
+    <script src="{{ asset('Custom_js/Backoffice/ExternalApi/Documentation.js') }}"></script>
+@endsection

--- a/resources/views/layout/mainlayout.blade.php
+++ b/resources/views/layout/mainlayout.blade.php
@@ -112,6 +112,8 @@
         'cashreceipt-2',
         'cashreceipt-3',
         'cashreceipt-4',
+        'apiDocsPublic',
+        'apiDocsPublicGroup',
     ]))
   @include('layout.partials.header')
 @endif
@@ -137,6 +139,8 @@
         'cashreceipt-2',
         'cashreceipt-3',
         'cashreceipt-4',
+        'apiDocsPublic',
+        'apiDocsPublicGroup',
     ]))
   @include('layout.partials.sidebar')
 @endif

--- a/routes/web.php
+++ b/routes/web.php
@@ -21,6 +21,16 @@ use Illuminate\Support\Facades\Route;
 
 Route::get('/login', [GeneralController::class, 'login'])->name('login');
 Route::post('/loginUser', [UserController::class, 'loginUser'])->name('loginUser');
+
+// Dokumentasi API Eksternal — versi publik, tanpa login. Sama persis dengan
+// /externalApiDocumentation (lihat check.access:Dokumentasi API Eksternal|view
+// di bawah), hanya view & chrome-nya beda (tanpa sidebar/topbar admin). Isinya
+// bukan rahasia: hanya struktur endpoint & contoh, bukan API Key sungguhan.
+Route::middleware('throttle:60,1')->group(function () {
+    Route::get('/api-docs', [ExternalApiController::class, 'publicApiDocumentation'])->name('apiDocsPublic');
+    Route::get('/api-docs/{group}', [ExternalApiController::class, 'publicApiDocumentation'])->name('apiDocsPublicGroup');
+});
+
 Route::middleware(checkLogin::class)->group(function () {
     Route::get('/', function () {
         return view('Backoffice.Dashboard.Dashboard-Admin');


### PR DESCRIPTION
## Ringkasan

Menambahkan rute publik `/api-docs` untuk halaman **Dokumentasi API Eksternal**, agar bisa diakses pengembang pihak ketiga yang belum/tidak punya akun Pegasus — tanpa login dan tanpa tampilan sidebar/topbar admin.

Konten halaman **sama persis** dengan versi admin (`/externalApiDocumentation`): keduanya memakai partial Blade yang sama (`doc-nav`, `doc-general`, `doc-group`) dan sumber data yang sama (`ApiDocRegistry`). Jadi begitu ada endpoint baru terdaftar atau deskripsi diubah, otomatis muncul di kedua halaman — tidak ada dua salinan konten yang bisa berbeda.

## Yang beda antara admin vs publik
| | Admin (`/externalApiDocumentation`) | Publik (`/api-docs`) |
|---|---|---|
| Akses | Login + `check.access:Dokumentasi API Eksternal\|view` | Publik, tanpa login (di-`throttle:60,1`) |
| Chrome halaman | Sidebar + topbar admin | Header minimal (logo + judul), tanpa sidebar/topbar |
| Banner "hanya untuk internal" | Tampil | Tidak tampil (dihapus khusus versi publik) |
| Konten dokumentasi | Sama | Sama |

## Perubahan implementasi
- **`ExternalApiController`**: logika pengambilan data dokumentasi diekstrak ke `renderApiDocumentation()` privat, dipakai bersama oleh `externalApiDocumentation()` (admin, tidak berubah perilakunya) dan `publicApiDocumentation()` (baru).
- **View baru** `resources/views/Public/ApiDocumentation.blade.php` — include partial yang sama dengan versi admin, header sendiri (logo + judul).
- **`layout/mainlayout.blade.php`**: rute `apiDocsPublic`/`apiDocsPublicGroup` ditambahkan ke daftar `Route::is([...])` yang sudah ada untuk menyembunyikan header & sidebar (pola yang sama dipakai untuk halaman `login`/`register`).
- **Partials `doc-nav`/`doc-general`/`doc-group`**: tautan antar halaman diubah dari hardcode `url('externalApiDocumentation...')` menjadi `route($docRoute[...])`, supaya partial yang sama tetap menghasilkan tautan yang benar baik di halaman admin maupun publik.
- **`Documentation.js`**: bug kecil ikut diperbaiki — pemilih versi API sebelumnya hardcode redirect ke `/externalApiDocumentation`, yang akan salah (melempar pengunjung publik ke URL admin yang butuh login) kalau dipakai dari halaman publik. Sekarang pakai variabel `docBasePath` yang di-set sesuai halaman yang sedang dibuka.
- **`routes/web.php`**: `/api-docs` dan `/api-docs/{group}` didaftarkan di luar middleware `auth`/`check.access`, dibungkus `throttle:60,1` karena sekarang endpoint ini terbuka ke publik tanpa autentikasi.

## Keamanan
Konten yang ditampilkan bukan data rahasia — hanya struktur endpoint, contoh request/response, dan daftar kode error. Contoh API Key di halaman hanya placeholder (`ext_live_xxxxxxxxxxxxxxxx`), tidak ada API Key sungguhan yang pernah ditampilkan di halaman ini (baik versi admin maupun publik).

## Pengujian
Diverifikasi lewat HTTP kernel penuh (bukan cuma render langsung):
- `GET /api-docs` → 200, tidak ada markup sidebar/topbar admin, header publik tampil.
- `GET /api-docs/master` (grup endpoint valid) → 200, tautan navigasi mengarah ke `/api-docs/...`, tidak ada tautan yang bocor ke `/externalApiDocumentation`.
- `GET /externalApiDocumentation` (admin) → tetap menampilkan banner "hanya untuk internal", tidak ada regresi.
- `php -l` bersih di kedua file controller & routes; keempat nama rute (`externalApiDocumentation(Group)`, `apiDocsPublic(Group)`) resolve dengan benar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)