### PR TITLE
feat: create/update/delete/connect untuk gudang, sales, dan satuan (External API v1)

### DIFF
--- a/app/ExternalApi/Docs/Endpoints/V1/MasterSalesCreateDoc.php
+++ b/app/ExternalApi/Docs/Endpoints/V1/MasterSalesCreateDoc.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace App\ExternalApi\Docs\Endpoints\V1;
+
+use App\ExternalApi\Docs\ApiEndpointDoc;
+
+/**
+ * Dokumentasi POST /api/external/v1/master/sales (API-002 lanjutan).
+ */
+class MasterSalesCreateDoc extends ApiEndpointDoc
+{
+    public function key(): string
+    {
+        return 'master-sales-create';
+    }
+
+    public function title(): string
+    {
+        return 'Buat Sales';
+    }
+
+    public function method(): string
+    {
+        return 'POST';
+    }
+
+    public function path(): string
+    {
+        return '/master/sales';
+    }
+
+    public function group(): string
+    {
+        return 'master';
+    }
+
+    public function description(): string
+    {
+        return 'Membuat sales baru, atau memperbarui sales yang sudah ada kalau staff_id yang dikirim sudah dipakai (upsert). Sales yang baru dibuat otomatis berperan Sales, tanpa akun login (staff_username/staff_password tetap kosong).';
+    }
+
+    public function bodyParameters(): array
+    {
+        return [
+            ['name' => 'staff_id', 'type' => 'integer', 'required' => true, 'description' => 'id staf. Kalau sudah ada dan berperan Sales aktif, sales itu diperbarui (bukan dibuat baru). Kalau belum ada, dibuatkan staf baru dengan id ini juga (bukan id yang di-generate sistem).'],
+            ['name' => 'nama_depan', 'type' => 'string', 'required' => true, 'description' => 'Nama depan.'],
+            ['name' => 'nama_belakang', 'type' => 'string', 'required' => false, 'description' => 'Nama belakang. Boleh dikosongkan.'],
+            ['name' => 'email', 'type' => 'string', 'required' => true, 'description' => 'Alamat email.'],
+            ['name' => 'alamat', 'type' => 'string', 'required' => false, 'description' => 'Alamat. Boleh dikosongkan.'],
+        ];
+    }
+
+    public function requestExample(): ?array
+    {
+        return [
+            'staff_id' => 2,
+            'nama_depan' => 'Willian',
+            'nama_belakang' => 'Hartanto',
+            'email' => 'wilha.h@gmail.com',
+            'alamat' => 'Jl. Sudirman Block A No. 12',
+        ];
+    }
+
+    public function responseExample(): array
+    {
+        return [
+            'success' => true,
+            'data' => [
+                'staff_id' => 2,
+                'nama_depan' => 'Willian',
+                'nama_belakang' => 'Hartanto',
+                'email' => 'wilha.h@gmail.com',
+                'alamat' => 'Jl. Sudirman Block A No. 12',
+            ],
+        ];
+    }
+
+    public function errors(): array
+    {
+        return [
+            ['code' => 'validation_failed', 'http_status' => 422, 'message' => 'staff_id, nama_depan, atau email kosong/tidak valid.'],
+            ['code' => 'not_found', 'http_status' => 404, 'message' => 'staff_id sudah dipakai staf lain yang bukan sales aktif (mis. staf berperan Admin, atau sales yang sudah dihapus lewat DELETE sales) — permintaan ditolak, bukan menimpa staf itu.'],
+        ];
+    }
+
+    public function notes(): array
+    {
+        return [
+            'staff_id, nama_depan, dan email wajib diisi; nama_belakang dan alamat boleh dikosongkan.',
+            'Body selalu dianggap representasi penuh sales ini: nama_belakang/alamat yang tidak dikirim disimpan sebagai kosong, bukan mempertahankan nilai lama — sama seperti endpoint gudang.',
+            'Endpoint ini HANYA boleh menyentuh staf yang berperan Sales (dan aktif). staff_id yang menunjuk staf lain, atau sales yang sudah dihapus lewat DELETE sales, dijawab not_found — bukan diizinkan mengubah/menghidupkan kembali staf itu.',
+            'staff_id sekaligus dipakai sebagai path parameter pada endpoint ubah (PUT) dan hapus (DELETE) sales.',
+            'kode (staff_code), telepon (staff_phone), dan role tidak dikelola lewat endpoint ini — lihat GET /master/sales untuk field itu.',
+        ];
+    }
+}

--- a/app/ExternalApi/Docs/Endpoints/V1/MasterSalesCreateDoc.php
+++ b/app/ExternalApi/Docs/Endpoints/V1/MasterSalesCreateDoc.php
@@ -36,13 +36,13 @@ class MasterSalesCreateDoc extends ApiEndpointDoc
 
     public function description(): string
     {
-        return 'Membuat sales baru, atau memperbarui sales yang sudah ada kalau staff_id yang dikirim sudah dipakai (upsert). Sales yang baru dibuat otomatis berperan Sales, tanpa akun login (staff_username/staff_password tetap kosong).';
+        return 'Membuat sales baru di Pegasus, dihubungkan dengan id milik sistem pemanggil sendiri (staff_id pada body). Sales yang baru dibuat otomatis berperan Sales, tanpa akun login (staff_username/staff_password tetap kosong). Selalu membuat baris baru — bukan upsert; staff_id yang sudah dipakai sales lain ditolak.';
     }
 
     public function bodyParameters(): array
     {
         return [
-            ['name' => 'staff_id', 'type' => 'integer', 'required' => true, 'description' => 'id staf. Kalau sudah ada dan berperan Sales aktif, sales itu diperbarui (bukan dibuat baru). Kalau belum ada, dibuatkan staf baru dengan id ini juga (bukan id yang di-generate sistem).'],
+            ['name' => 'staff_id', 'type' => 'string|integer', 'required' => true, 'description' => 'id milik sistem pemanggil sendiri untuk sales ini (BUKAN id Pegasus). Wajib belum pernah dipakai sales lain di Pegasus.'],
             ['name' => 'nama_depan', 'type' => 'string', 'required' => true, 'description' => 'Nama depan.'],
             ['name' => 'nama_belakang', 'type' => 'string', 'required' => false, 'description' => 'Nama belakang. Boleh dikosongkan.'],
             ['name' => 'email', 'type' => 'string', 'required' => true, 'description' => 'Alamat email.'],
@@ -66,7 +66,8 @@ class MasterSalesCreateDoc extends ApiEndpointDoc
         return [
             'success' => true,
             'data' => [
-                'staff_id' => 2,
+                'id' => 105,
+                'staff_id' => '2',
                 'nama_depan' => 'Willian',
                 'nama_belakang' => 'Hartanto',
                 'email' => 'wilha.h@gmail.com',
@@ -79,7 +80,7 @@ class MasterSalesCreateDoc extends ApiEndpointDoc
     {
         return [
             ['code' => 'validation_failed', 'http_status' => 422, 'message' => 'staff_id, nama_depan, atau email kosong/tidak valid.'],
-            ['code' => 'not_found', 'http_status' => 404, 'message' => 'staff_id sudah dipakai staf lain yang bukan sales aktif (mis. staf berperan Admin, atau sales yang sudah dihapus lewat DELETE sales) — permintaan ditolak, bukan menimpa staf itu.'],
+            ['code' => 'duplicate_ref_id', 'http_status' => 422, 'message' => 'staff_id sudah dipakai sales lain (baik yang masih aktif maupun yang sudah dihapus lewat DELETE sales) — pakai PUT untuk memperbarui sales yang sudah ada.'],
         ];
     }
 
@@ -87,9 +88,10 @@ class MasterSalesCreateDoc extends ApiEndpointDoc
     {
         return [
             'staff_id, nama_depan, dan email wajib diisi; nama_belakang dan alamat boleh dikosongkan.',
-            'Body selalu dianggap representasi penuh sales ini: nama_belakang/alamat yang tidak dikirim disimpan sebagai kosong, bukan mempertahankan nilai lama — sama seperti endpoint gudang.',
-            'Endpoint ini HANYA boleh menyentuh staf yang berperan Sales (dan aktif). staff_id yang menunjuk staf lain, atau sales yang sudah dihapus lewat DELETE sales, dijawab not_found — bukan diizinkan mengubah/menghidupkan kembali staf itu.',
-            'staff_id sekaligus dipakai sebagai path parameter pada endpoint ubah (PUT) dan hapus (DELETE) sales.',
+            'id pada respons adalah id staf yang dibuat Pegasus sendiri (auto-increment) — SIMPAN nilai ini kalau nanti perlu memanggil PATCH /master/sales/{staff_id} (yang path parameternya memakai id Pegasus, bukan staff_id/rujukan Anda).',
+            'staff_id pada body dan respons adalah id milik sistem Anda sendiri, disimpan di kolom terpisah (external_ref_id) — TIDAK menjadi id staf Pegasus. Endpoint ini tidak pernah membiarkan Anda menentukan id Pegasus.',
+            'Bukan upsert: mengirim staff_id yang sudah dipakai (aktif maupun yang sales-nya sudah dihapus) selalu ditolak dengan duplicate_ref_id, tidak pernah menimpa data yang sudah ada. Pakai PUT /master/sales/{staff_id} untuk memperbarui sales yang rujukannya sudah ada.',
+            'Untuk menghubungkan rujukan ke staf Pegasus yang SUDAH ADA (dibuat lewat halaman admin, misalnya), pakai PATCH /master/sales/{id} — bukan POST ini, yang selalu membuat staf baru.',
             'kode (staff_code), telepon (staff_phone), dan role tidak dikelola lewat endpoint ini — lihat GET /master/sales untuk field itu.',
         ];
     }

--- a/app/ExternalApi/Docs/Endpoints/V1/MasterSalesDeleteDoc.php
+++ b/app/ExternalApi/Docs/Endpoints/V1/MasterSalesDeleteDoc.php
@@ -36,13 +36,13 @@ class MasterSalesDeleteDoc extends ApiEndpointDoc
 
     public function description(): string
     {
-        return 'Menghapus sales (soft delete).';
+        return 'Menghapus sales (soft delete), dicari lewat staff_id (rujukan milik sistem Anda sendiri, bukan id Pegasus).';
     }
 
     public function pathParameters(): array
     {
         return [
-            ['name' => 'staff_id', 'type' => 'integer', 'required' => true, 'description' => 'id sales yang akan dihapus, lihat GET /master/sales.'],
+            ['name' => 'staff_id', 'type' => 'string', 'required' => true, 'description' => 'id milik sistem Anda sendiri untuk sales yang akan dihapus (BUKAN id Pegasus).'],
         ];
     }
 
@@ -51,7 +51,7 @@ class MasterSalesDeleteDoc extends ApiEndpointDoc
         return [
             'success' => true,
             'data' => [
-                'staff_id' => 2,
+                'staff_id' => '2',
             ],
         ];
     }
@@ -59,15 +59,16 @@ class MasterSalesDeleteDoc extends ApiEndpointDoc
     public function errors(): array
     {
         return [
-            ['code' => 'not_found', 'http_status' => 404, 'message' => 'staff_id tidak ditemukan, atau ditemukan tapi bukan sales aktif (staf berperan lain, atau sudah dihapus sebelumnya).'],
+            ['code' => 'not_found', 'http_status' => 404, 'message' => 'staff_id (rujukan Anda) tidak ditemukan, atau ditemukan tapi bukan sales aktif (staf berperan lain, atau sudah dihapus sebelumnya).'],
         ];
     }
 
     public function notes(): array
     {
         return [
+            'staff_id pada path adalah rujukan milik sistem Anda sendiri (external_ref_id), BUKAN id Pegasus.',
             'Ini soft delete: status staf diubah menjadi 0, bukan baris yang dihapus dari basis data — sama seperti penghapusan lewat halaman admin (Pengguna).',
-            'staff_id yang sudah dihapus lewat endpoint ini tidak bisa dibuat ulang lewat POST /master/sales dengan id yang sama — baris dengan id itu tetap ada (soft deleted) dan endpoint ini hanya mengelola staf yang statusnya aktif.',
+            'Rujukan (staff_id) TIDAK dilepas oleh operasi ini — baris staf lama masih memegangnya, hanya berstatus nonaktif. Karena itu staff_id yang sudah dihapus lewat endpoint ini tidak bisa dipakai lagi lewat POST /master/sales (ditolak duplicate_ref_id), dan tidak muncul lagi lewat GET /master/sales.',
             'Endpoint ini HANYA boleh menghapus staf yang berperan Sales (dan masih aktif) — staff_id yang menunjuk staf lain dijawab not_found, bukan diizinkan menghapus staf itu.',
             'Akun login (staff_username/staff_password), riwayat transaksi, dan saldo staf tidak ikut dihapus atau diubah.',
         ];

--- a/app/ExternalApi/Docs/Endpoints/V1/MasterSalesDeleteDoc.php
+++ b/app/ExternalApi/Docs/Endpoints/V1/MasterSalesDeleteDoc.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\ExternalApi\Docs\Endpoints\V1;
+
+use App\ExternalApi\Docs\ApiEndpointDoc;
+
+/**
+ * Dokumentasi DELETE /api/external/v1/master/sales/{staff_id} (API-002 lanjutan).
+ */
+class MasterSalesDeleteDoc extends ApiEndpointDoc
+{
+    public function key(): string
+    {
+        return 'master-sales-delete';
+    }
+
+    public function title(): string
+    {
+        return 'Hapus Sales';
+    }
+
+    public function method(): string
+    {
+        return 'DELETE';
+    }
+
+    public function path(): string
+    {
+        return '/master/sales/{staff_id}';
+    }
+
+    public function group(): string
+    {
+        return 'master';
+    }
+
+    public function description(): string
+    {
+        return 'Menghapus sales (soft delete).';
+    }
+
+    public function pathParameters(): array
+    {
+        return [
+            ['name' => 'staff_id', 'type' => 'integer', 'required' => true, 'description' => 'id sales yang akan dihapus, lihat GET /master/sales.'],
+        ];
+    }
+
+    public function responseExample(): array
+    {
+        return [
+            'success' => true,
+            'data' => [
+                'staff_id' => 2,
+            ],
+        ];
+    }
+
+    public function errors(): array
+    {
+        return [
+            ['code' => 'not_found', 'http_status' => 404, 'message' => 'staff_id tidak ditemukan, atau ditemukan tapi bukan sales aktif (staf berperan lain, atau sudah dihapus sebelumnya).'],
+        ];
+    }
+
+    public function notes(): array
+    {
+        return [
+            'Ini soft delete: status staf diubah menjadi 0, bukan baris yang dihapus dari basis data — sama seperti penghapusan lewat halaman admin (Pengguna).',
+            'staff_id yang sudah dihapus lewat endpoint ini tidak bisa dibuat ulang lewat POST /master/sales dengan id yang sama — baris dengan id itu tetap ada (soft deleted) dan endpoint ini hanya mengelola staf yang statusnya aktif.',
+            'Endpoint ini HANYA boleh menghapus staf yang berperan Sales (dan masih aktif) — staff_id yang menunjuk staf lain dijawab not_found, bukan diizinkan menghapus staf itu.',
+            'Akun login (staff_username/staff_password), riwayat transaksi, dan saldo staf tidak ikut dihapus atau diubah.',
+        ];
+    }
+}

--- a/app/ExternalApi/Docs/Endpoints/V1/MasterSalesLinkDoc.php
+++ b/app/ExternalApi/Docs/Endpoints/V1/MasterSalesLinkDoc.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace App\ExternalApi\Docs\Endpoints\V1;
+
+use App\ExternalApi\Docs\ApiEndpointDoc;
+
+/**
+ * Dokumentasi PATCH /api/external/v1/master/sales/{staff_id} (API-002 lanjutan).
+ *
+ * {staff_id} pada endpoint ini adalah id Pegasus — kebalikan dari PUT/DELETE
+ * sales yang path parameternya rujukan eksternal. Lihat catatan kelas
+ * MasterSalesController.
+ */
+class MasterSalesLinkDoc extends ApiEndpointDoc
+{
+    public function key(): string
+    {
+        return 'master-sales-link';
+    }
+
+    public function title(): string
+    {
+        return 'Hubungkan Sales';
+    }
+
+    public function method(): string
+    {
+        return 'PATCH';
+    }
+
+    public function path(): string
+    {
+        return '/master/sales/{staff_id}';
+    }
+
+    public function group(): string
+    {
+        return 'master';
+    }
+
+    public function description(): string
+    {
+        return 'Menghubungkan staf Pegasus yang SUDAH ADA (berperan Sales, dibuat lewat halaman admin misalnya) dengan id milik sistem Anda sendiri, tanpa membuat staf baru. Beda dengan endpoint sales lain: {staff_id} di sini adalah id Pegasus, bukan rujukan Anda.';
+    }
+
+    public function pathParameters(): array
+    {
+        return [
+            ['name' => 'staff_id', 'type' => 'integer', 'required' => true, 'description' => 'id STAF PEGASUS (bukan rujukan Anda) yang akan dihubungkan — lihat field id pada GET /master/sales, atau field id pada respons POST /master/sales.'],
+        ];
+    }
+
+    public function bodyParameters(): array
+    {
+        return [
+            ['name' => 'map_staff_id', 'type' => 'string', 'required' => true, 'description' => 'id milik sistem Anda sendiri yang akan dipasang ke staf ini.'],
+        ];
+    }
+
+    public function requestExample(): ?array
+    {
+        return [
+            'map_staff_id' => 'SLS-002',
+        ];
+    }
+
+    public function responseExample(): array
+    {
+        return [
+            'success' => true,
+            'data' => [
+                'id' => 20,
+                'staff_id' => 'SLS-002',
+                'nama_depan' => 'Bisma',
+                'nama_belakang' => null,
+                'email' => 'bisma@contoh.com',
+                'alamat' => 'Jl. Rungkut Industri No. 12, Surabaya',
+            ],
+        ];
+    }
+
+    public function errors(): array
+    {
+        return [
+            ['code' => 'not_found', 'http_status' => 404, 'message' => 'staff_id (id Pegasus) tidak ditemukan, atau ditemukan tapi bukan sales aktif (staf berperan lain, atau sudah dihapus).'],
+            ['code' => 'validation_failed', 'http_status' => 422, 'message' => 'map_staff_id kosong.'],
+        ];
+    }
+
+    public function notes(): array
+    {
+        return [
+            'staff_id pada PATH endpoint ini adalah id STAF PEGASUS — kebalikan dari PUT dan DELETE /master/sales, yang path parameternya adalah rujukan Anda sendiri. Jangan tertukar.',
+            'Menimpa link yang sudah ada pada staf tujuan diperbolehkan.',
+            'Kalau map_staff_id yang dikirim sedang dipegang staf LAIN, rujukan itu DILEPAS dulu dari staf itu (jadi null) sebelum dipasang ke staf tujuan — dipindah, bukan ditolak sebagai duplikat. Staf yang kehilangan rujukannya tidak dihapus atau diubah datanya selain kehilangan link tersebut.',
+            'Endpoint ini HANYA boleh menghubungkan staf yang berperan Sales (dan aktif) — staff_id yang menunjuk staf lain dijawab not_found.',
+            'Cocok dipakai untuk sales yang dibuat lewat halaman admin (belum punya rujukan eksternal, staff_id-nya null pada GET /master/sales) yang baru mau disinkronkan ke sistem Anda, tanpa perlu membuat baris duplikat lewat POST.',
+            'nama_depan/nama_belakang/email/alamat tidak diubah oleh endpoint ini — hanya rujukan yang dipasang.',
+        ];
+    }
+}

--- a/app/ExternalApi/Docs/Endpoints/V1/MasterSalesLinkDoc.php
+++ b/app/ExternalApi/Docs/Endpoints/V1/MasterSalesLinkDoc.php
@@ -5,17 +5,19 @@ namespace App\ExternalApi\Docs\Endpoints\V1;
 use App\ExternalApi\Docs\ApiEndpointDoc;
 
 /**
- * Dokumentasi PATCH /api/external/v1/master/sales/{staff_id} (API-002 lanjutan).
+ * Dokumentasi PATCH /api/external/v1/master/sales/connect (API-002 lanjutan).
  *
- * {staff_id} pada endpoint ini adalah id Pegasus — kebalikan dari PUT/DELETE
- * sales yang path parameternya rujukan eksternal. Lihat catatan kelas
- * MasterSalesController.
+ * Path-nya tetap (/connect), tidak menerima path parameter — setiap staf
+ * yang mau dihubungkan disebutkan lewat staff_id pada tiap butir body
+ * connections. staff_id di SINI adalah id Pegasus — kebalikan dari PUT/
+ * DELETE sales yang path parameternya rujukan eksternal. Lihat catatan
+ * kelas MasterSalesController.
  */
 class MasterSalesLinkDoc extends ApiEndpointDoc
 {
     public function key(): string
     {
-        return 'master-sales-link';
+        return 'master-sales-connect';
     }
 
     public function title(): string
@@ -30,7 +32,7 @@ class MasterSalesLinkDoc extends ApiEndpointDoc
 
     public function path(): string
     {
-        return '/master/sales/{staff_id}';
+        return '/master/sales/connect';
     }
 
     public function group(): string
@@ -40,27 +42,25 @@ class MasterSalesLinkDoc extends ApiEndpointDoc
 
     public function description(): string
     {
-        return 'Menghubungkan staf Pegasus yang SUDAH ADA (berperan Sales, dibuat lewat halaman admin misalnya) dengan id milik sistem Anda sendiri, tanpa membuat staf baru. Beda dengan endpoint sales lain: {staff_id} di sini adalah id Pegasus, bukan rujukan Anda.';
-    }
-
-    public function pathParameters(): array
-    {
-        return [
-            ['name' => 'staff_id', 'type' => 'integer', 'required' => true, 'description' => 'id STAF PEGASUS (bukan rujukan Anda) yang akan dihubungkan — lihat field id pada GET /master/sales, atau field id pada respons POST /master/sales.'],
-        ];
+        return 'Menghubungkan satu atau banyak staf Pegasus yang SUDAH ADA (berperan Sales, dibuat lewat halaman admin misalnya) dengan id milik sistem Anda sendiri sekaligus, tanpa membuat staf baru. Tiap butir diproses independen — sebagian boleh berhasil walau sebagian lain gagal.';
     }
 
     public function bodyParameters(): array
     {
         return [
-            ['name' => 'map_staff_id', 'type' => 'string', 'required' => true, 'description' => 'id milik sistem Anda sendiri yang akan dipasang ke staf ini.'],
+            ['name' => 'connections', 'type' => 'array', 'required' => true, 'description' => 'Daftar pasangan yang mau dihubungkan, minimal satu butir.'],
+            ['name' => 'connections[].staff_id', 'type' => 'integer', 'required' => true, 'description' => 'id STAF PEGASUS (bukan rujukan Anda) yang akan dihubungkan — lihat field id pada GET /master/sales, atau field id pada respons POST /master/sales.'],
+            ['name' => 'connections[].map_staff_id', 'type' => 'string', 'required' => true, 'description' => 'id milik sistem Anda sendiri yang akan dipasang ke staf tersebut.'],
         ];
     }
 
     public function requestExample(): ?array
     {
         return [
-            'map_staff_id' => 'SLS-002',
+            'connections' => [
+                ['staff_id' => 20, 'map_staff_id' => 'SLS-002'],
+                ['staff_id' => 21, 'map_staff_id' => 'SLS-003'],
+            ],
         ];
     }
 
@@ -69,12 +69,33 @@ class MasterSalesLinkDoc extends ApiEndpointDoc
         return [
             'success' => true,
             'data' => [
-                'id' => 20,
-                'staff_id' => 'SLS-002',
-                'nama_depan' => 'Bisma',
-                'nama_belakang' => null,
-                'email' => 'bisma@contoh.com',
-                'alamat' => 'Jl. Rungkut Industri No. 12, Surabaya',
+                [
+                    'staff_id' => 20,
+                    'map_staff_id' => 'SLS-002',
+                    'success' => true,
+                    'data' => [
+                        'id' => 20,
+                        'staff_id' => 'SLS-002',
+                        'nama_depan' => 'Bisma',
+                        'nama_belakang' => null,
+                        'email' => 'bisma@contoh.com',
+                        'alamat' => 'Jl. Rungkut Industri No. 12, Surabaya',
+                    ],
+                ],
+                [
+                    'staff_id' => 999,
+                    'map_staff_id' => 'SLS-003',
+                    'success' => false,
+                    'error' => [
+                        'code' => 'not_found',
+                        'message' => 'Staf dengan id 999 tidak ditemukan atau bukan sales aktif.',
+                    ],
+                ],
+            ],
+            'meta' => [
+                'total' => 2,
+                'success' => 1,
+                'failed' => 1,
             ],
         ];
     }
@@ -82,18 +103,19 @@ class MasterSalesLinkDoc extends ApiEndpointDoc
     public function errors(): array
     {
         return [
-            ['code' => 'not_found', 'http_status' => 404, 'message' => 'staff_id (id Pegasus) tidak ditemukan, atau ditemukan tapi bukan sales aktif (staf berperan lain, atau sudah dihapus).'],
-            ['code' => 'validation_failed', 'http_status' => 422, 'message' => 'map_staff_id kosong.'],
+            ['code' => 'validation_failed', 'http_status' => 422, 'message' => 'connections kosong/bukan array, atau salah satu butir tidak berbentuk {staff_id, map_staff_id} yang sah — berlaku untuk SELURUH permintaan (bukan per butir).'],
         ];
     }
 
     public function notes(): array
     {
         return [
-            'staff_id pada PATH endpoint ini adalah id STAF PEGASUS — kebalikan dari PUT dan DELETE /master/sales, yang path parameternya adalah rujukan Anda sendiri. Jangan tertukar.',
+            'Endpoint ini SELALU menjawab 200 selama bentuk permintaannya sah (connections berupa array, tiap butir punya staff_id integer dan map_staff_id string) — kegagalan per butir (staf tidak ditemukan/bukan sales, map_staff_id kosong) muncul lewat success:false pada butir itu di data, bukan lewat status HTTP gagal untuk seluruh permintaan. meta.failed > 0 menandakan ada butir yang gagal.',
+            'staff_id pada tiap butir connections adalah id STAF PEGASUS — kebalikan dari PUT dan DELETE /master/sales, yang path parameternya adalah rujukan Anda sendiri. Jangan tertukar.',
+            'Setiap butir diproses independen, bukan satu transaksi besar: butir yang gagal tidak membatalkan butir lain yang berhasil dalam permintaan yang sama.',
             'Menimpa link yang sudah ada pada staf tujuan diperbolehkan.',
-            'Kalau map_staff_id yang dikirim sedang dipegang staf LAIN, rujukan itu DILEPAS dulu dari staf itu (jadi null) sebelum dipasang ke staf tujuan — dipindah, bukan ditolak sebagai duplikat. Staf yang kehilangan rujukannya tidak dihapus atau diubah datanya selain kehilangan link tersebut.',
-            'Endpoint ini HANYA boleh menghubungkan staf yang berperan Sales (dan aktif) — staff_id yang menunjuk staf lain dijawab not_found.',
+            'Kalau map_staff_id yang dikirim sedang dipegang staf LAIN (termasuk staf lain dalam butir connections yang sama), rujukan itu DILEPAS dulu dari staf itu (jadi null) sebelum dipasang ke staf tujuan — dipindah, bukan ditolak sebagai duplikat. Staf yang kehilangan rujukannya tidak dihapus atau diubah datanya selain kehilangan link tersebut.',
+            'Endpoint ini HANYA boleh menghubungkan staf yang berperan Sales (dan aktif) — staff_id yang menunjuk staf lain gagal dengan not_found pada butir itu.',
             'Cocok dipakai untuk sales yang dibuat lewat halaman admin (belum punya rujukan eksternal, staff_id-nya null pada GET /master/sales) yang baru mau disinkronkan ke sistem Anda, tanpa perlu membuat baris duplikat lewat POST.',
             'nama_depan/nama_belakang/email/alamat tidak diubah oleh endpoint ini — hanya rujukan yang dipasang.',
         ];

--- a/app/ExternalApi/Docs/Endpoints/V1/MasterSalesListDoc.php
+++ b/app/ExternalApi/Docs/Endpoints/V1/MasterSalesListDoc.php
@@ -36,8 +36,7 @@ class MasterSalesListDoc extends ApiEndpointDoc
 
     public function description(): string
     {
-        return 'Mengambil daftar staf sales yang berstatus aktif. Dipakai sistem '
-            .'eksternal antara lain untuk mengisi staff_id pada endpoint Pembayaran Kas.';
+        return 'Mengambil daftar staf sales yang berstatus aktif.';
     }
 
     public function responseExample(): array
@@ -46,7 +45,8 @@ class MasterSalesListDoc extends ApiEndpointDoc
             'success' => true,
             'data' => [
                 [
-                    'staff_id' => 20,
+                    'id' => 20,
+                    'staff_id' => null,
                     'nama' => 'Bisma',
                     'nama_depan' => 'Bisma',
                     'nama_belakang' => null,
@@ -57,7 +57,8 @@ class MasterSalesListDoc extends ApiEndpointDoc
                     'role' => 'Sales',
                 ],
                 [
-                    'staff_id' => 26,
+                    'id' => 26,
+                    'staff_id' => 'SLS-002',
                     'nama' => 'Sales Counter',
                     'nama_depan' => 'Sales',
                     'nama_belakang' => 'Counter',
@@ -80,10 +81,11 @@ class MasterSalesListDoc extends ApiEndpointDoc
             'Endpoint ini tidak menerima parameter apa pun.',
             'Sales bukan tabel tersendiri: yang dikembalikan adalah staf yang nama perannya mengandung kata "sales". Penyaringan memakai nama peran, bukan id peran, sehingga peran baru yang mengandung kata itu otomatis ikut terbawa.',
             'Hanya staf berstatus aktif yang muncul.',
-            'staff_id di sini adalah nilai yang diminta endpoint Pembayaran Kas pada field staff_id ketika payment_type bernilai 2, dan yang dipakai sebagai path parameter pada endpoint ubah (PUT) dan hapus (DELETE) sales.',
+            'id adalah id staf pada sistem Pegasus. Inilah nilai yang diminta endpoint Pembayaran Kas pada field staff_id ketika payment_type bernilai 2, dan juga path parameter {staff_id} pada PATCH /master/sales (menghubungkan staf yang sudah ada dengan rujukan eksternal).',
+            'staff_id di respons ini BUKAN id staf Pegasus — ini rujukan milik sistem pemanggil sendiri (external_ref_id), boleh null kalau staf itu belum pernah dihubungkan ke sistem eksternal mana pun lewat POST atau PATCH /master/sales. Inilah nilai yang dipakai sebagai path parameter {staff_id} pada PUT dan DELETE /master/sales.',
             'nama_depan dan nama_belakang adalah hasil pemisahan otomatis dari nama (dipisah pada spasi pertama), disertakan supaya sejalan dengan bentuk body create/update sales. Untuk staf yang namanya terdiri lebih dari dua kata dan tidak pernah dibuat/diubah lewat endpoint create/update sales, pemisahan ini bisa saja tidak sama dengan pembagian depan/belakang yang sebenarnya — staffs.staff_name memang cuma satu kolom gabungan.',
             'role berisi nama peran staf yang bersangkutan apa adanya seperti tersimpan di Pegasus, misalnya "Sales".',
-            'kode, email, telepon, alamat, dan nama_belakang boleh bernilai null bila datanya memang belum diisi di Pegasus.',
+            'kode, email, telepon, alamat, staff_id, dan nama_belakang boleh bernilai null bila datanya memang belum diisi di Pegasus.',
             'Kata sandi, nama pengguna, saldo staf, dan hak akses tidak pernah dikembalikan.',
             'Urutan daftar bersifat tetap.',
         ];

--- a/app/ExternalApi/Docs/Endpoints/V1/MasterSalesListDoc.php
+++ b/app/ExternalApi/Docs/Endpoints/V1/MasterSalesListDoc.php
@@ -48,6 +48,8 @@ class MasterSalesListDoc extends ApiEndpointDoc
                 [
                     'staff_id' => 20,
                     'nama' => 'Bisma',
+                    'nama_depan' => 'Bisma',
+                    'nama_belakang' => null,
                     'kode' => null,
                     'email' => 'bisma@contoh.com',
                     'telepon' => '08123456789',
@@ -57,6 +59,8 @@ class MasterSalesListDoc extends ApiEndpointDoc
                 [
                     'staff_id' => 26,
                     'nama' => 'Sales Counter',
+                    'nama_depan' => 'Sales',
+                    'nama_belakang' => 'Counter',
                     'kode' => null,
                     'email' => null,
                     'telepon' => null,
@@ -76,9 +80,10 @@ class MasterSalesListDoc extends ApiEndpointDoc
             'Endpoint ini tidak menerima parameter apa pun.',
             'Sales bukan tabel tersendiri: yang dikembalikan adalah staf yang nama perannya mengandung kata "sales". Penyaringan memakai nama peran, bukan id peran, sehingga peran baru yang mengandung kata itu otomatis ikut terbawa.',
             'Hanya staf berstatus aktif yang muncul.',
-            'staff_id di sini adalah nilai yang diminta endpoint Pembayaran Kas pada field staff_id ketika payment_type bernilai 2.',
+            'staff_id di sini adalah nilai yang diminta endpoint Pembayaran Kas pada field staff_id ketika payment_type bernilai 2, dan yang dipakai sebagai path parameter pada endpoint ubah (PUT) dan hapus (DELETE) sales.',
+            'nama_depan dan nama_belakang adalah hasil pemisahan otomatis dari nama (dipisah pada spasi pertama), disertakan supaya sejalan dengan bentuk body create/update sales. Untuk staf yang namanya terdiri lebih dari dua kata dan tidak pernah dibuat/diubah lewat endpoint create/update sales, pemisahan ini bisa saja tidak sama dengan pembagian depan/belakang yang sebenarnya — staffs.staff_name memang cuma satu kolom gabungan.',
             'role berisi nama peran staf yang bersangkutan apa adanya seperti tersimpan di Pegasus, misalnya "Sales".',
-            'kode, email, telepon, dan alamat boleh bernilai null bila datanya memang belum diisi di Pegasus.',
+            'kode, email, telepon, alamat, dan nama_belakang boleh bernilai null bila datanya memang belum diisi di Pegasus.',
             'Kata sandi, nama pengguna, saldo staf, dan hak akses tidak pernah dikembalikan.',
             'Urutan daftar bersifat tetap.',
         ];

--- a/app/ExternalApi/Docs/Endpoints/V1/MasterSalesUpdateDoc.php
+++ b/app/ExternalApi/Docs/Endpoints/V1/MasterSalesUpdateDoc.php
@@ -36,13 +36,13 @@ class MasterSalesUpdateDoc extends ApiEndpointDoc
 
     public function description(): string
     {
-        return 'Mengubah data sales yang sudah ada. Bersifat penggantian penuh — seluruh field body wajib dikirim meski hanya satu yang berubah. Berbeda dengan POST, PUT tidak pernah membuat sales baru.';
+        return 'Mengubah data sales yang sudah ada, dicari lewat staff_id (rujukan milik sistem Anda sendiri, bukan id Pegasus). Bersifat penggantian penuh — seluruh field body wajib dikirim meski hanya satu yang berubah. Tidak pernah membuat sales baru.';
     }
 
     public function pathParameters(): array
     {
         return [
-            ['name' => 'staff_id', 'type' => 'integer', 'required' => true, 'description' => 'id sales yang akan diubah, lihat GET /master/sales.'],
+            ['name' => 'staff_id', 'type' => 'string', 'required' => true, 'description' => 'id milik sistem Anda sendiri untuk sales yang akan diubah (BUKAN id Pegasus) — nilai yang sama dengan field staff_id pada GET /master/sales atau yang dikirim saat POST/PATCH.'],
         ];
     }
 
@@ -71,7 +71,8 @@ class MasterSalesUpdateDoc extends ApiEndpointDoc
         return [
             'success' => true,
             'data' => [
-                'staff_id' => 2,
+                'id' => 105,
+                'staff_id' => '2',
                 'nama_depan' => 'Willian',
                 'nama_belakang' => 'Hartanto',
                 'email' => 'wilha.h@gmail.com',
@@ -83,7 +84,7 @@ class MasterSalesUpdateDoc extends ApiEndpointDoc
     public function errors(): array
     {
         return [
-            ['code' => 'not_found', 'http_status' => 404, 'message' => 'staff_id tidak ditemukan, atau ditemukan tapi bukan sales aktif (staf berperan lain, atau sales yang sudah dihapus).'],
+            ['code' => 'not_found', 'http_status' => 404, 'message' => 'staff_id (rujukan Anda) tidak ditemukan, atau ditemukan tapi bukan sales aktif (staf berperan lain, atau sales yang sudah dihapus).'],
             ['code' => 'validation_failed', 'http_status' => 422, 'message' => 'nama_depan atau email kosong/tidak valid.'],
         ];
     }
@@ -91,6 +92,7 @@ class MasterSalesUpdateDoc extends ApiEndpointDoc
     public function notes(): array
     {
         return [
+            'staff_id pada path adalah rujukan milik sistem Anda sendiri (external_ref_id), BUKAN id Pegasus — endpoint yang path parameternya id Pegasus adalah PATCH /master/sales/{id}.',
             'nama_depan dan email wajib diisi meski hanya satu yang berubah; nama_belakang dan alamat boleh dikosongkan.',
             'Body selalu dianggap representasi penuh sales ini: nama_belakang/alamat yang tidak dikirim disimpan sebagai kosong, bukan mempertahankan nilai lama.',
             'Endpoint ini HANYA boleh menyentuh staf yang berperan Sales (dan aktif) — staff_id yang menunjuk staf lain dijawab not_found, bukan diizinkan mengubah data staf itu.',

--- a/app/ExternalApi/Docs/Endpoints/V1/MasterSalesUpdateDoc.php
+++ b/app/ExternalApi/Docs/Endpoints/V1/MasterSalesUpdateDoc.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace App\ExternalApi\Docs\Endpoints\V1;
+
+use App\ExternalApi\Docs\ApiEndpointDoc;
+
+/**
+ * Dokumentasi PUT /api/external/v1/master/sales/{staff_id} (API-002 lanjutan).
+ */
+class MasterSalesUpdateDoc extends ApiEndpointDoc
+{
+    public function key(): string
+    {
+        return 'master-sales-update';
+    }
+
+    public function title(): string
+    {
+        return 'Ubah Sales';
+    }
+
+    public function method(): string
+    {
+        return 'PUT';
+    }
+
+    public function path(): string
+    {
+        return '/master/sales/{staff_id}';
+    }
+
+    public function group(): string
+    {
+        return 'master';
+    }
+
+    public function description(): string
+    {
+        return 'Mengubah data sales yang sudah ada. Bersifat penggantian penuh — seluruh field body wajib dikirim meski hanya satu yang berubah. Berbeda dengan POST, PUT tidak pernah membuat sales baru.';
+    }
+
+    public function pathParameters(): array
+    {
+        return [
+            ['name' => 'staff_id', 'type' => 'integer', 'required' => true, 'description' => 'id sales yang akan diubah, lihat GET /master/sales.'],
+        ];
+    }
+
+    public function bodyParameters(): array
+    {
+        return [
+            ['name' => 'nama_depan', 'type' => 'string', 'required' => true, 'description' => 'Nama depan.'],
+            ['name' => 'nama_belakang', 'type' => 'string', 'required' => false, 'description' => 'Nama belakang. Boleh dikosongkan.'],
+            ['name' => 'email', 'type' => 'string', 'required' => true, 'description' => 'Alamat email.'],
+            ['name' => 'alamat', 'type' => 'string', 'required' => false, 'description' => 'Alamat. Boleh dikosongkan.'],
+        ];
+    }
+
+    public function requestExample(): ?array
+    {
+        return [
+            'nama_depan' => 'Willian',
+            'nama_belakang' => 'Hartanto',
+            'email' => 'wilha.h@gmail.com',
+            'alamat' => 'Jl. Sudirman Block A No. 12',
+        ];
+    }
+
+    public function responseExample(): array
+    {
+        return [
+            'success' => true,
+            'data' => [
+                'staff_id' => 2,
+                'nama_depan' => 'Willian',
+                'nama_belakang' => 'Hartanto',
+                'email' => 'wilha.h@gmail.com',
+                'alamat' => 'Jl. Sudirman Block A No. 12',
+            ],
+        ];
+    }
+
+    public function errors(): array
+    {
+        return [
+            ['code' => 'not_found', 'http_status' => 404, 'message' => 'staff_id tidak ditemukan, atau ditemukan tapi bukan sales aktif (staf berperan lain, atau sales yang sudah dihapus).'],
+            ['code' => 'validation_failed', 'http_status' => 422, 'message' => 'nama_depan atau email kosong/tidak valid.'],
+        ];
+    }
+
+    public function notes(): array
+    {
+        return [
+            'nama_depan dan email wajib diisi meski hanya satu yang berubah; nama_belakang dan alamat boleh dikosongkan.',
+            'Body selalu dianggap representasi penuh sales ini: nama_belakang/alamat yang tidak dikirim disimpan sebagai kosong, bukan mempertahankan nilai lama.',
+            'Endpoint ini HANYA boleh menyentuh staf yang berperan Sales (dan aktif) — staff_id yang menunjuk staf lain dijawab not_found, bukan diizinkan mengubah data staf itu.',
+            'kode (staff_code), telepon (staff_phone), dan role tidak dikelola lewat endpoint ini — nilainya tidak berubah walau tidak dikirim.',
+        ];
+    }
+}

--- a/app/ExternalApi/Docs/Endpoints/V1/MasterUnitCreateDoc.php
+++ b/app/ExternalApi/Docs/Endpoints/V1/MasterUnitCreateDoc.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace App\ExternalApi\Docs\Endpoints\V1;
+
+use App\ExternalApi\Docs\ApiEndpointDoc;
+
+/**
+ * Dokumentasi POST /api/external/v1/master/units (API-001 lanjutan).
+ */
+class MasterUnitCreateDoc extends ApiEndpointDoc
+{
+    public function key(): string
+    {
+        return 'master-units-create';
+    }
+
+    public function title(): string
+    {
+        return 'Buat Satuan';
+    }
+
+    public function method(): string
+    {
+        return 'POST';
+    }
+
+    public function path(): string
+    {
+        return '/master/units';
+    }
+
+    public function group(): string
+    {
+        return 'master';
+    }
+
+    public function description(): string
+    {
+        return 'Membuat satuan baru di Pegasus, dihubungkan dengan id satuan pada sistem PMO (ref_unit_id). Selalu membuat baris baru — bukan upsert; ref_unit_id yang sudah dipakai satuan lain ditolak.';
+    }
+
+    public function bodyParameters(): array
+    {
+        return [
+            ['name' => 'ref_unit_id', 'type' => 'integer', 'required' => true, 'description' => 'id satuan yang sama pada sistem PMO. Wajib belum pernah dipakai satuan lain di Pegasus.'],
+            ['name' => 'unit_name', 'type' => 'string', 'required' => true, 'description' => 'Nama satuan, mis. "Kilogram".'],
+            ['name' => 'unit_short_name', 'type' => 'string', 'required' => true, 'description' => 'Singkatan satuan, mis. "kg".'],
+        ];
+    }
+
+    public function requestExample(): ?array
+    {
+        return [
+            'ref_unit_id' => 1042,
+            'unit_name' => 'Kilogram',
+            'unit_short_name' => 'kg',
+        ];
+    }
+
+    public function responseExample(): array
+    {
+        return [
+            'success' => true,
+            'data' => [
+                'id' => 12,
+                'ref_unit_id' => 1042,
+                'unit_name' => 'Kilogram',
+                'unit_short_name' => 'kg',
+            ],
+        ];
+    }
+
+    public function errors(): array
+    {
+        return [
+            ['code' => 'validation_failed', 'http_status' => 422, 'message' => 'ref_unit_id, unit_name, atau unit_short_name kosong/tidak valid.'],
+            ['code' => 'duplicate_ref_id', 'http_status' => 422, 'message' => 'ref_unit_id sudah dipakai satuan lain (baik yang masih aktif maupun yang sudah dihapus lewat DELETE units) — pakai PUT untuk memperbarui satuan yang sudah ada.'],
+        ];
+    }
+
+    public function notes(): array
+    {
+        return [
+            'Ketiga field wajib diisi, tidak ada yang bersifat opsional.',
+            'id pada respons adalah id satuan yang dibuat Pegasus sendiri (auto-increment) — SIMPAN nilai ini kalau nanti perlu memanggil PATCH /master/units/connect (yang butir connections-nya memakai id Pegasus, bukan ref_unit_id).',
+            'Bukan upsert: mengirim ref_unit_id yang sudah dipakai (aktif maupun yang satuannya sudah dihapus) selalu ditolak dengan duplicate_ref_id, tidak pernah menimpa data yang sudah ada. Pakai PUT /master/units/{ref_unit_id} untuk memperbarui satuan yang rujukannya sudah ada.',
+            'Untuk menghubungkan ref_unit_id ke satuan Pegasus yang SUDAH ADA (dibuat lewat halaman admin atau Pusat Sinkronisasi, misalnya), pakai PATCH /master/units/connect — bukan POST ini, yang selalu membuat satuan baru.',
+            'ref_unit_id juga ditulis Pusat Sinkronisasi (menarik data satuan dari PMO) — endpoint ini adalah jalur tulis kedua ke kolom yang sama, disengaja karena keduanya melayani sistem yang sama (PMO).',
+        ];
+    }
+}

--- a/app/ExternalApi/Docs/Endpoints/V1/MasterUnitDeleteDoc.php
+++ b/app/ExternalApi/Docs/Endpoints/V1/MasterUnitDeleteDoc.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\ExternalApi\Docs\Endpoints\V1;
+
+use App\ExternalApi\Docs\ApiEndpointDoc;
+
+/**
+ * Dokumentasi DELETE /api/external/v1/master/units/{ref_unit_id} (API-001 lanjutan).
+ */
+class MasterUnitDeleteDoc extends ApiEndpointDoc
+{
+    public function key(): string
+    {
+        return 'master-units-delete';
+    }
+
+    public function title(): string
+    {
+        return 'Hapus Satuan';
+    }
+
+    public function method(): string
+    {
+        return 'DELETE';
+    }
+
+    public function path(): string
+    {
+        return '/master/units/{ref_unit_id}';
+    }
+
+    public function group(): string
+    {
+        return 'master';
+    }
+
+    public function description(): string
+    {
+        return 'Menghapus satuan (soft delete), dicari lewat ref_unit_id (id satuan pada sistem PMO).';
+    }
+
+    public function pathParameters(): array
+    {
+        return [
+            ['name' => 'ref_unit_id', 'type' => 'integer', 'required' => true, 'description' => 'id satuan pada sistem PMO untuk satuan yang akan dihapus.'],
+        ];
+    }
+
+    public function responseExample(): array
+    {
+        return [
+            'success' => true,
+            'data' => [
+                'ref_unit_id' => 1042,
+            ],
+        ];
+    }
+
+    public function errors(): array
+    {
+        return [
+            ['code' => 'not_found', 'http_status' => 404, 'message' => 'ref_unit_id tidak ditemukan, atau ditemukan tapi satuannya sudah nonaktif/dihapus sebelumnya.'],
+        ];
+    }
+
+    public function notes(): array
+    {
+        return [
+            'Ini soft delete: status satuan diubah menjadi 0, bukan baris yang dihapus dari basis data — sama seperti penghapusan lewat halaman admin.',
+            'ref_unit_id TIDAK dilepas oleh operasi ini — baris satuan lama masih memegangnya, hanya berstatus nonaktif. Karena itu ref_unit_id yang sudah dihapus lewat endpoint ini tidak bisa dipakai lagi lewat POST /master/units (ditolak duplicate_ref_id), dan tidak muncul lagi lewat GET /master/units.',
+            'Satuan yang masih dipakai produk/varian/stok tetap bisa dihapus lewat endpoint ini — tidak ada pemeriksaan pemakaian seperti pada penghapusan gudang.',
+        ];
+    }
+}

--- a/app/ExternalApi/Docs/Endpoints/V1/MasterUnitLinkDoc.php
+++ b/app/ExternalApi/Docs/Endpoints/V1/MasterUnitLinkDoc.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace App\ExternalApi\Docs\Endpoints\V1;
+
+use App\ExternalApi\Docs\ApiEndpointDoc;
+
+/**
+ * Dokumentasi PATCH /api/external/v1/master/units/connect (API-001 lanjutan).
+ *
+ * Path-nya tetap (/connect), tidak menerima path parameter — setiap satuan
+ * yang mau dihubungkan disebutkan lewat id pada tiap butir body connections.
+ */
+class MasterUnitLinkDoc extends ApiEndpointDoc
+{
+    public function key(): string
+    {
+        return 'master-units-connect';
+    }
+
+    public function title(): string
+    {
+        return 'Hubungkan Satuan';
+    }
+
+    public function method(): string
+    {
+        return 'PATCH';
+    }
+
+    public function path(): string
+    {
+        return '/master/units/connect';
+    }
+
+    public function group(): string
+    {
+        return 'master';
+    }
+
+    public function description(): string
+    {
+        return 'Menghubungkan satu atau banyak satuan Pegasus yang SUDAH ADA dengan id satuan pada sistem PMO (ref_unit_id) sekaligus, tanpa membuat satuan baru. Tiap butir diproses independen — sebagian boleh berhasil walau sebagian lain gagal.';
+    }
+
+    public function bodyParameters(): array
+    {
+        return [
+            ['name' => 'connections', 'type' => 'array', 'required' => true, 'description' => 'Daftar pasangan yang mau dihubungkan, minimal satu butir.'],
+            ['name' => 'connections[].id', 'type' => 'integer', 'required' => true, 'description' => 'id satuan PEGASUS (bukan ref_unit_id) yang akan dihubungkan — lihat field id pada GET /master/units, atau field id pada respons POST /master/units.'],
+            ['name' => 'connections[].ref_unit_id', 'type' => 'integer', 'required' => true, 'description' => 'id satuan pada sistem PMO yang akan dipasang ke satuan tersebut.'],
+        ];
+    }
+
+    public function requestExample(): ?array
+    {
+        return [
+            'connections' => [
+                ['id' => 1, 'ref_unit_id' => 1042],
+                ['id' => 2, 'ref_unit_id' => 1043],
+            ],
+        ];
+    }
+
+    public function responseExample(): array
+    {
+        return [
+            'success' => true,
+            'data' => [
+                [
+                    'id' => 1,
+                    'ref_unit_id' => 1042,
+                    'success' => true,
+                    'data' => [
+                        'id' => 1,
+                        'ref_unit_id' => 1042,
+                        'unit_name' => 'Kilogram',
+                        'unit_short_name' => 'kg',
+                    ],
+                ],
+                [
+                    'id' => 999,
+                    'ref_unit_id' => 1043,
+                    'success' => false,
+                    'error' => [
+                        'code' => 'not_found',
+                        'message' => 'Satuan dengan id 999 tidak ditemukan atau tidak aktif.',
+                    ],
+                ],
+            ],
+            'meta' => [
+                'total' => 2,
+                'success' => 1,
+                'failed' => 1,
+            ],
+        ];
+    }
+
+    public function errors(): array
+    {
+        return [
+            ['code' => 'validation_failed', 'http_status' => 422, 'message' => 'connections kosong/bukan array, atau salah satu butir tidak berbentuk {id, ref_unit_id} yang sah — berlaku untuk SELURUH permintaan (bukan per butir).'],
+        ];
+    }
+
+    public function notes(): array
+    {
+        return [
+            'Endpoint ini SELALU menjawab 200 selama bentuk permintaannya sah (connections berupa array, tiap butir punya id dan ref_unit_id berupa integer) — kegagalan per butir (satuan tidak ditemukan/nonaktif) muncul lewat success:false pada butir itu di data, bukan lewat status HTTP gagal untuk seluruh permintaan. meta.failed > 0 menandakan ada butir yang gagal.',
+            'id pada tiap butir connections adalah id satuan PEGASUS, bukan ref_unit_id — kebalikan dari PUT dan DELETE /master/units, yang path parameternya adalah ref_unit_id. Jangan tertukar.',
+            'Setiap butir diproses independen, bukan satu transaksi besar: butir yang gagal tidak membatalkan butir lain yang berhasil dalam permintaan yang sama.',
+            'Menimpa ref_unit_id yang sudah ada pada satuan tujuan diperbolehkan.',
+            'Kalau ref_unit_id yang dikirim sedang dipegang satuan LAIN (termasuk satuan lain dalam butir connections yang sama), rujukan itu DILEPAS dulu dari satuan itu (jadi null) sebelum dipasang ke satuan tujuan — dipindah, bukan ditolak sebagai duplikat.',
+            'Cocok dipakai untuk satuan yang dibuat lewat halaman admin atau Pusat Sinkronisasi yang belum/salah terhubung ke ref_unit_id yang benar, tanpa perlu membuat baris duplikat lewat POST.',
+            'unit_name/unit_short_name tidak diubah oleh endpoint ini — hanya ref_unit_id yang dipasang.',
+            'ref_unit_id juga ditulis Pusat Sinkronisasi (menarik data satuan dari PMO) — endpoint ini adalah jalur tulis kedua ke kolom yang sama, disengaja karena keduanya melayani sistem yang sama (PMO); siapa yang menulis terakhir yang berlaku.',
+        ];
+    }
+}

--- a/app/ExternalApi/Docs/Endpoints/V1/MasterUnitListDoc.php
+++ b/app/ExternalApi/Docs/Endpoints/V1/MasterUnitListDoc.php
@@ -51,20 +51,20 @@ class MasterUnitListDoc extends ApiEndpointDoc
             'success' => true,
             'data' => [
                 [
-                    'unit_id' => 1,
+                    'id' => 1,
                     'ref_unit_id' => null,
                     'unit_name' => 'Kilogram',
                     'unit_short_name' => 'kg',
                 ],
                 [
-                    'unit_id' => 2,
+                    'id' => 2,
                     'ref_unit_id' => null,
                     'unit_name' => 'Jerigen',
                     'unit_short_name' => 'jerigen',
                 ],
                 [
-                    'unit_id' => 7,
-                    'ref_unit_id' => null,
+                    'id' => 7,
+                    'ref_unit_id' => 1042,
                     'unit_name' => 'DOS',
                     'unit_short_name' => 'DOS',
                 ],
@@ -80,7 +80,8 @@ class MasterUnitListDoc extends ApiEndpointDoc
         return [
             'Endpoint ini tidak menerima parameter apa pun. Seluruh satuan aktif selalu dikembalikan sekaligus.',
             'Hanya satuan berstatus aktif yang muncul. Satuan yang dihapus di Pegasus akan hilang dari daftar ini — perlakukan satuan yang tidak lagi muncul sebagai satuan yang sudah tidak berlaku.',
-            'unit_id adalah id pada sistem Pegasus. ref_unit_id adalah id satuan yang sama pada sistem PMO, dan bernilai null selama satuan tersebut belum pernah dicocokkan lewat Pusat Sinkronisasi.',
+            'id adalah id pada sistem Pegasus, dipakai sebagai field id pada tiap butir body PATCH /master/units/connect. ref_unit_id adalah id satuan yang sama pada sistem PMO, boleh null selama satuan tersebut belum pernah dihubungkan lewat POST/PATCH endpoint ini atau Pusat Sinkronisasi — dan dipakai sebagai path parameter pada PUT/DELETE /master/units.',
+            'ref_unit_id sekaligus ditulis Pusat Sinkronisasi (menarik data satuan dari PMO). POST/PUT/PATCH pada grup endpoint ini adalah jalur tulis kedua ke kolom yang sama — disengaja, keduanya melayani sistem yang sama (PMO); siapa yang menulis terakhir yang berlaku.',
             'unit_short_name adalah singkatan yang tampil di layar stok, misalnya "kg". Nilainya tidak pernah kosong.',
             'Urutan daftar bersifat tetap, sehingga dua permintaan berturut-turut atas data yang sama menghasilkan urutan yang sama.',
         ];

--- a/app/ExternalApi/Docs/Endpoints/V1/MasterUnitUpdateDoc.php
+++ b/app/ExternalApi/Docs/Endpoints/V1/MasterUnitUpdateDoc.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\ExternalApi\Docs\Endpoints\V1;
+
+use App\ExternalApi\Docs\ApiEndpointDoc;
+
+/**
+ * Dokumentasi PUT /api/external/v1/master/units/{ref_unit_id} (API-001 lanjutan).
+ */
+class MasterUnitUpdateDoc extends ApiEndpointDoc
+{
+    public function key(): string
+    {
+        return 'master-units-update';
+    }
+
+    public function title(): string
+    {
+        return 'Ubah Satuan';
+    }
+
+    public function method(): string
+    {
+        return 'PUT';
+    }
+
+    public function path(): string
+    {
+        return '/master/units/{ref_unit_id}';
+    }
+
+    public function group(): string
+    {
+        return 'master';
+    }
+
+    public function description(): string
+    {
+        return 'Mengubah data satuan yang sudah ada, dicari lewat ref_unit_id (id satuan pada sistem PMO). Bersifat penggantian penuh — seluruh field body wajib dikirim meski hanya satu yang berubah. Tidak pernah membuat satuan baru.';
+    }
+
+    public function pathParameters(): array
+    {
+        return [
+            ['name' => 'ref_unit_id', 'type' => 'integer', 'required' => true, 'description' => 'id satuan pada sistem PMO untuk satuan yang akan diubah, lihat GET /master/units.'],
+        ];
+    }
+
+    public function bodyParameters(): array
+    {
+        return [
+            ['name' => 'unit_name', 'type' => 'string', 'required' => true, 'description' => 'Nama satuan, mis. "Kilogram".'],
+            ['name' => 'unit_short_name', 'type' => 'string', 'required' => true, 'description' => 'Singkatan satuan, mis. "kg".'],
+        ];
+    }
+
+    public function requestExample(): ?array
+    {
+        return [
+            'unit_name' => 'Kilogram',
+            'unit_short_name' => 'kg',
+        ];
+    }
+
+    public function responseExample(): array
+    {
+        return [
+            'success' => true,
+            'data' => [
+                'id' => 12,
+                'ref_unit_id' => 1042,
+                'unit_name' => 'Kilogram',
+                'unit_short_name' => 'kg',
+            ],
+        ];
+    }
+
+    public function errors(): array
+    {
+        return [
+            ['code' => 'not_found', 'http_status' => 404, 'message' => 'ref_unit_id tidak ditemukan, atau ditemukan tapi satuannya nonaktif/sudah dihapus.'],
+            ['code' => 'validation_failed', 'http_status' => 422, 'message' => 'unit_name atau unit_short_name kosong/tidak valid.'],
+        ];
+    }
+
+    public function notes(): array
+    {
+        return [
+            'Kedua field wajib diisi meski hanya satu yang berubah — tidak ada partial update.',
+            'Endpoint ini HANYA menyentuh satuan berstatus aktif — ref_unit_id yang menunjuk satuan nonaktif/sudah dihapus dijawab not_found, bukan diizinkan mengubah data satuan itu.',
+        ];
+    }
+}

--- a/app/ExternalApi/Docs/Endpoints/V1/MasterWarehouseCreateDoc.php
+++ b/app/ExternalApi/Docs/Endpoints/V1/MasterWarehouseCreateDoc.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace App\ExternalApi\Docs\Endpoints\V1;
+
+use App\ExternalApi\Docs\ApiEndpointDoc;
+
+/**
+ * Dokumentasi POST /api/external/v1/master/warehouses (API-002 lanjutan).
+ */
+class MasterWarehouseCreateDoc extends ApiEndpointDoc
+{
+    public function key(): string
+    {
+        return 'master-warehouses-create';
+    }
+
+    public function title(): string
+    {
+        return 'Buat Gudang';
+    }
+
+    public function method(): string
+    {
+        return 'POST';
+    }
+
+    public function path(): string
+    {
+        return '/master/warehouses';
+    }
+
+    public function group(): string
+    {
+        return 'master';
+    }
+
+    public function description(): string
+    {
+        return 'Membuat gudang baru. Gudang baru otomatis mendapat baris stok produk dan bahan mentah bernilai 0 di seluruh produk aktif, sama seperti pembuatan lewat halaman admin.';
+    }
+
+    public function bodyParameters(): array
+    {
+        return [
+            ['name' => 'nama', 'type' => 'string', 'required' => true, 'description' => 'Nama gudang. Harus unik di antara gudang yang masih aktif.'],
+            ['name' => 'tipe_nama', 'type' => 'string', 'required' => true, 'description' => 'Nama tipe gudang. Wajib sama persis (tanpa peduli besar/kecil huruf) dengan nama tipe gudang yang sebenarnya untuk tipe_id yang dikirim — dipakai sebagai konfirmasi, bukan disimpan.'],
+            ['name' => 'tipe_id', 'type' => 'integer', 'required' => true, 'description' => 'id tipe gudang, lihat GET /master/warehouse_types.'],
+            ['name' => 'alamat', 'type' => 'string', 'required' => true, 'description' => 'Alamat gudang.'],
+        ];
+    }
+
+    public function requestExample(): ?array
+    {
+        return [
+            'nama' => 'Gudang Surabaya Pusat',
+            'tipe_nama' => 'Gudang Utama',
+            'tipe_id' => 1,
+            'alamat' => 'Jl. Raya Darmo No. 25, Surabaya',
+        ];
+    }
+
+    public function responseExample(): array
+    {
+        return [
+            'success' => true,
+            'data' => [
+                'gudang_id' => 101,
+                'nama' => 'Gudang Surabaya Pusat',
+                'tipe_nama' => 'Gudang Utama',
+                'tipe_id' => 1,
+                'alamat' => 'Jl. Raya Darmo No. 25, Surabaya',
+            ],
+        ];
+    }
+
+    public function errors(): array
+    {
+        return [
+            ['code' => 'validation_failed', 'http_status' => 422, 'message' => 'Salah satu field wajib kosong, atau tipe_nama tidak sesuai dengan tipe_id yang dikirim.'],
+            ['code' => 'duplicate_name', 'http_status' => 422, 'message' => 'Nama gudang sudah dipakai gudang aktif lain.'],
+        ];
+    }
+
+    public function notes(): array
+    {
+        return [
+            'Keempat field wajib diisi, tidak ada yang bersifat opsional.',
+            'GET /master/warehouse_types tidak menyertakan id (lihat catatan pada dokumentasinya), jadi tipe_id yang valid untuk saat ini didapat dari field tipe_id pada GET /master/warehouses, atau dikoordinasikan langsung dengan admin Pegasus.',
+            'gudang_id pada respons adalah pegangan yang dipakai untuk memanggil endpoint ubah (PUT) dan hapus (DELETE) gudang ini.',
+        ];
+    }
+}

--- a/app/ExternalApi/Docs/Endpoints/V1/MasterWarehouseCreateDoc.php
+++ b/app/ExternalApi/Docs/Endpoints/V1/MasterWarehouseCreateDoc.php
@@ -43,8 +43,8 @@ class MasterWarehouseCreateDoc extends ApiEndpointDoc
     {
         return [
             ['name' => 'nama', 'type' => 'string', 'required' => true, 'description' => 'Nama gudang. Harus unik di antara gudang yang masih aktif.'],
-            ['name' => 'tipe_nama', 'type' => 'string', 'required' => true, 'description' => 'Nama tipe gudang. Wajib sama persis (tanpa peduli besar/kecil huruf) dengan nama tipe gudang yang sebenarnya untuk tipe_id yang dikirim — dipakai sebagai konfirmasi, bukan disimpan.'],
-            ['name' => 'tipe_id', 'type' => 'integer', 'required' => true, 'description' => 'id tipe gudang, lihat GET /master/warehouse_types.'],
+            ['name' => 'tipe_nama', 'type' => 'string', 'required' => true, 'description' => 'Nama tipe gudang. Bersifat upsert bersama tipe_id: kalau tipe_id sudah ada, nama tipe itu diganti menjadi tipe_nama ini; kalau belum ada, dipakai sebagai nama tipe baru. Harus unik di antara tipe gudang aktif lain.'],
+            ['name' => 'tipe_id', 'type' => 'integer', 'required' => true, 'description' => 'id tipe gudang. Kalau sudah ada di sistem Pegasus, gudang ini memakai tipe tersebut dan tipe_nama menggantikan namanya. Kalau belum ada, dibuatkan tipe gudang baru dengan id ini juga (bukan id yang di-generate sistem).'],
             ['name' => 'alamat', 'type' => 'string', 'required' => true, 'description' => 'Alamat gudang.'],
         ];
     }
@@ -76,7 +76,7 @@ class MasterWarehouseCreateDoc extends ApiEndpointDoc
     public function errors(): array
     {
         return [
-            ['code' => 'validation_failed', 'http_status' => 422, 'message' => 'Salah satu field wajib kosong, atau tipe_nama tidak sesuai dengan tipe_id yang dikirim.'],
+            ['code' => 'validation_failed', 'http_status' => 422, 'message' => 'Salah satu field wajib kosong, atau tipe_nama sudah dipakai tipe gudang lain (rename ditolak).'],
             ['code' => 'duplicate_name', 'http_status' => 422, 'message' => 'Nama gudang sudah dipakai gudang aktif lain.'],
         ];
     }
@@ -85,7 +85,8 @@ class MasterWarehouseCreateDoc extends ApiEndpointDoc
     {
         return [
             'Keempat field wajib diisi, tidak ada yang bersifat opsional.',
-            'GET /master/warehouse_types tidak menyertakan id (lihat catatan pada dokumentasinya), jadi tipe_id yang valid untuk saat ini didapat dari field tipe_id pada GET /master/warehouses, atau dikoordinasikan langsung dengan admin Pegasus.',
+            'tipe_id/tipe_nama bersifat upsert, bukan sekadar rujukan: mengirim tipe_id yang sudah dipakai gudang lain dengan tipe_nama yang berbeda akan MENGGANTI nama tipe itu untuk seluruh gudang yang memakainya, bukan cuma gudang yang sedang dibuat di panggilan ini.',
+            'Kirim tipe_nama yang sama persis dengan nama tipe yang sudah ada (lihat GET /master/warehouses) kalau tidak bermaksud mengganti namanya.',
             'gudang_id pada respons adalah pegangan yang dipakai untuk memanggil endpoint ubah (PUT) dan hapus (DELETE) gudang ini.',
         ];
     }

--- a/app/ExternalApi/Docs/Endpoints/V1/MasterWarehouseDeleteDoc.php
+++ b/app/ExternalApi/Docs/Endpoints/V1/MasterWarehouseDeleteDoc.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\ExternalApi\Docs\Endpoints\V1;
+
+use App\ExternalApi\Docs\ApiEndpointDoc;
+
+/**
+ * Dokumentasi DELETE /api/external/v1/master/warehouses/{gudang_id} (API-002 lanjutan).
+ */
+class MasterWarehouseDeleteDoc extends ApiEndpointDoc
+{
+    public function key(): string
+    {
+        return 'master-warehouses-delete';
+    }
+
+    public function title(): string
+    {
+        return 'Hapus Gudang';
+    }
+
+    public function method(): string
+    {
+        return 'DELETE';
+    }
+
+    public function path(): string
+    {
+        return '/master/warehouses/{gudang_id}';
+    }
+
+    public function group(): string
+    {
+        return 'master';
+    }
+
+    public function description(): string
+    {
+        return 'Menghapus gudang (soft delete). Ditolak selama gudang masih punya stok produk atau bahan mentah, kecuali force=1 disertakan.';
+    }
+
+    public function pathParameters(): array
+    {
+        return [
+            ['name' => 'gudang_id', 'type' => 'integer', 'required' => true, 'description' => 'id gudang yang akan dihapus, lihat GET /master/warehouses.'],
+        ];
+    }
+
+    public function queryParameters(): array
+    {
+        return [
+            ['name' => 'force', 'type' => 'boolean', 'required' => false, 'description' => 'Kirim force=1 untuk tetap menghapus gudang walau masih ada stok terdaftar di dalamnya.'],
+        ];
+    }
+
+    public function responseExample(): array
+    {
+        return [
+            'success' => true,
+            'data' => [
+                'gudang_id' => 101,
+            ],
+        ];
+    }
+
+    public function errors(): array
+    {
+        return [
+            ['code' => 'not_found', 'http_status' => 404, 'message' => 'Gudang dengan gudang_id tersebut tidak ditemukan (termasuk yang sudah dihapus sebelumnya).'],
+            ['code' => 'warehouse_has_stock', 'http_status' => 409, 'message' => 'Gudang masih punya stok produk/bahan mentah terdaftar. Kirim ulang dengan force=1 untuk tetap menghapus.'],
+        ];
+    }
+
+    public function notes(): array
+    {
+        return [
+            'Ini soft delete: status gudang diubah menjadi 0, bukan baris yang dihapus dari basis data — sama seperti penghapusan lewat halaman admin.',
+            'Akses staf ke gudang ini (staff_warehouses) ikut dilepas, dan baris stok produk/bahan mentah di gudang ini dinonaktifkan.',
+            'Tanpa force=1, penghapusan ditolak (warehouse_has_stock) selama gudang masih punya baris stok bernilai lebih dari 0.',
+        ];
+    }
+}

--- a/app/ExternalApi/Docs/Endpoints/V1/MasterWarehouseListDoc.php
+++ b/app/ExternalApi/Docs/Endpoints/V1/MasterWarehouseListDoc.php
@@ -48,7 +48,6 @@ class MasterWarehouseListDoc extends ApiEndpointDoc
             'success' => true,
             'data' => [
                 [
-                    'id' => 1,
                     'gudang_id' => 1,
                     'nama' => 'Gudang Surabaya',
                     'tipe_nama' => 'Gol A',
@@ -56,7 +55,6 @@ class MasterWarehouseListDoc extends ApiEndpointDoc
                     'alamat' => 'Jl. Surabaya',
                 ],
                 [
-                    'id' => 2,
                     'gudang_id' => 2,
                     'nama' => 'Jakarta Warehouse',
                     'tipe_nama' => 'Gol A',
@@ -74,7 +72,7 @@ class MasterWarehouseListDoc extends ApiEndpointDoc
     {
         return [
             'Endpoint ini tidak menerima parameter apa pun. Seluruh gudang aktif selalu dikembalikan sekaligus.',
-            'gudang_id dan id merujuk nilai yang sama — id gudang pada sistem Pegasus, dan pegangan yang stabil untuk merujuk satu gudang (dipakai sebagai path parameter pada endpoint ubah dan hapus gudang). Pakai salah satunya, bukan nama, karena nama gudang bisa berubah. Keduanya dikembalikan berdampingan untuk kompatibilitas dengan pemanggil yang sudah memakai id lebih dulu.',
+            'gudang_id adalah id gudang pada sistem Pegasus dan merupakan pegangan yang stabil untuk merujuk satu gudang, dipakai sebagai path parameter pada endpoint ubah dan hapus gudang. Pakai gudang_id, bukan nama, karena nama gudang bisa berubah.',
             'Hanya gudang berstatus Aktif yang muncul. Gudang yang dinonaktifkan atau dihapus tidak ikut, jadi gudang yang hilang dari daftar berarti sudah tidak berlaku.',
             'alamat boleh bernilai null bila gudang memang belum diisi alamatnya.',
             'tipe_nama diambil lewat relasi ke tipe gudang, bukan disalin, sehingga selalu mengikuti nama tipe yang berlaku saat ini.',

--- a/app/ExternalApi/Docs/Endpoints/V1/MasterWarehouseListDoc.php
+++ b/app/ExternalApi/Docs/Endpoints/V1/MasterWarehouseListDoc.php
@@ -49,6 +49,7 @@ class MasterWarehouseListDoc extends ApiEndpointDoc
             'data' => [
                 [
                     'id' => 1,
+                    'gudang_id' => 1,
                     'nama' => 'Gudang Surabaya',
                     'tipe_nama' => 'Gol A',
                     'tipe_id' => 1,
@@ -56,6 +57,7 @@ class MasterWarehouseListDoc extends ApiEndpointDoc
                 ],
                 [
                     'id' => 2,
+                    'gudang_id' => 2,
                     'nama' => 'Jakarta Warehouse',
                     'tipe_nama' => 'Gol A',
                     'tipe_id' => 1,
@@ -72,7 +74,7 @@ class MasterWarehouseListDoc extends ApiEndpointDoc
     {
         return [
             'Endpoint ini tidak menerima parameter apa pun. Seluruh gudang aktif selalu dikembalikan sekaligus.',
-            'id adalah id gudang pada sistem Pegasus dan merupakan pegangan yang stabil untuk merujuk satu gudang. Pakai id ini, bukan nama, karena nama gudang bisa berubah.',
+            'gudang_id dan id merujuk nilai yang sama — id gudang pada sistem Pegasus, dan pegangan yang stabil untuk merujuk satu gudang (dipakai sebagai path parameter pada endpoint ubah dan hapus gudang). Pakai salah satunya, bukan nama, karena nama gudang bisa berubah. Keduanya dikembalikan berdampingan untuk kompatibilitas dengan pemanggil yang sudah memakai id lebih dulu.',
             'Hanya gudang berstatus Aktif yang muncul. Gudang yang dinonaktifkan atau dihapus tidak ikut, jadi gudang yang hilang dari daftar berarti sudah tidak berlaku.',
             'alamat boleh bernilai null bila gudang memang belum diisi alamatnya.',
             'tipe_nama diambil lewat relasi ke tipe gudang, bukan disalin, sehingga selalu mengikuti nama tipe yang berlaku saat ini.',

--- a/app/ExternalApi/Docs/Endpoints/V1/MasterWarehouseUpdateDoc.php
+++ b/app/ExternalApi/Docs/Endpoints/V1/MasterWarehouseUpdateDoc.php
@@ -50,8 +50,8 @@ class MasterWarehouseUpdateDoc extends ApiEndpointDoc
     {
         return [
             ['name' => 'nama', 'type' => 'string', 'required' => true, 'description' => 'Nama gudang. Harus unik di antara gudang aktif lain (di luar gudang ini sendiri).'],
-            ['name' => 'tipe_nama', 'type' => 'string', 'required' => true, 'description' => 'Nama tipe gudang. Wajib sama persis (tanpa peduli besar/kecil huruf) dengan nama tipe gudang yang sebenarnya untuk tipe_id yang dikirim — dipakai sebagai konfirmasi, bukan disimpan.'],
-            ['name' => 'tipe_id', 'type' => 'integer', 'required' => true, 'description' => 'id tipe gudang, lihat GET /master/warehouse_types.'],
+            ['name' => 'tipe_nama', 'type' => 'string', 'required' => true, 'description' => 'Nama tipe gudang. Bersifat upsert bersama tipe_id: kalau tipe_id sudah ada, nama tipe itu diganti menjadi tipe_nama ini; kalau belum ada, dipakai sebagai nama tipe baru. Harus unik di antara tipe gudang aktif lain.'],
+            ['name' => 'tipe_id', 'type' => 'integer', 'required' => true, 'description' => 'id tipe gudang. Kalau sudah ada di sistem Pegasus, gudang ini memakai tipe tersebut dan tipe_nama menggantikan namanya. Kalau belum ada, dibuatkan tipe gudang baru dengan id ini juga (bukan id yang di-generate sistem).'],
             ['name' => 'alamat', 'type' => 'string', 'required' => true, 'description' => 'Alamat gudang.'],
         ];
     }
@@ -84,7 +84,7 @@ class MasterWarehouseUpdateDoc extends ApiEndpointDoc
     {
         return [
             ['code' => 'not_found', 'http_status' => 404, 'message' => 'Gudang dengan gudang_id tersebut tidak ditemukan (termasuk yang sudah dihapus).'],
-            ['code' => 'validation_failed', 'http_status' => 422, 'message' => 'Salah satu field wajib kosong, atau tipe_nama tidak sesuai dengan tipe_id yang dikirim.'],
+            ['code' => 'validation_failed', 'http_status' => 422, 'message' => 'Salah satu field wajib kosong, atau tipe_nama sudah dipakai tipe gudang lain (rename ditolak).'],
             ['code' => 'duplicate_name', 'http_status' => 422, 'message' => 'Nama gudang sudah dipakai gudang aktif lain.'],
         ];
     }
@@ -94,6 +94,8 @@ class MasterWarehouseUpdateDoc extends ApiEndpointDoc
         return [
             'Keempat field body wajib diisi meski hanya satu yang berubah — tidak ada partial update.',
             'Gudang berstatus Non-Aktif tetap bisa diubah (sama seperti halaman admin); yang tidak ditemukan hanya gudang yang sudah dihapus.',
+            'tipe_id/tipe_nama bersifat upsert, bukan sekadar rujukan: mengirim tipe_id yang sudah dipakai gudang lain dengan tipe_nama yang berbeda akan MENGGANTI nama tipe itu untuk seluruh gudang yang memakainya, bukan cuma gudang yang sedang diubah di panggilan ini.',
+            'Kirim tipe_nama yang sama persis dengan nama tipe yang sudah ada (lihat GET /master/warehouses) kalau tidak bermaksud mengganti namanya.',
         ];
     }
 }

--- a/app/ExternalApi/Docs/Endpoints/V1/MasterWarehouseUpdateDoc.php
+++ b/app/ExternalApi/Docs/Endpoints/V1/MasterWarehouseUpdateDoc.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace App\ExternalApi\Docs\Endpoints\V1;
+
+use App\ExternalApi\Docs\ApiEndpointDoc;
+
+/**
+ * Dokumentasi PUT /api/external/v1/master/warehouses/{gudang_id} (API-002 lanjutan).
+ */
+class MasterWarehouseUpdateDoc extends ApiEndpointDoc
+{
+    public function key(): string
+    {
+        return 'master-warehouses-update';
+    }
+
+    public function title(): string
+    {
+        return 'Ubah Gudang';
+    }
+
+    public function method(): string
+    {
+        return 'PUT';
+    }
+
+    public function path(): string
+    {
+        return '/master/warehouses/{gudang_id}';
+    }
+
+    public function group(): string
+    {
+        return 'master';
+    }
+
+    public function description(): string
+    {
+        return 'Mengubah data gudang yang sudah ada. Bersifat penggantian penuh — seluruh field wajib dikirim meski hanya satu yang berubah.';
+    }
+
+    public function pathParameters(): array
+    {
+        return [
+            ['name' => 'gudang_id', 'type' => 'integer', 'required' => true, 'description' => 'id gudang yang akan diubah, lihat GET /master/warehouses.'],
+        ];
+    }
+
+    public function bodyParameters(): array
+    {
+        return [
+            ['name' => 'nama', 'type' => 'string', 'required' => true, 'description' => 'Nama gudang. Harus unik di antara gudang aktif lain (di luar gudang ini sendiri).'],
+            ['name' => 'tipe_nama', 'type' => 'string', 'required' => true, 'description' => 'Nama tipe gudang. Wajib sama persis (tanpa peduli besar/kecil huruf) dengan nama tipe gudang yang sebenarnya untuk tipe_id yang dikirim — dipakai sebagai konfirmasi, bukan disimpan.'],
+            ['name' => 'tipe_id', 'type' => 'integer', 'required' => true, 'description' => 'id tipe gudang, lihat GET /master/warehouse_types.'],
+            ['name' => 'alamat', 'type' => 'string', 'required' => true, 'description' => 'Alamat gudang.'],
+        ];
+    }
+
+    public function requestExample(): ?array
+    {
+        return [
+            'nama' => 'Gudang Surabaya Pusat',
+            'tipe_nama' => 'Gudang Utama',
+            'tipe_id' => 1,
+            'alamat' => 'Jl. Raya Darmo No. 25, Surabaya',
+        ];
+    }
+
+    public function responseExample(): array
+    {
+        return [
+            'success' => true,
+            'data' => [
+                'gudang_id' => 101,
+                'nama' => 'Gudang Surabaya Pusat',
+                'tipe_nama' => 'Gudang Utama',
+                'tipe_id' => 1,
+                'alamat' => 'Jl. Raya Darmo No. 25, Surabaya',
+            ],
+        ];
+    }
+
+    public function errors(): array
+    {
+        return [
+            ['code' => 'not_found', 'http_status' => 404, 'message' => 'Gudang dengan gudang_id tersebut tidak ditemukan (termasuk yang sudah dihapus).'],
+            ['code' => 'validation_failed', 'http_status' => 422, 'message' => 'Salah satu field wajib kosong, atau tipe_nama tidak sesuai dengan tipe_id yang dikirim.'],
+            ['code' => 'duplicate_name', 'http_status' => 422, 'message' => 'Nama gudang sudah dipakai gudang aktif lain.'],
+        ];
+    }
+
+    public function notes(): array
+    {
+        return [
+            'Keempat field body wajib diisi meski hanya satu yang berubah — tidak ada partial update.',
+            'Gudang berstatus Non-Aktif tetap bisa diubah (sama seperti halaman admin); yang tidak ditemukan hanya gudang yang sudah dihapus.',
+        ];
+    }
+}

--- a/app/Http/Controllers/ExternalApi/V1/MasterDataController.php
+++ b/app/Http/Controllers/ExternalApi/V1/MasterDataController.php
@@ -5,7 +5,6 @@ namespace App\Http\Controllers\ExternalApi\V1;
 use App\ExternalApi\Http\ApiResponse;
 use App\Http\Controllers\Controller;
 use App\Models\CashCategory;
-use App\Models\Staff;
 use App\Models\Unit;
 use App\Models\WarehouseType;
 
@@ -15,10 +14,11 @@ use App\Models\WarehouseType;
  * Hanya baca. Tidak ada pembuatan, perubahan, maupun penghapusan lewat jalur
  * ini — perubahan data master tetap dilakukan lewat halaman admin.
  *
- * Pengecualian: gudang (warehouses) sekarang juga punya create/update/delete
- * lewat External API (API-002 lanjutan). Endpoint-endpoint itu sengaja
- * ditaruh di controller terpisah, MasterWarehouseController, supaya
- * controller ini tetap murni baca-saja seperti didokumentasikan di sini.
+ * Pengecualian: gudang (warehouses) dan sales sekarang juga punya
+ * create/update/delete lewat External API (API-002 lanjutan). Endpoint-
+ * endpoint itu sengaja ditaruh di controller terpisah, masing-masing
+ * MasterWarehouseController dan MasterSalesController, supaya controller ini
+ * tetap murni baca-saja seperti didokumentasikan di sini.
  *
  * Autentikasi, pencatatan permintaan, dan bentuk respons seluruhnya diurus
  * lapisan platform (SPEC-001), jadi controller ini benar-benar hanya memilih
@@ -90,33 +90,6 @@ class MasterDataController extends Controller
                 'status' => (int) $type->status,
             ])->all(),
             ['total' => $types->count()],
-        );
-    }
-
-    /**
-     * GET /api/external/v1/master/sales
-     *
-     * Sales adalah staf yang perannya mengandung kata "sales". Spesifikasi
-     * API-002 tidak menetapkan bentuk keluaran untuk endpoint ini, jadi
-     * bentuknya diturunkan dari kolom yang ada — dan staff_id memakai nama
-     * yang sama dengan yang diminta endpoint pembayaran kas (API-005), supaya
-     * hasil endpoint ini bisa langsung dipakai di sana.
-     */
-    public function sales()
-    {
-        $sales = (new Staff())->getSalesForExternalApi();
-
-        return ApiResponse::success(
-            $sales->map(static fn ($staff) => [
-                'staff_id' => (int) $staff->staff_id,
-                'nama' => (string) $staff->staff_name,
-                'kode' => $staff->staff_code,
-                'email' => $staff->staff_email,
-                'telepon' => $staff->staff_phone,
-                'alamat' => $staff->staff_address,
-                'role' => (string) $staff->role_name,
-            ])->all(),
-            ['total' => $sales->count()],
         );
     }
 }

--- a/app/Http/Controllers/ExternalApi/V1/MasterDataController.php
+++ b/app/Http/Controllers/ExternalApi/V1/MasterDataController.php
@@ -7,7 +7,6 @@ use App\Http\Controllers\Controller;
 use App\Models\CashCategory;
 use App\Models\Staff;
 use App\Models\Unit;
-use App\Models\Warehouse;
 use App\Models\WarehouseType;
 
 /**
@@ -16,14 +15,19 @@ use App\Models\WarehouseType;
  * Hanya baca. Tidak ada pembuatan, perubahan, maupun penghapusan lewat jalur
  * ini — perubahan data master tetap dilakukan lewat halaman admin.
  *
+ * Pengecualian: gudang (warehouses) sekarang juga punya create/update/delete
+ * lewat External API (API-002 lanjutan). Endpoint-endpoint itu sengaja
+ * ditaruh di controller terpisah, MasterWarehouseController, supaya
+ * controller ini tetap murni baca-saja seperti didokumentasikan di sini.
+ *
  * Autentikasi, pencatatan permintaan, dan bentuk respons seluruhnya diurus
  * lapisan platform (SPEC-001), jadi controller ini benar-benar hanya memilih
  * data dan menyusun bentuk keluarannya.
  *
- * Kedua endpoint sengaja tidak menerima parameter apa pun. Tabelnya kecil
- * (belasan sampai puluhan baris) dan spesifikasi API-001 secara tegas
- * mengeluarkan penyaringan, pencarian, dan paginasi dari lingkupnya — jadi
- * respons selalu berupa daftar utuh data aktif.
+ * Endpoint di controller ini sengaja tidak menerima parameter apa pun.
+ * Tabelnya kecil (belasan sampai puluhan baris) dan spesifikasi API-001
+ * secara tegas mengeluarkan penyaringan, pencarian, dan paginasi dari
+ * lingkupnya — jadi respons selalu berupa daftar utuh data aktif.
  */
 class MasterDataController extends Controller
 {
@@ -67,31 +71,6 @@ class MasterDataController extends Controller
                 'cc_type' => (string) $category->cc_type,
             ])->all(),
             ['total' => $categories->count()],
-        );
-    }
-
-    /**
-     * GET /api/external/v1/master/warehouses
-     *
-     * Mengikuti kontrak API-002 (nama, tipe_nama, tipe_id, alamat) ditambah id
-     * gudang. Kontrak aslinya tidak menyebut id, padahal tanpa itu pemanggil
-     * hanya bisa membaca daftarnya dan tidak punya pegangan untuk merujuk satu
-     * gudang tertentu — nama pun bisa berubah sewaktu-waktu. Penambahan ini
-     * disetujui pemilik produk.
-     */
-    public function warehouses()
-    {
-        $warehouses = (new Warehouse())->getWarehouseForExternalApi();
-
-        return ApiResponse::success(
-            $warehouses->map(static fn ($warehouse) => [
-                'id' => (int) $warehouse->id,
-                'nama' => (string) $warehouse->warehouse_name,
-                'tipe_nama' => (string) ($warehouse->type->warehouse_type_name ?? ''),
-                'tipe_id' => (int) $warehouse->warehouse_type_id,
-                'alamat' => $warehouse->warehouse_address,
-            ])->all(),
-            ['total' => $warehouses->count()],
         );
     }
 

--- a/app/Http/Controllers/ExternalApi/V1/MasterDataController.php
+++ b/app/Http/Controllers/ExternalApi/V1/MasterDataController.php
@@ -5,7 +5,6 @@ namespace App\Http\Controllers\ExternalApi\V1;
 use App\ExternalApi\Http\ApiResponse;
 use App\Http\Controllers\Controller;
 use App\Models\CashCategory;
-use App\Models\Unit;
 use App\Models\WarehouseType;
 
 /**
@@ -14,11 +13,12 @@ use App\Models\WarehouseType;
  * Hanya baca. Tidak ada pembuatan, perubahan, maupun penghapusan lewat jalur
  * ini — perubahan data master tetap dilakukan lewat halaman admin.
  *
- * Pengecualian: gudang (warehouses) dan sales sekarang juga punya
- * create/update/delete lewat External API (API-002 lanjutan). Endpoint-
- * endpoint itu sengaja ditaruh di controller terpisah, masing-masing
- * MasterWarehouseController dan MasterSalesController, supaya controller ini
- * tetap murni baca-saja seperti didokumentasikan di sini.
+ * Pengecualian: gudang (warehouses), sales, dan satuan (units) sekarang
+ * juga punya create/update/delete lewat External API (API-001/API-002
+ * lanjutan). Endpoint-endpoint itu sengaja ditaruh di controller terpisah,
+ * masing-masing MasterWarehouseController, MasterSalesController, dan
+ * MasterUnitController, supaya controller ini tetap murni baca-saja seperti
+ * didokumentasikan di sini.
  *
  * Autentikasi, pencatatan permintaan, dan bentuk respons seluruhnya diurus
  * lapisan platform (SPEC-001), jadi controller ini benar-benar hanya memilih
@@ -31,28 +31,6 @@ use App\Models\WarehouseType;
  */
 class MasterDataController extends Controller
 {
-    /**
-     * GET /api/external/v1/master/units
-     *
-     * Nama field mengikuti kontrak satuan yang sudah ada pada dokumen
-     * integrasi PMO (§8.1 pada 202607260130-product-sync-flow.design.md),
-     * supaya kedua sistem memakai istilah yang sama.
-     */
-    public function units()
-    {
-        $units = (new Unit())->getUnitForExternalApi();
-
-        return ApiResponse::success(
-            $units->map(static fn ($unit) => [
-                'unit_id' => (int) $unit->unit_id,
-                'ref_unit_id' => $unit->ref_unit_id !== null ? (int) $unit->ref_unit_id : null,
-                'unit_name' => (string) $unit->unit_name,
-                'unit_short_name' => (string) $unit->unit_short_name,
-            ])->all(),
-            ['total' => $units->count()],
-        );
-    }
-
     /**
      * GET /api/external/v1/master/cash_categories
      *

--- a/app/Http/Controllers/ExternalApi/V1/MasterSalesController.php
+++ b/app/Http/Controllers/ExternalApi/V1/MasterSalesController.php
@@ -8,6 +8,8 @@ use App\Models\Role;
 use App\Models\Staff;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
 
 /**
  * Data master sales untuk sistem eksternal (API-002 lanjutan).
@@ -19,17 +21,25 @@ use Illuminate\Http\Request;
  * "Sales" bukan tabel tersendiri, melainkan staf (staffs) yang perannya
  * bernama "sales" (lihat Staff::getSalesForExternalApi()). Karena itu
  * endpoint ini HANYA boleh menyentuh staf yang perannya cocok dan masih
- * berstatus aktif — lihat isManagedSales(). staff_id yang menunjuk staf lain
- * (Admin, Direksi, dst.) atau staf yang sudah dihapus lewat endpoint ini
- * diperlakukan sebagai not_found, BUKAN diizinkan mengubah/menimpa peran
- * atau profil staf itu. Ini sengaja: pemanggil luar tidak boleh bisa
- * mengubah staf yang bukan urusannya walau staff_id yang dikirim valid dan
- * memang ada di sistem.
+ * berstatus aktif — lihat isManagedSales(). staff_id internal yang menunjuk
+ * staf lain (Admin, Direksi, dst.) atau staf yang sudah dihapus lewat
+ * endpoint ini diperlakukan sebagai not_found, BUKAN diizinkan mengubah/
+ * menimpa profil staf itu.
  *
- * Staf baru yang dibuat lewat endpoint ini TIDAK mendapat staff_username
- * atau staff_password (dibiarkan null) — baris yang dibuat adalah profil
- * sinkron dari sistem luar, bukan akun login ke Pegasus. Kedua kolom itu
- * memang nullable di basis data.
+ * DUA id yang berbeda dipakai di sini, jangan tertukar:
+ *   - staffs.staff_id  : id asli Pegasus, auto-increment, tidak pernah
+ *                        ditentukan pemanggil.
+ *   - external_ref_id  : id milik sistem pemanggil sendiri (nullable,
+ *                        unik). Inilah yang disebut "staff_id" pada BODY
+ *                        create dan pada PATH ubah/hapus — sengaja memakai
+ *                        nama yang sama dengan field di respons GET
+ *                        (lihat presentRow()), tapi maknanya rujukan
+ *                        eksternal, BUKAN staffs.staff_id.
+ *
+ * Staf baru yang dibuat lewat POST TIDAK mendapat staff_username atau
+ * staff_password (dibiarkan null) — baris yang dibuat adalah profil sinkron
+ * dari sistem luar, bukan akun login ke Pegasus. Kedua kolom itu memang
+ * nullable di basis data.
  */
 class MasterSalesController extends Controller
 {
@@ -49,36 +59,41 @@ class MasterSalesController extends Controller
     /**
      * POST /api/external/v1/master/sales
      *
-     * Upsert seperti tipe_id pada gudang: staff_id yang sudah ada (dan
-     * masih berperan sales aktif) diperbarui di tempat; staff_id yang belum
-     * ada dibuatkan staf baru dengan id PERSIS yang dikirim (bukan id
-     * auto-increment berikutnya), berperan Sales.
+     * Selalu membuat baris staf baru (id Pegasus-nya auto-increment, tidak
+     * pernah ditentukan pemanggil) dengan external_ref_id = body.staff_id.
+     * Bukan upsert: external_ref_id yang sudah dipakai sales lain ditolak
+     * sebagai duplicate_ref_id — pakai PUT (ubah) untuk memperbarui sales
+     * yang rujukannya sudah ada, atau PATCH untuk menghubungkan rujukan ke
+     * staf Pegasus yang sudah ada.
      */
     public function store(Request $request): JsonResponse
     {
-        $data = $this->validatePayload($request, true);
-        $staffId = (int) $data['staff_id'];
+        $data = $this->validateCreatePayload($request);
+        $refId = (string) $data['staff_id'];
 
-        $existing = Staff::find($staffId);
-
-        if ($existing !== null) {
-            if (! $this->isManagedSales($existing)) {
-                return $this->notFoundError($staffId);
-            }
-
-            $this->applyPayload($existing, $data);
-            $existing->save();
-
-            return ApiResponse::success($this->present($existing));
+        if (Staff::where('external_ref_id', $refId)->exists()) {
+            return $this->duplicateRefError($refId);
         }
 
         $staff = new Staff();
-        $staff->staff_id = $staffId;
+        $staff->external_ref_id = $refId;
         $staff->role_id = $this->salesRoleId();
         $staff->status = 1;
         $staff->created_by = null;
         $this->applyPayload($staff, $data);
-        $staff->save();
+
+        try {
+            $staff->save();
+        } catch (\Illuminate\Database\QueryException $e) {
+            // Dua permintaan dengan external_ref_id baru yang sama, nyaris
+            // bersamaan: keduanya sama-sama tidak menemukan baris di atas,
+            // lalu unique index menolak yang kalah cepat.
+            if (Staff::where('external_ref_id', $refId)->exists()) {
+                return $this->duplicateRefError($refId);
+            }
+
+            throw $e;
+        }
 
         return ApiResponse::success($this->present($staff), [], 201);
     }
@@ -86,19 +101,20 @@ class MasterSalesController extends Controller
     /**
      * PUT /api/external/v1/master/sales/{staff_id}
      *
-     * Beda dengan POST: staff_id di sini murni rujukan, tidak pernah
-     * membuat staf baru. staff_id yang tidak ditemukan (atau ditemukan tapi
+     * {staff_id} di sini adalah external_ref_id (rujukan sistem pemanggil),
+     * BUKAN id internal Pegasus — lihat catatan kelas. Tidak pernah membuat
+     * sales baru; external_ref_id yang tidak ditemukan (atau ditemukan tapi
      * bukan sales aktif) selalu dijawab not_found.
      */
-    public function update(Request $request, int $staff_id): JsonResponse
+    public function update(Request $request, string $staff_id): JsonResponse
     {
-        $staff = Staff::find($staff_id);
+        $staff = $this->findManagedByRef($staff_id);
 
-        if ($staff === null || ! $this->isManagedSales($staff)) {
-            return $this->notFoundError($staff_id);
+        if ($staff === null) {
+            return $this->notFoundByRefError($staff_id);
         }
 
-        $data = $this->validatePayload($request, false);
+        $data = $this->validateProfilePayload($request);
         $this->applyPayload($staff, $data);
         $staff->save();
 
@@ -108,20 +124,68 @@ class MasterSalesController extends Controller
     /**
      * DELETE /api/external/v1/master/sales/{staff_id}
      *
-     * Soft delete (status = 0), memakai ulang Staff::deletestaff() — sama
-     * persis dengan yang dipakai halaman admin (UserController::deleteStaff).
+     * {staff_id} adalah external_ref_id, sama seperti PUT. Soft delete
+     * (status = 0), memakai ulang Staff::deletestaff() — sama persis
+     * dengan yang dipakai halaman admin (UserController::deleteStaff).
+     * external_ref_id TIDAK dilepas oleh operasi ini, jadi id yang sudah
+     * dihapus lewat endpoint ini tidak bisa dipakai ulang lewat POST
+     * (baris lama masih memegangnya, hanya berstatus nonaktif).
      */
-    public function destroy(int $staff_id): JsonResponse
+    public function destroy(string $staff_id): JsonResponse
+    {
+        $staff = $this->findManagedByRef($staff_id);
+
+        if ($staff === null) {
+            return $this->notFoundByRefError($staff_id);
+        }
+
+        (new Staff())->deletestaff(['staff_id' => $staff->staff_id]);
+
+        return ApiResponse::success(['staff_id' => $staff_id]);
+    }
+
+    /**
+     * PATCH /api/external/v1/master/sales/{staff_id}
+     *
+     * {staff_id} di sini KEBALIKANNYA dari PUT/DELETE: id internal Pegasus,
+     * bukan external_ref_id — dipakai untuk menghubungkan staf yang sudah
+     * ada (dibuat lewat halaman admin, sudah berperan Sales) dengan rujukan
+     * milik sistem pemanggil, tanpa perlu membuat baris baru.
+     *
+     * Menimpa link yang sudah ada diperbolehkan. Kalau map_staff_id yang
+     * dikirim sedang dipegang staf LAIN, rujukan itu dilepas dulu dari staf
+     * itu (external_ref_id-nya jadi null) sebelum dipasang ke staf ini —
+     * "dipindah", bukan ditolak sebagai duplikat — supaya keunikan
+     * external_ref_id tetap terjaga tanpa membuat pemanggil harus melepas
+     * link lama secara manual lebih dulu.
+     */
+    public function patch(Request $request, int $staff_id): JsonResponse
     {
         $staff = Staff::find($staff_id);
 
         if ($staff === null || ! $this->isManagedSales($staff)) {
-            return $this->notFoundError($staff_id);
+            return $this->notFoundByInternalIdError($staff_id);
         }
 
-        (new Staff())->deletestaff(['staff_id' => $staff_id]);
+        $data = $request->validate([
+            'map_staff_id' => ['required', 'string', 'max:191'],
+        ]);
+        $mapStaffId = trim($data['map_staff_id']);
 
-        return ApiResponse::success(['staff_id' => $staff_id]);
+        if ($mapStaffId === '') {
+            $this->fail('map_staff_id', 'map_staff_id tidak boleh kosong.');
+        }
+
+        DB::transaction(function () use ($staff, $mapStaffId) {
+            Staff::where('external_ref_id', $mapStaffId)
+                ->where('staff_id', '!=', $staff->staff_id)
+                ->update(['external_ref_id' => null]);
+
+            $staff->external_ref_id = $mapStaffId;
+            $staff->save();
+        });
+
+        return ApiResponse::success($this->present($staff->fresh()));
     }
 
     /* ------------------------------------------------------------------ */
@@ -129,30 +193,50 @@ class MasterSalesController extends Controller
     /* ------------------------------------------------------------------ */
 
     /**
-     * staff_id hanya wajib pada body POST — pada PUT nilainya berasal dari
-     * path, bukan body (lihat update()).
-     *
-     * nama_belakang dan alamat bersifat nullable: kalau tidak dikirim,
-     * nilainya disimpan/ditimpa jadi null/kosong, bukan mempertahankan
-     * nilai lama — body selalu dianggap representasi penuh staf ini, sama
-     * seperti endpoint gudang.
+     * staff_id (POST) adalah external_ref_id, boleh dikirim sebagai angka
+     * atau teks (sistem lain bisa punya id alfanumerik) — divalidasi lewat
+     * closure, bukan aturan 'string', supaya angka JSON polos seperti pada
+     * contoh (staff_id: 2) tetap diterima dan disimpan sebagai teks.
      *
      * @return array<string, mixed>
      */
-    private function validatePayload(Request $request, bool $requireStaffId): array
+    private function validateCreatePayload(Request $request): array
     {
         $rules = [
+            'staff_id' => ['required', function (string $attribute, $value, \Closure $fail) {
+                if (! is_string($value) && ! is_int($value)) {
+                    $fail('staff_id wajib berupa teks atau angka.');
+                }
+            }],
+        ] + $this->profileRules();
+
+        return $request->validate($rules);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function validateProfilePayload(Request $request): array
+    {
+        return $request->validate($this->profileRules());
+    }
+
+    /**
+     * nama_belakang dan alamat bersifat nullable: kalau tidak dikirim,
+     * nilainya disimpan/ditimpa jadi null/kosong, bukan mempertahankan
+     * nilai lama — body selalu dianggap representasi penuh sales ini, sama
+     * seperti endpoint gudang.
+     *
+     * @return array<string, array<int, mixed>>
+     */
+    private function profileRules(): array
+    {
+        return [
             'nama_depan' => ['required', 'string', 'max:120'],
             'nama_belakang' => ['nullable', 'string', 'max:120'],
             'email' => ['required', 'email', 'max:255'],
             'alamat' => ['nullable', 'string'],
         ];
-
-        if ($requireStaffId) {
-            $rules['staff_id'] = ['required', 'integer', 'min:1'];
-        }
-
-        return $request->validate($rules);
     }
 
     /**
@@ -191,6 +275,13 @@ class MasterSalesController extends Controller
             ->exists();
     }
 
+    private function findManagedByRef(string $refId): ?Staff
+    {
+        $staff = Staff::where('external_ref_id', $refId)->first();
+
+        return ($staff !== null && $this->isManagedSales($staff)) ? $staff : null;
+    }
+
     /**
      * id peran "Sales" dipakai saat membuat staf baru lewat POST.
      *
@@ -214,12 +305,20 @@ class MasterSalesController extends Controller
         return (int) $roleIds->first();
     }
 
+    private function fail(string $field, string $message): void
+    {
+        throw ValidationException::withMessages([$field => [$message]]);
+    }
+
     /* ------------------------------------------------------------------ */
     /* Respons                                                             */
     /* ------------------------------------------------------------------ */
 
     /**
-     * Bentuk respons create/update: hanya field yang dikelola endpoint ini.
+     * Bentuk respons create/update/patch: id internal Pegasus DAN
+     * external_ref_id sekaligus, supaya pemanggil yang baru membuat sales
+     * lewat POST bisa tahu id internalnya tanpa panggilan GET terpisah
+     * (dibutuhkan seandainya nanti perlu PATCH).
      *
      * @return array<string, mixed>
      */
@@ -228,7 +327,8 @@ class MasterSalesController extends Controller
         [$namaDepan, $namaBelakang] = $this->splitName((string) $staff->staff_name);
 
         return [
-            'staff_id' => (int) $staff->staff_id,
+            'id' => (int) $staff->staff_id,
+            'staff_id' => $staff->external_ref_id,
             'nama_depan' => $namaDepan,
             'nama_belakang' => $namaBelakang,
             'email' => $staff->staff_email,
@@ -237,11 +337,10 @@ class MasterSalesController extends Controller
     }
 
     /**
-     * Bentuk respons daftar (GET): field lama (nama, kode, telepon, role)
-     * dipertahankan supaya pemanggil yang sudah ada tidak putus, ditambah
-     * nama_depan/nama_belakang supaya sejalan dengan bentuk create/update —
-     * sama seperti gudang_id ditambahkan berdampingan dengan id pada daftar
-     * gudang.
+     * Bentuk respons daftar (GET). id = id internal Pegasus (dulu bernama
+     * staff_id sebelum endpoint create/update/delete/patch ini ada);
+     * staff_id sekarang berarti external_ref_id, boleh null kalau staf itu
+     * belum pernah dihubungkan ke sistem eksternal mana pun.
      *
      * @return array<string, mixed>
      */
@@ -250,7 +349,8 @@ class MasterSalesController extends Controller
         [$namaDepan, $namaBelakang] = $this->splitName((string) $staff->staff_name);
 
         return [
-            'staff_id' => (int) $staff->staff_id,
+            'id' => (int) $staff->staff_id,
+            'staff_id' => $staff->external_ref_id,
             'nama' => (string) $staff->staff_name,
             'nama_depan' => $namaDepan,
             'nama_belakang' => $namaBelakang,
@@ -285,12 +385,30 @@ class MasterSalesController extends Controller
         return [$parts[0], $parts[1] ?? null];
     }
 
-    private function notFoundError(int $staffId): JsonResponse
+    private function notFoundByRefError(string $refId): JsonResponse
     {
         return ApiResponse::error(
             ApiResponse::ERROR_NOT_FOUND,
-            'Sales dengan staff_id '.$staffId.' tidak ditemukan.',
+            'Sales dengan staff_id (external_ref_id) "'.$refId.'" tidak ditemukan.',
             404,
+        );
+    }
+
+    private function notFoundByInternalIdError(int $staffId): JsonResponse
+    {
+        return ApiResponse::error(
+            ApiResponse::ERROR_NOT_FOUND,
+            'Staf dengan id '.$staffId.' tidak ditemukan atau bukan sales aktif.',
+            404,
+        );
+    }
+
+    private function duplicateRefError(string $refId): JsonResponse
+    {
+        return ApiResponse::error(
+            'duplicate_ref_id',
+            'staff_id (external_ref_id) "'.$refId.'" sudah dipakai sales lain.',
+            422,
         );
     }
 }

--- a/app/Http/Controllers/ExternalApi/V1/MasterSalesController.php
+++ b/app/Http/Controllers/ExternalApi/V1/MasterSalesController.php
@@ -1,0 +1,296 @@
+<?php
+
+namespace App\Http\Controllers\ExternalApi\V1;
+
+use App\ExternalApi\Http\ApiResponse;
+use App\Http\Controllers\Controller;
+use App\Models\Role;
+use App\Models\Staff;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+/**
+ * Data master sales untuk sistem eksternal (API-002 lanjutan).
+ *
+ * Beda dengan MasterDataController: sales di sini boleh dibuat, diubah, dan
+ * dihapus lewat External API, bukan cuma dibaca — sama alasannya dengan
+ * kenapa MasterWarehouseController dipisah dari MasterDataController.
+ *
+ * "Sales" bukan tabel tersendiri, melainkan staf (staffs) yang perannya
+ * bernama "sales" (lihat Staff::getSalesForExternalApi()). Karena itu
+ * endpoint ini HANYA boleh menyentuh staf yang perannya cocok dan masih
+ * berstatus aktif — lihat isManagedSales(). staff_id yang menunjuk staf lain
+ * (Admin, Direksi, dst.) atau staf yang sudah dihapus lewat endpoint ini
+ * diperlakukan sebagai not_found, BUKAN diizinkan mengubah/menimpa peran
+ * atau profil staf itu. Ini sengaja: pemanggil luar tidak boleh bisa
+ * mengubah staf yang bukan urusannya walau staff_id yang dikirim valid dan
+ * memang ada di sistem.
+ *
+ * Staf baru yang dibuat lewat endpoint ini TIDAK mendapat staff_username
+ * atau staff_password (dibiarkan null) — baris yang dibuat adalah profil
+ * sinkron dari sistem luar, bukan akun login ke Pegasus. Kedua kolom itu
+ * memang nullable di basis data.
+ */
+class MasterSalesController extends Controller
+{
+    /**
+     * GET /api/external/v1/master/sales
+     */
+    public function index(): JsonResponse
+    {
+        $sales = (new Staff())->getSalesForExternalApi();
+
+        return ApiResponse::success(
+            $sales->map(fn ($staff) => $this->presentRow($staff))->all(),
+            ['total' => $sales->count()],
+        );
+    }
+
+    /**
+     * POST /api/external/v1/master/sales
+     *
+     * Upsert seperti tipe_id pada gudang: staff_id yang sudah ada (dan
+     * masih berperan sales aktif) diperbarui di tempat; staff_id yang belum
+     * ada dibuatkan staf baru dengan id PERSIS yang dikirim (bukan id
+     * auto-increment berikutnya), berperan Sales.
+     */
+    public function store(Request $request): JsonResponse
+    {
+        $data = $this->validatePayload($request, true);
+        $staffId = (int) $data['staff_id'];
+
+        $existing = Staff::find($staffId);
+
+        if ($existing !== null) {
+            if (! $this->isManagedSales($existing)) {
+                return $this->notFoundError($staffId);
+            }
+
+            $this->applyPayload($existing, $data);
+            $existing->save();
+
+            return ApiResponse::success($this->present($existing));
+        }
+
+        $staff = new Staff();
+        $staff->staff_id = $staffId;
+        $staff->role_id = $this->salesRoleId();
+        $staff->status = 1;
+        $staff->created_by = null;
+        $this->applyPayload($staff, $data);
+        $staff->save();
+
+        return ApiResponse::success($this->present($staff), [], 201);
+    }
+
+    /**
+     * PUT /api/external/v1/master/sales/{staff_id}
+     *
+     * Beda dengan POST: staff_id di sini murni rujukan, tidak pernah
+     * membuat staf baru. staff_id yang tidak ditemukan (atau ditemukan tapi
+     * bukan sales aktif) selalu dijawab not_found.
+     */
+    public function update(Request $request, int $staff_id): JsonResponse
+    {
+        $staff = Staff::find($staff_id);
+
+        if ($staff === null || ! $this->isManagedSales($staff)) {
+            return $this->notFoundError($staff_id);
+        }
+
+        $data = $this->validatePayload($request, false);
+        $this->applyPayload($staff, $data);
+        $staff->save();
+
+        return ApiResponse::success($this->present($staff));
+    }
+
+    /**
+     * DELETE /api/external/v1/master/sales/{staff_id}
+     *
+     * Soft delete (status = 0), memakai ulang Staff::deletestaff() — sama
+     * persis dengan yang dipakai halaman admin (UserController::deleteStaff).
+     */
+    public function destroy(int $staff_id): JsonResponse
+    {
+        $staff = Staff::find($staff_id);
+
+        if ($staff === null || ! $this->isManagedSales($staff)) {
+            return $this->notFoundError($staff_id);
+        }
+
+        (new Staff())->deletestaff(['staff_id' => $staff_id]);
+
+        return ApiResponse::success(['staff_id' => $staff_id]);
+    }
+
+    /* ------------------------------------------------------------------ */
+    /* Validasi & penyimpanan                                             */
+    /* ------------------------------------------------------------------ */
+
+    /**
+     * staff_id hanya wajib pada body POST — pada PUT nilainya berasal dari
+     * path, bukan body (lihat update()).
+     *
+     * nama_belakang dan alamat bersifat nullable: kalau tidak dikirim,
+     * nilainya disimpan/ditimpa jadi null/kosong, bukan mempertahankan
+     * nilai lama — body selalu dianggap representasi penuh staf ini, sama
+     * seperti endpoint gudang.
+     *
+     * @return array<string, mixed>
+     */
+    private function validatePayload(Request $request, bool $requireStaffId): array
+    {
+        $rules = [
+            'nama_depan' => ['required', 'string', 'max:120'],
+            'nama_belakang' => ['nullable', 'string', 'max:120'],
+            'email' => ['required', 'email', 'max:255'],
+            'alamat' => ['nullable', 'string'],
+        ];
+
+        if ($requireStaffId) {
+            $rules['staff_id'] = ['required', 'integer', 'min:1'];
+        }
+
+        return $request->validate($rules);
+    }
+
+    /**
+     * staffs.staff_name adalah satu kolom gabungan (tidak ada kolom nama
+     * depan/belakang terpisah), jadi nama_depan dan nama_belakang digabung
+     * di sini dan dipisah lagi lewat splitName() saat disajikan kembali.
+     * kode (staff_code), telepon (staff_phone), dan role (role_id staf yang
+     * sudah ada) sengaja tidak disentuh — endpoint ini tidak mengelola
+     * field-field itu.
+     */
+    private function applyPayload(Staff $staff, array $data): void
+    {
+        $namaDepan = trim($data['nama_depan']);
+        $namaBelakang = trim((string) ($data['nama_belakang'] ?? ''));
+
+        $staff->staff_name = $namaBelakang !== '' ? $namaDepan.' '.$namaBelakang : $namaDepan;
+        $staff->staff_email = $data['email'];
+        $staff->staff_address = $data['alamat'] ?? null;
+    }
+
+    /**
+     * Sales dikelola endpoint ini kalau statusnya aktif DAN perannya cocok
+     * dengan definisi "sales" yang sama dipakai GET (nama peran mengandung
+     * kata "sales"). Di luar itu — staf nonaktif, atau staf berperan lain
+     * seperti Admin/Direksi — dianggap di luar jangkauan endpoint ini.
+     */
+    private function isManagedSales(Staff $staff): bool
+    {
+        if ((int) $staff->status !== 1 || $staff->role_id === null) {
+            return false;
+        }
+
+        return Role::query()
+            ->where('role_id', $staff->role_id)
+            ->where('role_name', 'like', '%sales%')
+            ->exists();
+    }
+
+    /**
+     * id peran "Sales" dipakai saat membuat staf baru lewat POST.
+     *
+     * Sengaja gagal keras (jadi 500 lewat ExceptionRenderer, bukan dijawab
+     * seolah berhasil) kalau nama peran yang mengandung "sales" bukan
+     * persis satu — itu berarti data master peran tidak lagi sesuai dengan
+     * asumsi endpoint ini, bukan kesalahan pemanggil yang perlu divalidasi.
+     */
+    private function salesRoleId(): int
+    {
+        $roleIds = Role::query()
+            ->where('role_name', 'like', '%sales%')
+            ->pluck('role_id');
+
+        if ($roleIds->count() !== 1) {
+            throw new \RuntimeException(
+                'Peran "sales" tidak dapat ditentukan secara unik ('.$roleIds->count().' kecocokan).',
+            );
+        }
+
+        return (int) $roleIds->first();
+    }
+
+    /* ------------------------------------------------------------------ */
+    /* Respons                                                             */
+    /* ------------------------------------------------------------------ */
+
+    /**
+     * Bentuk respons create/update: hanya field yang dikelola endpoint ini.
+     *
+     * @return array<string, mixed>
+     */
+    private function present(Staff $staff): array
+    {
+        [$namaDepan, $namaBelakang] = $this->splitName((string) $staff->staff_name);
+
+        return [
+            'staff_id' => (int) $staff->staff_id,
+            'nama_depan' => $namaDepan,
+            'nama_belakang' => $namaBelakang,
+            'email' => $staff->staff_email,
+            'alamat' => $staff->staff_address,
+        ];
+    }
+
+    /**
+     * Bentuk respons daftar (GET): field lama (nama, kode, telepon, role)
+     * dipertahankan supaya pemanggil yang sudah ada tidak putus, ditambah
+     * nama_depan/nama_belakang supaya sejalan dengan bentuk create/update —
+     * sama seperti gudang_id ditambahkan berdampingan dengan id pada daftar
+     * gudang.
+     *
+     * @return array<string, mixed>
+     */
+    private function presentRow(Staff $staff): array
+    {
+        [$namaDepan, $namaBelakang] = $this->splitName((string) $staff->staff_name);
+
+        return [
+            'staff_id' => (int) $staff->staff_id,
+            'nama' => (string) $staff->staff_name,
+            'nama_depan' => $namaDepan,
+            'nama_belakang' => $namaBelakang,
+            'kode' => $staff->staff_code,
+            'email' => $staff->staff_email,
+            'telepon' => $staff->staff_phone,
+            'alamat' => $staff->staff_address,
+            'role' => (string) $staff->role_name,
+        ];
+    }
+
+    /**
+     * staff_name dipisah pada spasi pertama: token pertama jadi nama_depan,
+     * sisanya (kalau ada) jadi nama_belakang. Untuk staf yang namanya lebih
+     * dari dua kata dan tidak pernah dibuat/diubah lewat endpoint ini,
+     * pemisahan ini bisa saja tidak sama dengan pembagian depan/belakang
+     * yang "benar" secara manusiawi — staffs.staff_name memang cuma satu
+     * kolom gabungan, tidak ada sumber lain untuk memisahkannya.
+     *
+     * @return array{0: string, 1: ?string}
+     */
+    private function splitName(string $staffName): array
+    {
+        $staffName = trim($staffName);
+
+        if ($staffName === '') {
+            return ['', null];
+        }
+
+        $parts = explode(' ', $staffName, 2);
+
+        return [$parts[0], $parts[1] ?? null];
+    }
+
+    private function notFoundError(int $staffId): JsonResponse
+    {
+        return ApiResponse::error(
+            ApiResponse::ERROR_NOT_FOUND,
+            'Sales dengan staff_id '.$staffId.' tidak ditemukan.',
+            404,
+        );
+    }
+}

--- a/app/Http/Controllers/ExternalApi/V1/MasterSalesController.php
+++ b/app/Http/Controllers/ExternalApi/V1/MasterSalesController.php
@@ -9,7 +9,6 @@ use App\Models\Staff;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Validation\ValidationException;
 
 /**
  * Data master sales untuk sistem eksternal (API-002 lanjutan).
@@ -145,35 +144,70 @@ class MasterSalesController extends Controller
     }
 
     /**
-     * PATCH /api/external/v1/master/sales/{staff_id}
+     * PATCH /api/external/v1/master/sales/connect
      *
-     * {staff_id} di sini KEBALIKANNYA dari PUT/DELETE: id internal Pegasus,
-     * bukan external_ref_id — dipakai untuk menghubungkan staf yang sudah
-     * ada (dibuat lewat halaman admin, sudah berperan Sales) dengan rujukan
-     * milik sistem pemanggil, tanpa perlu membuat baris baru.
+     * Bentuk jamak: satu permintaan boleh menghubungkan banyak staf
+     * sekaligus lewat body.connections (array). Setiap butir berisi
+     * staff_id (id internal Pegasus — KEBALIKANNYA dari PUT/DELETE, lihat
+     * catatan kelas) dan map_staff_id (rujukan yang mau dipasang), dipakai
+     * untuk menghubungkan staf yang sudah ada (dibuat lewat halaman admin,
+     * sudah berperan Sales) dengan rujukan milik sistem pemanggil, tanpa
+     * perlu membuat baris baru.
      *
-     * Menimpa link yang sudah ada diperbolehkan. Kalau map_staff_id yang
-     * dikirim sedang dipegang staf LAIN, rujukan itu dilepas dulu dari staf
-     * itu (external_ref_id-nya jadi null) sebelum dipasang ke staf ini —
-     * "dipindah", bukan ditolak sebagai duplikat — supaya keunikan
-     * external_ref_id tetap terjaga tanpa membuat pemanggil harus melepas
-     * link lama secara manual lebih dulu.
+     * Setiap butir diproses independen (bukan atomik satu transaksi
+     * besar): butir yang datanya salah tidak menggagalkan butir lain dalam
+     * permintaan yang sama. Respons berupa daftar hasil per butir, masing-
+     * masing menandai berhasil/gagal sendiri-sendiri lewat success.
+     *
+     * Menimpa link yang sudah ada pada staf tujuan diperbolehkan. Kalau
+     * map_staff_id yang dikirim sedang dipegang staf LAIN, rujukan itu
+     * dilepas dulu dari staf itu (external_ref_id-nya jadi null) sebelum
+     * dipasang ke staf tujuan — "dipindah", bukan ditolak sebagai duplikat
+     * — supaya keunikan external_ref_id tetap terjaga tanpa pemanggil harus
+     * melepas link lama secara manual lebih dulu.
      */
-    public function patch(Request $request, int $staff_id): JsonResponse
+    public function connect(Request $request): JsonResponse
     {
-        $staff = Staff::find($staff_id);
-
-        if ($staff === null || ! $this->isManagedSales($staff)) {
-            return $this->notFoundByInternalIdError($staff_id);
-        }
-
         $data = $request->validate([
-            'map_staff_id' => ['required', 'string', 'max:191'],
+            'connections' => ['required', 'array', 'min:1'],
+            'connections.*.staff_id' => ['required', 'integer', 'min:1'],
+            'connections.*.map_staff_id' => ['required', 'string', 'max:191'],
         ]);
-        $mapStaffId = trim($data['map_staff_id']);
+
+        $results = array_map(
+            fn (array $item) => $this->connectOne((int) $item['staff_id'], (string) $item['map_staff_id']),
+            $data['connections'],
+        );
+
+        $successCount = count(array_filter($results, static fn ($r) => $r['success']));
+
+        return ApiResponse::success($results, [
+            'total' => count($results),
+            'success' => $successCount,
+            'failed' => count($results) - $successCount,
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function connectOne(int $staffId, string $rawMapStaffId): array
+    {
+        $mapStaffId = trim($rawMapStaffId);
 
         if ($mapStaffId === '') {
-            $this->fail('map_staff_id', 'map_staff_id tidak boleh kosong.');
+            return $this->connectFailure($staffId, $rawMapStaffId, ApiResponse::ERROR_VALIDATION, 'map_staff_id tidak boleh kosong.');
+        }
+
+        $staff = Staff::find($staffId);
+
+        if ($staff === null || ! $this->isManagedSales($staff)) {
+            return $this->connectFailure(
+                $staffId,
+                $mapStaffId,
+                ApiResponse::ERROR_NOT_FOUND,
+                'Staf dengan id '.$staffId.' tidak ditemukan atau bukan sales aktif.',
+            );
         }
 
         DB::transaction(function () use ($staff, $mapStaffId) {
@@ -185,7 +219,25 @@ class MasterSalesController extends Controller
             $staff->save();
         });
 
-        return ApiResponse::success($this->present($staff->fresh()));
+        return [
+            'staff_id' => $staffId,
+            'map_staff_id' => $mapStaffId,
+            'success' => true,
+            'data' => $this->present($staff->fresh()),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function connectFailure(int $staffId, string $mapStaffId, string $code, string $message): array
+    {
+        return [
+            'staff_id' => $staffId,
+            'map_staff_id' => $mapStaffId,
+            'success' => false,
+            'error' => ['code' => $code, 'message' => $message],
+        ];
     }
 
     /* ------------------------------------------------------------------ */
@@ -305,11 +357,6 @@ class MasterSalesController extends Controller
         return (int) $roleIds->first();
     }
 
-    private function fail(string $field, string $message): void
-    {
-        throw ValidationException::withMessages([$field => [$message]]);
-    }
-
     /* ------------------------------------------------------------------ */
     /* Respons                                                             */
     /* ------------------------------------------------------------------ */
@@ -394,14 +441,6 @@ class MasterSalesController extends Controller
         );
     }
 
-    private function notFoundByInternalIdError(int $staffId): JsonResponse
-    {
-        return ApiResponse::error(
-            ApiResponse::ERROR_NOT_FOUND,
-            'Staf dengan id '.$staffId.' tidak ditemukan atau bukan sales aktif.',
-            404,
-        );
-    }
 
     private function duplicateRefError(string $refId): JsonResponse
     {

--- a/app/Http/Controllers/ExternalApi/V1/MasterUnitController.php
+++ b/app/Http/Controllers/ExternalApi/V1/MasterUnitController.php
@@ -1,0 +1,327 @@
+<?php
+
+namespace App\Http\Controllers\ExternalApi\V1;
+
+use App\ExternalApi\Http\ApiResponse;
+use App\Http\Controllers\Controller;
+use App\Models\Unit;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Data master satuan untuk sistem eksternal (API-001 lanjutan).
+ *
+ * Beda dengan MasterDataController: satuan di sini boleh dibuat, diubah, dan
+ * dihapus lewat External API, bukan cuma dibaca — sama alasannya dengan
+ * kenapa MasterWarehouseController/MasterSalesController dipisah dari
+ * MasterDataController.
+ *
+ * Polanya sama persis dengan MasterSalesController, disesuaikan untuk
+ * satuan:
+ *   - units.unit_id     : id asli Pegasus, auto-increment, tidak pernah
+ *                         ditentukan pemanggil. Disebut "id" pada respons.
+ *   - units.ref_unit_id : id satuan yang sama pada sistem PMO (nullable,
+ *                         unik lewat units_ref_unit_id_unique — lihat
+ *                         migrasi tabel units). Inilah yang dipakai sebagai
+ *                         BODY create dan PATH ubah/hapus. TIDAK diganti
+ *                         nama jadi "external_ref_id" seperti pada sales:
+ *                         kolom ini memang sudah dipakai kontrak PMO
+ *                         (SyncUnitStep, API-001) dengan nama ref_unit_id,
+ *                         jadi nama itu dipertahankan di sini.
+ *
+ * CATATAN PENTING: kolom ref_unit_id ini juga ditulis Pusat Sinkronisasi
+ * (SyncUnitStep, menarik data dari PMO). Endpoint di controller ini adalah
+ * jalur tulis KEDUA ke kolom yang sama — disengaja (dikonfirmasi pemilik
+ * produk): keduanya melayani sistem yang sama (PMO), siapa yang menulis
+ * terakhir yang berlaku, tidak ada penguncian tambahan di antara keduanya.
+ *
+ * Tidak ada konsep "peran" untuk satuan (beda dengan sales yang dibatasi ke
+ * staf berperan Sales) — satu-satunya syarat "dikelola" endpoint ini adalah
+ * status aktif (status = 1), sama seperti getUnit()/getUnitForExternalApi().
+ */
+class MasterUnitController extends Controller
+{
+    /**
+     * GET /api/external/v1/master/units
+     */
+    public function index(): JsonResponse
+    {
+        $units = (new Unit())->getUnitForExternalApi();
+
+        return ApiResponse::success(
+            $units->map(fn ($unit) => $this->present($unit))->all(),
+            ['total' => $units->count()],
+        );
+    }
+
+    /**
+     * POST /api/external/v1/master/units
+     *
+     * Selalu membuat baris satuan baru (id Pegasus-nya auto-increment,
+     * tidak pernah ditentukan pemanggil). Bukan upsert: ref_unit_id yang
+     * sudah dipakai satuan lain ditolak sebagai duplicate_ref_id — pakai
+     * PUT untuk memperbarui satuan yang rujukannya sudah ada, atau PATCH
+     * /master/units/connect untuk menghubungkan rujukan ke satuan Pegasus
+     * yang sudah ada.
+     */
+    public function store(Request $request): JsonResponse
+    {
+        $data = $this->validateCreatePayload($request);
+        $refUnitId = (int) $data['ref_unit_id'];
+
+        if (Unit::where('ref_unit_id', $refUnitId)->exists()) {
+            return $this->duplicateRefError($refUnitId);
+        }
+
+        $unit = new Unit();
+        $unit->ref_unit_id = $refUnitId;
+        $unit->status = 1;
+        $unit->created_by = null;
+        $this->applyPayload($unit, $data);
+
+        try {
+            $unit->save();
+        } catch (\Illuminate\Database\QueryException $e) {
+            // Dua permintaan dengan ref_unit_id baru yang sama, nyaris
+            // bersamaan: keduanya sama-sama tidak menemukan baris di atas,
+            // lalu unique index menolak yang kalah cepat.
+            if (Unit::where('ref_unit_id', $refUnitId)->exists()) {
+                return $this->duplicateRefError($refUnitId);
+            }
+
+            throw $e;
+        }
+
+        return ApiResponse::success($this->present($unit), [], 201);
+    }
+
+    /**
+     * PUT /api/external/v1/master/units/{ref_unit_id}
+     *
+     * {ref_unit_id} tidak pernah membuat satuan baru; ref_unit_id yang
+     * tidak ditemukan (atau ditemukan tapi statusnya nonaktif) selalu
+     * dijawab not_found.
+     */
+    public function update(Request $request, int $ref_unit_id): JsonResponse
+    {
+        $unit = $this->findManagedByRef($ref_unit_id);
+
+        if ($unit === null) {
+            return $this->notFoundByRefError($ref_unit_id);
+        }
+
+        $data = $this->validateProfilePayload($request);
+        $this->applyPayload($unit, $data);
+        $unit->save();
+
+        return ApiResponse::success($this->present($unit));
+    }
+
+    /**
+     * DELETE /api/external/v1/master/units/{ref_unit_id}
+     *
+     * Soft delete (status = 0), memakai ulang Unit::deleteUnit() — sama
+     * persis dengan yang dipakai halaman admin. ref_unit_id TIDAK dilepas
+     * oleh operasi ini, jadi id yang sudah dihapus lewat endpoint ini tidak
+     * bisa dipakai ulang lewat POST (baris lama masih memegangnya, hanya
+     * berstatus nonaktif).
+     */
+    public function destroy(int $ref_unit_id): JsonResponse
+    {
+        $unit = $this->findManagedByRef($ref_unit_id);
+
+        if ($unit === null) {
+            return $this->notFoundByRefError($ref_unit_id);
+        }
+
+        (new Unit())->deleteUnit(['unit_id' => $unit->unit_id]);
+
+        return ApiResponse::success(['ref_unit_id' => $ref_unit_id]);
+    }
+
+    /**
+     * PATCH /api/external/v1/master/units/connect
+     *
+     * Bentuk jamak, sama seperti PATCH /master/sales/connect: satu
+     * permintaan boleh menghubungkan banyak satuan sekaligus lewat
+     * body.connections (array). Setiap butir berisi id (id internal
+     * Pegasus) dan ref_unit_id (rujukan yang mau dipasang), dipakai untuk
+     * menghubungkan satuan yang sudah ada dengan id PMO-nya tanpa perlu
+     * membuat baris baru.
+     *
+     * Setiap butir diproses independen: butir yang datanya salah tidak
+     * menggagalkan butir lain dalam permintaan yang sama. Respons berupa
+     * daftar hasil per butir, masing-masing menandai berhasil/gagal
+     * sendiri-sendiri lewat success.
+     *
+     * Menimpa link yang sudah ada pada satuan tujuan diperbolehkan. Kalau
+     * ref_unit_id yang dikirim sedang dipegang satuan LAIN, rujukan itu
+     * dilepas dulu dari satuan itu (jadi null) sebelum dipasang ke satuan
+     * tujuan — "dipindah", bukan ditolak sebagai duplikat.
+     */
+    public function connect(Request $request): JsonResponse
+    {
+        $data = $request->validate([
+            'connections' => ['required', 'array', 'min:1'],
+            'connections.*.id' => ['required', 'integer', 'min:1'],
+            'connections.*.ref_unit_id' => ['required', 'integer', 'min:1'],
+        ]);
+
+        $results = array_map(
+            fn (array $item) => $this->connectOne((int) $item['id'], (int) $item['ref_unit_id']),
+            $data['connections'],
+        );
+
+        $successCount = count(array_filter($results, static fn ($r) => $r['success']));
+
+        return ApiResponse::success($results, [
+            'total' => count($results),
+            'success' => $successCount,
+            'failed' => count($results) - $successCount,
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function connectOne(int $unitId, int $refUnitId): array
+    {
+        $unit = Unit::find($unitId);
+
+        if ($unit === null || ! $this->isManagedUnit($unit)) {
+            return $this->connectFailure(
+                $unitId,
+                $refUnitId,
+                ApiResponse::ERROR_NOT_FOUND,
+                'Satuan dengan id '.$unitId.' tidak ditemukan atau tidak aktif.',
+            );
+        }
+
+        DB::transaction(function () use ($unit, $refUnitId) {
+            Unit::where('ref_unit_id', $refUnitId)
+                ->where('unit_id', '!=', $unit->unit_id)
+                ->update(['ref_unit_id' => null]);
+
+            $unit->ref_unit_id = $refUnitId;
+            $unit->save();
+        });
+
+        return [
+            'id' => $unitId,
+            'ref_unit_id' => $refUnitId,
+            'success' => true,
+            'data' => $this->present($unit->fresh()),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function connectFailure(int $unitId, int $refUnitId, string $code, string $message): array
+    {
+        return [
+            'id' => $unitId,
+            'ref_unit_id' => $refUnitId,
+            'success' => false,
+            'error' => ['code' => $code, 'message' => $message],
+        ];
+    }
+
+    /* ------------------------------------------------------------------ */
+    /* Validasi & penyimpanan                                             */
+    /* ------------------------------------------------------------------ */
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function validateCreatePayload(Request $request): array
+    {
+        return $request->validate([
+            'ref_unit_id' => ['required', 'integer', 'min:1'],
+        ] + $this->profileRules());
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function validateProfilePayload(Request $request): array
+    {
+        return $request->validate($this->profileRules());
+    }
+
+    /**
+     * unit_name dan unit_short_name berdua wajib (tidak nullable di basis
+     * data), tidak seperti nama_belakang/alamat pada sales — jadi tidak ada
+     * field opsional di sini. Body tetap dianggap representasi penuh:
+     * memperbarui satuan berarti mengirim ulang kedua field, bukan hanya
+     * yang berubah.
+     *
+     * @return array<string, array<int, mixed>>
+     */
+    private function profileRules(): array
+    {
+        return [
+            'unit_name' => ['required', 'string', 'max:250'],
+            'unit_short_name' => ['required', 'string', 'max:250'],
+        ];
+    }
+
+    private function applyPayload(Unit $unit, array $data): void
+    {
+        $unit->unit_name = trim($data['unit_name']);
+        $unit->unit_short_name = trim($data['unit_short_name']);
+    }
+
+    /**
+     * Satuan dikelola endpoint ini kalau statusnya aktif — tidak ada
+     * penyaringan lain seperti peran pada sales, karena tabel units tidak
+     * punya sub-jenis baris yang perlu dilindungi dari endpoint ini.
+     */
+    private function isManagedUnit(Unit $unit): bool
+    {
+        return (int) $unit->status === 1;
+    }
+
+    private function findManagedByRef(int $refUnitId): ?Unit
+    {
+        $unit = Unit::where('ref_unit_id', $refUnitId)->first();
+
+        return ($unit !== null && $this->isManagedUnit($unit)) ? $unit : null;
+    }
+
+    /* ------------------------------------------------------------------ */
+    /* Respons                                                             */
+    /* ------------------------------------------------------------------ */
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function present(Unit $unit): array
+    {
+        return [
+            'id' => (int) $unit->unit_id,
+            'ref_unit_id' => $unit->ref_unit_id !== null ? (int) $unit->ref_unit_id : null,
+            'unit_name' => (string) $unit->unit_name,
+            'unit_short_name' => (string) $unit->unit_short_name,
+        ];
+    }
+
+    private function notFoundByRefError(int $refUnitId): JsonResponse
+    {
+        return ApiResponse::error(
+            ApiResponse::ERROR_NOT_FOUND,
+            'Satuan dengan ref_unit_id '.$refUnitId.' tidak ditemukan.',
+            404,
+        );
+    }
+
+    private function duplicateRefError(int $refUnitId): JsonResponse
+    {
+        return ApiResponse::error(
+            'duplicate_ref_id',
+            'ref_unit_id '.$refUnitId.' sudah dipakai satuan lain.',
+            422,
+        );
+    }
+}

--- a/app/Http/Controllers/ExternalApi/V1/MasterWarehouseController.php
+++ b/app/Http/Controllers/ExternalApi/V1/MasterWarehouseController.php
@@ -31,10 +31,8 @@ class MasterWarehouseController extends Controller
      * GET /api/external/v1/master/warehouses
      *
      * Mengikuti kontrak API-002 (nama, tipe_nama, tipe_id, alamat) ditambah
-     * id gudang. gudang_id dan id sengaja dikembalikan berdampingan: id
-     * sudah dipakai pemanggil yang ada sejak sebelum endpoint create/update/
-     * delete ini ditambahkan, sedangkan gudang_id menyamakan penamaan dengan
-     * field yang dikembalikan tiga endpoint baru itu.
+     * gudang_id, memakai nama field yang sama dengan yang dikembalikan
+     * endpoint create/update/delete gudang.
      */
     public function index(): JsonResponse
     {
@@ -42,7 +40,6 @@ class MasterWarehouseController extends Controller
 
         return ApiResponse::success(
             $warehouses->map(static fn ($warehouse) => [
-                'id' => (int) $warehouse->id,
                 'gudang_id' => (int) $warehouse->id,
                 'nama' => (string) $warehouse->warehouse_name,
                 'tipe_nama' => (string) ($warehouse->type->warehouse_type_name ?? ''),

--- a/app/Http/Controllers/ExternalApi/V1/MasterWarehouseController.php
+++ b/app/Http/Controllers/ExternalApi/V1/MasterWarehouseController.php
@@ -24,6 +24,12 @@ use Illuminate\Validation\ValidationException;
  * pembuatan baris stok 0 otomatis untuk gudang baru. Controller ini hanya
  * menerjemahkan bentuk permintaan/respons API dan tidak menduplikasi logika
  * bisnisnya.
+ *
+ * tipe_id/tipe_nama pada create dan update bersifat upsert terhadap
+ * warehouse_types, lihat upsertWarehouseType(). Karena warehouse_types
+ * dipakai bersama oleh seluruh gudang, rename lewat satu panggilan create/
+ * update gudang ikut mengubah nama tipe itu untuk semua gudang lain yang
+ * memakai tipe_id yang sama — ini efek yang disengaja, bukan kebocoran.
  */
 class MasterWarehouseController extends Controller
 {
@@ -57,6 +63,8 @@ class MasterWarehouseController extends Controller
     {
         $data = $this->validatePayload($request);
 
+        $this->upsertWarehouseType((int) $data['tipe_id'], $data['tipe_nama']);
+
         $result = (new Warehouse())->insertWarehouse([
             'warehouse_name' => $data['nama'],
             'warehouse_type_id' => $data['tipe_id'],
@@ -84,6 +92,8 @@ class MasterWarehouseController extends Controller
         }
 
         $data = $this->validatePayload($request);
+
+        $this->upsertWarehouseType((int) $data['tipe_id'], $data['tipe_nama']);
 
         $result = (new Warehouse())->updateWarehouse([
             'id' => $gudang_id,
@@ -139,40 +149,93 @@ class MasterWarehouseController extends Controller
     /**
      * Seluruh field wajib diisi, baik pada create maupun update.
      *
-     * tipe_nama tidak tersimpan sebagai kolom sendiri — namanya selalu
-     * diturunkan dari relasi ke warehouse_types lewat tipe_id. Karena itu
-     * tipe_nama di sini diperlakukan sebagai konfirmasi dari pemanggil, bukan
-     * sumber data: nilainya wajib sama persis (tanpa peduli besar/kecil
-     * huruf) dengan nama tipe gudang yang sebenarnya untuk tipe_id yang
-     * dikirim, kalau tidak permintaan ditolak. Ini mencegah salah kirim
-     * tipe_id yang lolos tanpa disadari pemanggil.
+     * tipe_id/tipe_nama tidak lagi diverifikasi kecocokannya di sini — lihat
+     * upsertWarehouseType(), dipanggil terpisah setelah validasi ini supaya
+     * pesan error kegagalan format field (tipe_id bukan angka, dsb.) tetap
+     * lolos lewat validation_failed standar sebelum upsert dicoba.
      *
      * @return array<string, mixed>
      */
     private function validatePayload(Request $request): array
     {
-        $data = $request->validate([
+        return $request->validate([
             'nama' => ['required', 'string', 'max:250'],
             'tipe_nama' => ['required', 'string', 'max:250'],
-            'tipe_id' => ['required', 'integer'],
+            'tipe_id' => ['required', 'integer', 'min:1'],
             'alamat' => ['required', 'string'],
         ]);
+    }
 
-        $type = WarehouseType::active()->find($data['tipe_id']);
+    /**
+     * Upsert tipe gudang: tipe_id menentukan baris, tipe_nama menentukan isi.
+     *
+     * - tipe_id sudah ada di warehouse_types (aktif atau tidak) -> nama tipe
+     *   itu DIGANTI menjadi tipe_nama kalau berbeda. Ini rename, bukan tipe
+     *   baru, dan berlaku untuk seluruh gudang lain yang memakai tipe_id yang
+     *   sama — bukan cuma gudang yang sedang dibuat/diubah di panggilan ini.
+     * - tipe_id belum ada -> dibuat baris warehouse_types baru dengan id
+     *   PERSIS tipe_id yang dikirim (bukan id auto-increment berikutnya),
+     *   supaya gudang yang dibuat/diubah sesudah ini benar-benar memakai
+     *   tipe_id yang diminta pemanggil, bukan id lain yang kebetulan
+     *   dihasilkan sistem.
+     *
+     * Nama tipe (baik hasil rename maupun tipe baru) tetap wajib unik di
+     * antara tipe gudang aktif lain, sama seperti pembuatan tipe lewat
+     * halaman admin.
+     */
+    private function upsertWarehouseType(int $tipeId, string $tipeNama): WarehouseType
+    {
+        $tipeNama = trim($tipeNama);
+        $type = WarehouseType::find($tipeId);
 
-        if (! $type) {
-            $this->fail('tipe_id', 'Tipe gudang dengan tipe_id '.$data['tipe_id'].' tidak ditemukan atau tidak aktif.');
+        if ($type) {
+            if (trim((string) $type->warehouse_type_name) === $tipeNama) {
+                return $type;
+            }
+
+            if ($type->isDuplicateName($tipeNama, $type->id)) {
+                $this->fail('tipe_nama', 'Nama tipe gudang "'.$tipeNama.'" sudah dipakai tipe gudang lain.');
+            }
+
+            $type->warehouse_type_name = $tipeNama;
+            $type->save();
+
+            return $type;
         }
 
-        if (mb_strtolower(trim($type->warehouse_type_name)) !== mb_strtolower(trim($data['tipe_nama']))) {
-            $this->fail(
-                'tipe_nama',
-                'tipe_nama "'.$data['tipe_nama'].'" tidak sesuai dengan nama tipe gudang untuk tipe_id '
-                    .$data['tipe_id'].' ("'.$type->warehouse_type_name.'").',
-            );
+        if ((new WarehouseType())->isDuplicateName($tipeNama)) {
+            $this->fail('tipe_nama', 'Nama tipe gudang "'.$tipeNama.'" sudah dipakai tipe gudang lain.');
         }
 
-        return $data;
+        $type = new WarehouseType();
+        $type->id = $tipeId;
+        $type->warehouse_type_name = $tipeNama;
+        $type->is_main_warehouse = 0;
+        $type->status = 1;
+        $type->created_by = null;
+
+        try {
+            $type->save();
+        } catch (\Illuminate\Database\QueryException $e) {
+            // Dua permintaan dengan tipe_id baru yang sama, nyaris bersamaan:
+            // keduanya sama-sama tidak menemukan baris di atas, lalu primary
+            // key menolak yang kalah cepat. Perlakukan sebagai upsert biasa
+            // terhadap baris yang barusan dibuat request lain, bukan galat.
+            $existing = WarehouseType::find($tipeId);
+
+            if ($existing === null) {
+                throw $e;
+            }
+
+            $type = $existing;
+
+            if (trim((string) $type->warehouse_type_name) !== $tipeNama) {
+                $type->warehouse_type_name = $tipeNama;
+                $type->save();
+            }
+        }
+
+        return $type;
     }
 
     private function fail(string $field, string $message): void

--- a/app/Http/Controllers/ExternalApi/V1/MasterWarehouseController.php
+++ b/app/Http/Controllers/ExternalApi/V1/MasterWarehouseController.php
@@ -1,0 +1,221 @@
+<?php
+
+namespace App\Http\Controllers\ExternalApi\V1;
+
+use App\ExternalApi\Http\ApiResponse;
+use App\Http\Controllers\Controller;
+use App\Models\Warehouse;
+use App\Models\WarehouseType;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\ValidationException;
+
+/**
+ * Data master gudang untuk sistem eksternal (API-002 lanjutan).
+ *
+ * Beda dengan MasterDataController: gudang di sini boleh dibuat, diubah, dan
+ * dihapus lewat External API, bukan cuma dibaca. Sengaja ditaruh di
+ * controller terpisah supaya MasterDataController tetap murni baca-saja
+ * seperti didokumentasikan di sana.
+ *
+ * Aturan penyimpanan sepenuhnya memakai ulang Warehouse::insertWarehouse() /
+ * updateWarehouse() / deleteWarehouse() — sama persis dengan yang dipakai
+ * halaman admin (WarehouseController), termasuk cek nama ganda dan
+ * pembuatan baris stok 0 otomatis untuk gudang baru. Controller ini hanya
+ * menerjemahkan bentuk permintaan/respons API dan tidak menduplikasi logika
+ * bisnisnya.
+ */
+class MasterWarehouseController extends Controller
+{
+    /**
+     * GET /api/external/v1/master/warehouses
+     *
+     * Mengikuti kontrak API-002 (nama, tipe_nama, tipe_id, alamat) ditambah
+     * id gudang. gudang_id dan id sengaja dikembalikan berdampingan: id
+     * sudah dipakai pemanggil yang ada sejak sebelum endpoint create/update/
+     * delete ini ditambahkan, sedangkan gudang_id menyamakan penamaan dengan
+     * field yang dikembalikan tiga endpoint baru itu.
+     */
+    public function index(): JsonResponse
+    {
+        $warehouses = (new Warehouse())->getWarehouseForExternalApi();
+
+        return ApiResponse::success(
+            $warehouses->map(static fn ($warehouse) => [
+                'id' => (int) $warehouse->id,
+                'gudang_id' => (int) $warehouse->id,
+                'nama' => (string) $warehouse->warehouse_name,
+                'tipe_nama' => (string) ($warehouse->type->warehouse_type_name ?? ''),
+                'tipe_id' => (int) $warehouse->warehouse_type_id,
+                'alamat' => $warehouse->warehouse_address,
+            ])->all(),
+            ['total' => $warehouses->count()],
+        );
+    }
+
+    /**
+     * POST /api/external/v1/master/warehouses
+     */
+    public function store(Request $request): JsonResponse
+    {
+        $data = $this->validatePayload($request);
+
+        $result = (new Warehouse())->insertWarehouse([
+            'warehouse_name' => $data['nama'],
+            'warehouse_type_id' => $data['tipe_id'],
+            'warehouse_address' => $data['alamat'],
+        ]);
+
+        if ($result === -2) {
+            return $this->duplicateNameError($data['nama']);
+        }
+
+        return ApiResponse::success(
+            $this->present(Warehouse::with('type')->findOrFail($result)),
+            [],
+            201,
+        );
+    }
+
+    /**
+     * PUT /api/external/v1/master/warehouses/{gudang_id}
+     */
+    public function update(Request $request, int $gudang_id): JsonResponse
+    {
+        if (! Warehouse::whereIn('status', [1, 2])->where('id', $gudang_id)->exists()) {
+            return $this->notFoundError($gudang_id);
+        }
+
+        $data = $this->validatePayload($request);
+
+        $result = (new Warehouse())->updateWarehouse([
+            'id' => $gudang_id,
+            'warehouse_name' => $data['nama'],
+            'warehouse_type_id' => $data['tipe_id'],
+            'warehouse_address' => $data['alamat'],
+        ]);
+
+        if ($result === -2) {
+            return $this->duplicateNameError($data['nama']);
+        }
+
+        return ApiResponse::success(
+            $this->present(Warehouse::with('type')->findOrFail($result)),
+        );
+    }
+
+    /**
+     * DELETE /api/external/v1/master/warehouses/{gudang_id}
+     *
+     * Soft delete (status = 0), sama seperti halaman admin. Kalau gudang
+     * masih punya stok produk/bahan mentah, permintaan ditolak dengan
+     * warehouse_has_stock kecuali force=1 disertakan — cerminan tepat dari
+     * konfirmasi dua langkah yang dilihat pengguna admin di halamannya.
+     */
+    public function destroy(Request $request, int $gudang_id): JsonResponse
+    {
+        if (! Warehouse::whereIn('status', [1, 2])->where('id', $gudang_id)->exists()) {
+            return $this->notFoundError($gudang_id);
+        }
+
+        $result = (new Warehouse())->deleteWarehouse([
+            'id' => $gudang_id,
+            'force' => $request->boolean('force'),
+        ]);
+
+        if (is_array($result)) {
+            return ApiResponse::error(
+                'warehouse_has_stock',
+                $result['message'],
+                409,
+                ['count' => $result['count']],
+            );
+        }
+
+        return ApiResponse::success(['gudang_id' => (int) $result]);
+    }
+
+    /* ------------------------------------------------------------------ */
+    /* Validasi                                                            */
+    /* ------------------------------------------------------------------ */
+
+    /**
+     * Seluruh field wajib diisi, baik pada create maupun update.
+     *
+     * tipe_nama tidak tersimpan sebagai kolom sendiri — namanya selalu
+     * diturunkan dari relasi ke warehouse_types lewat tipe_id. Karena itu
+     * tipe_nama di sini diperlakukan sebagai konfirmasi dari pemanggil, bukan
+     * sumber data: nilainya wajib sama persis (tanpa peduli besar/kecil
+     * huruf) dengan nama tipe gudang yang sebenarnya untuk tipe_id yang
+     * dikirim, kalau tidak permintaan ditolak. Ini mencegah salah kirim
+     * tipe_id yang lolos tanpa disadari pemanggil.
+     *
+     * @return array<string, mixed>
+     */
+    private function validatePayload(Request $request): array
+    {
+        $data = $request->validate([
+            'nama' => ['required', 'string', 'max:250'],
+            'tipe_nama' => ['required', 'string', 'max:250'],
+            'tipe_id' => ['required', 'integer'],
+            'alamat' => ['required', 'string'],
+        ]);
+
+        $type = WarehouseType::active()->find($data['tipe_id']);
+
+        if (! $type) {
+            $this->fail('tipe_id', 'Tipe gudang dengan tipe_id '.$data['tipe_id'].' tidak ditemukan atau tidak aktif.');
+        }
+
+        if (mb_strtolower(trim($type->warehouse_type_name)) !== mb_strtolower(trim($data['tipe_nama']))) {
+            $this->fail(
+                'tipe_nama',
+                'tipe_nama "'.$data['tipe_nama'].'" tidak sesuai dengan nama tipe gudang untuk tipe_id '
+                    .$data['tipe_id'].' ("'.$type->warehouse_type_name.'").',
+            );
+        }
+
+        return $data;
+    }
+
+    private function fail(string $field, string $message): void
+    {
+        throw ValidationException::withMessages([$field => [$message]]);
+    }
+
+    /* ------------------------------------------------------------------ */
+    /* Respons                                                             */
+    /* ------------------------------------------------------------------ */
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function present(Warehouse $warehouse): array
+    {
+        return [
+            'gudang_id' => (int) $warehouse->id,
+            'nama' => (string) $warehouse->warehouse_name,
+            'tipe_nama' => (string) ($warehouse->type->warehouse_type_name ?? ''),
+            'tipe_id' => (int) $warehouse->warehouse_type_id,
+            'alamat' => $warehouse->warehouse_address,
+        ];
+    }
+
+    private function duplicateNameError(string $name): JsonResponse
+    {
+        return ApiResponse::error(
+            'duplicate_name',
+            'Nama gudang "'.$name.'" sudah dipakai gudang aktif lain.',
+            422,
+        );
+    }
+
+    private function notFoundError(int $gudangId): JsonResponse
+    {
+        return ApiResponse::error(
+            ApiResponse::ERROR_NOT_FOUND,
+            'Gudang dengan gudang_id '.$gudangId.' tidak ditemukan.',
+            404,
+        );
+    }
+}

--- a/app/Models/Staff.php
+++ b/app/Models/Staff.php
@@ -58,6 +58,7 @@ class Staff extends Model
                 'staffs.staff_id',
                 'staffs.staff_name',
                 'staffs.staff_code',
+                'staffs.external_ref_id',
                 'staffs.staff_email',
                 'staffs.staff_phone',
                 'staffs.staff_address',

--- a/config/externalapi.php
+++ b/config/externalapi.php
@@ -140,6 +140,10 @@ return [
     'docs' => [
         // API-001 — Data Master
         \App\ExternalApi\Docs\Endpoints\V1\MasterUnitListDoc::class,
+        \App\ExternalApi\Docs\Endpoints\V1\MasterUnitCreateDoc::class,
+        \App\ExternalApi\Docs\Endpoints\V1\MasterUnitUpdateDoc::class,
+        \App\ExternalApi\Docs\Endpoints\V1\MasterUnitDeleteDoc::class,
+        \App\ExternalApi\Docs\Endpoints\V1\MasterUnitLinkDoc::class,
         \App\ExternalApi\Docs\Endpoints\V1\MasterCashCategoryListDoc::class,
 
         // API-002 — Data Master (batch 2)

--- a/config/externalapi.php
+++ b/config/externalapi.php
@@ -149,6 +149,9 @@ return [
         \App\ExternalApi\Docs\Endpoints\V1\MasterWarehouseDeleteDoc::class,
         \App\ExternalApi\Docs\Endpoints\V1\MasterWarehouseTypeListDoc::class,
         \App\ExternalApi\Docs\Endpoints\V1\MasterSalesListDoc::class,
+        \App\ExternalApi\Docs\Endpoints\V1\MasterSalesCreateDoc::class,
+        \App\ExternalApi\Docs\Endpoints\V1\MasterSalesUpdateDoc::class,
+        \App\ExternalApi\Docs\Endpoints\V1\MasterSalesDeleteDoc::class,
 
         // API-005 — Pembayaran Kas
         \App\ExternalApi\Docs\Endpoints\V1\CashPaymentCreateDoc::class,

--- a/config/externalapi.php
+++ b/config/externalapi.php
@@ -144,6 +144,9 @@ return [
 
         // API-002 — Data Master (batch 2)
         \App\ExternalApi\Docs\Endpoints\V1\MasterWarehouseListDoc::class,
+        \App\ExternalApi\Docs\Endpoints\V1\MasterWarehouseCreateDoc::class,
+        \App\ExternalApi\Docs\Endpoints\V1\MasterWarehouseUpdateDoc::class,
+        \App\ExternalApi\Docs\Endpoints\V1\MasterWarehouseDeleteDoc::class,
         \App\ExternalApi\Docs\Endpoints\V1\MasterWarehouseTypeListDoc::class,
         \App\ExternalApi\Docs\Endpoints\V1\MasterSalesListDoc::class,
 

--- a/config/externalapi.php
+++ b/config/externalapi.php
@@ -152,6 +152,7 @@ return [
         \App\ExternalApi\Docs\Endpoints\V1\MasterSalesCreateDoc::class,
         \App\ExternalApi\Docs\Endpoints\V1\MasterSalesUpdateDoc::class,
         \App\ExternalApi\Docs\Endpoints\V1\MasterSalesDeleteDoc::class,
+        \App\ExternalApi\Docs\Endpoints\V1\MasterSalesLinkDoc::class,
 
         // API-005 — Pembayaran Kas
         \App\ExternalApi\Docs\Endpoints\V1\CashPaymentCreateDoc::class,

--- a/database/migrations/2026_08_08_120000_add_external_ref_id_to_staffs_table.php
+++ b/database/migrations/2026_08_08_120000_add_external_ref_id_to_staffs_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * external_ref_id: id yang dipakai sistem eksternal untuk merujuk satu staf
+ * (dipakai lewat External API /master/sales — API-002 lanjutan). Nullable
+ * karena staf yang dibuat lewat halaman admin tidak otomatis punya rujukan
+ * eksternal; dihubungkan belakangan lewat PATCH /master/sales/{staff_id}.
+ *
+ * Unique (nullable-safe di MySQL — banyak baris NULL tetap diperbolehkan,
+ * hanya nilai bukan-NULL yang wajib unik) supaya pencarian
+ * external_ref_id -> satu staf selalu tidak ambigu.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('staffs', function (Blueprint $table) {
+            $table->string('external_ref_id', 191)->nullable()->after('staff_code');
+            $table->unique('external_ref_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('staffs', function (Blueprint $table) {
+            $table->dropUnique(['external_ref_id']);
+            $table->dropColumn('external_ref_id');
+        });
+    }
+};

--- a/routes/external-api/v1.php
+++ b/routes/external-api/v1.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\ExternalApi\V1\CashPaymentController;
 use App\Http\Controllers\ExternalApi\V1\MasterDataController;
+use App\Http\Controllers\ExternalApi\V1\MasterWarehouseController;
 use Illuminate\Support\Facades\Route;
 
 /*
@@ -35,7 +36,10 @@ Route::prefix('master')->name('master.')->group(function () {
     Route::get('/cash_categories', [MasterDataController::class, 'cashCategories'])->name('cashCategories');
 
     // API-002
-    Route::get('/warehouses', [MasterDataController::class, 'warehouses'])->name('warehouses');
+    Route::get('/warehouses', [MasterWarehouseController::class, 'index'])->name('warehouses');
+    Route::post('/warehouses', [MasterWarehouseController::class, 'store'])->name('warehouses.store');
+    Route::put('/warehouses/{gudang_id}', [MasterWarehouseController::class, 'update'])->name('warehouses.update');
+    Route::delete('/warehouses/{gudang_id}', [MasterWarehouseController::class, 'destroy'])->name('warehouses.destroy');
     Route::get('/warehouse_types', [MasterDataController::class, 'warehouseTypes'])->name('warehouseTypes');
     Route::get('/sales', [MasterDataController::class, 'sales'])->name('sales');
 });

--- a/routes/external-api/v1.php
+++ b/routes/external-api/v1.php
@@ -44,14 +44,15 @@ Route::prefix('master')->name('master.')->group(function () {
     Route::get('/warehouse_types', [MasterDataController::class, 'warehouseTypes'])->name('warehouseTypes');
 
     // {staff_id} pada PUT/DELETE adalah external_ref_id (rujukan sistem
-    // pemanggil). Pada PATCH, {staff_id} justru id internal Pegasus — dipakai
-    // untuk menghubungkan staf yang sudah ada dengan rujukan eksternal. Lihat
-    // catatan kelas MasterSalesController.
+    // pemanggil). PATCH /sales/connect terpisah dari situ: menghubungkan
+    // banyak staf sekaligus (body.connections), masing-masing butir memakai
+    // id internal Pegasus, bukan external_ref_id. Lihat catatan kelas
+    // MasterSalesController.
     Route::get('/sales', [MasterSalesController::class, 'index'])->name('sales');
     Route::post('/sales', [MasterSalesController::class, 'store'])->name('sales.store');
     Route::put('/sales/{staff_id}', [MasterSalesController::class, 'update'])->name('sales.update');
     Route::delete('/sales/{staff_id}', [MasterSalesController::class, 'destroy'])->name('sales.destroy');
-    Route::patch('/sales/{staff_id}', [MasterSalesController::class, 'patch'])->name('sales.patch');
+    Route::patch('/sales/connect', [MasterSalesController::class, 'connect'])->name('sales.connect');
 });
 
 /*

--- a/routes/external-api/v1.php
+++ b/routes/external-api/v1.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\ExternalApi\V1\CashPaymentController;
 use App\Http\Controllers\ExternalApi\V1\MasterDataController;
+use App\Http\Controllers\ExternalApi\V1\MasterSalesController;
 use App\Http\Controllers\ExternalApi\V1\MasterWarehouseController;
 use Illuminate\Support\Facades\Route;
 
@@ -41,7 +42,11 @@ Route::prefix('master')->name('master.')->group(function () {
     Route::put('/warehouses/{gudang_id}', [MasterWarehouseController::class, 'update'])->name('warehouses.update');
     Route::delete('/warehouses/{gudang_id}', [MasterWarehouseController::class, 'destroy'])->name('warehouses.destroy');
     Route::get('/warehouse_types', [MasterDataController::class, 'warehouseTypes'])->name('warehouseTypes');
-    Route::get('/sales', [MasterDataController::class, 'sales'])->name('sales');
+
+    Route::get('/sales', [MasterSalesController::class, 'index'])->name('sales');
+    Route::post('/sales', [MasterSalesController::class, 'store'])->name('sales.store');
+    Route::put('/sales/{staff_id}', [MasterSalesController::class, 'update'])->name('sales.update');
+    Route::delete('/sales/{staff_id}', [MasterSalesController::class, 'destroy'])->name('sales.destroy');
 });
 
 /*

--- a/routes/external-api/v1.php
+++ b/routes/external-api/v1.php
@@ -43,10 +43,15 @@ Route::prefix('master')->name('master.')->group(function () {
     Route::delete('/warehouses/{gudang_id}', [MasterWarehouseController::class, 'destroy'])->name('warehouses.destroy');
     Route::get('/warehouse_types', [MasterDataController::class, 'warehouseTypes'])->name('warehouseTypes');
 
+    // {staff_id} pada PUT/DELETE adalah external_ref_id (rujukan sistem
+    // pemanggil). Pada PATCH, {staff_id} justru id internal Pegasus — dipakai
+    // untuk menghubungkan staf yang sudah ada dengan rujukan eksternal. Lihat
+    // catatan kelas MasterSalesController.
     Route::get('/sales', [MasterSalesController::class, 'index'])->name('sales');
     Route::post('/sales', [MasterSalesController::class, 'store'])->name('sales.store');
     Route::put('/sales/{staff_id}', [MasterSalesController::class, 'update'])->name('sales.update');
     Route::delete('/sales/{staff_id}', [MasterSalesController::class, 'destroy'])->name('sales.destroy');
+    Route::patch('/sales/{staff_id}', [MasterSalesController::class, 'patch'])->name('sales.patch');
 });
 
 /*

--- a/routes/external-api/v1.php
+++ b/routes/external-api/v1.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\ExternalApi\V1\CashPaymentController;
 use App\Http\Controllers\ExternalApi\V1\MasterDataController;
 use App\Http\Controllers\ExternalApi\V1\MasterSalesController;
+use App\Http\Controllers\ExternalApi\V1\MasterUnitController;
 use App\Http\Controllers\ExternalApi\V1\MasterWarehouseController;
 use Illuminate\Support\Facades\Route;
 
@@ -33,7 +34,19 @@ use Illuminate\Support\Facades\Route;
  */
 Route::prefix('master')->name('master.')->group(function () {
     // API-001
-    Route::get('/units', [MasterDataController::class, 'units'])->name('units');
+    //
+    // {ref_unit_id} pada PUT/DELETE units adalah id satuan yang sama pada
+    // sistem PMO (units.ref_unit_id), bukan id internal Pegasus. PATCH
+    // /units/connect terpisah dari situ: menghubungkan banyak satuan
+    // sekaligus (body.connections), tiap butir memakai id internal Pegasus.
+    // Lihat catatan kelas MasterUnitController — termasuk kenapa kolom yang
+    // sama juga ditulis Pusat Sinkronisasi (SyncUnitStep), disengaja.
+    Route::get('/units', [MasterUnitController::class, 'index'])->name('units');
+    Route::post('/units', [MasterUnitController::class, 'store'])->name('units.store');
+    Route::put('/units/{ref_unit_id}', [MasterUnitController::class, 'update'])->name('units.update');
+    Route::delete('/units/{ref_unit_id}', [MasterUnitController::class, 'destroy'])->name('units.destroy');
+    Route::patch('/units/connect', [MasterUnitController::class, 'connect'])->name('units.connect');
+
     Route::get('/cash_categories', [MasterDataController::class, 'cashCategories'])->name('cashCategories');
 
     // API-002


### PR DESCRIPTION
## Ringkasan

Menambah endpoint create/update/delete (dan connect untuk sales/units) ke External API v1, untuk tiga resource data master yang sebelumnya hanya bisa dibaca:

- `/master/warehouses` — POST, PUT `/{gudang_id}`, DELETE `/{gudang_id}`
- `/master/sales` — POST, PUT `/{staff_id}`, DELETE `/{staff_id}`, PATCH `/connect`
- `/master/units` — POST, PUT `/{ref_unit_id}`, DELETE `/{ref_unit_id}`, PATCH `/connect`

Setiap endpoint create/update/delete/connect dipindah ke controller khusus per-resource (`MasterWarehouseController`, `MasterSalesController`, `MasterUnitController`), supaya `MasterDataController` tetap murni baca-saja seperti didokumentasikan di sana. Dokumentasi tiap endpoint terdaftar di `config/externalapi.php` dan tampil di halaman publik `/api-docs/master`.

## Poin desain penting

- **Gudang**: `tipe_id`/`tipe_nama` bersifat upsert terhadap `warehouse_types` — `tipe_id` yang sudah ada di-rename namanya, yang belum ada dibuatkan baris baru dengan id persis yang dikirim. `GET /master/warehouses` sekarang mengembalikan `gudang_id` (bukan `id`).
- **Sales**: `staff_id` pada body/path endpoint sales BUKAN `staffs.staff_id` Pegasus, melainkan rujukan eksternal (kolom baru `staffs.external_ref_id`, migrasi disertakan). `staffs.staff_id` tetap auto-increment. Setiap endpoint dibatasi hanya menyentuh staf berperan **Sales** dan aktif — staf lain (Admin, dst.) selalu dijawab `not_found`, tidak pernah diubah.
- **Satuan**: mengikuti pola yang sama, tapi memakai `ref_unit_id` (bukan `external_ref_id`) karena kolom ini sudah punya kontrak PMO yang ada (`SyncUnitStep`, Pusat Sinkronisasi). **Catatan**: `units.ref_unit_id` sekarang punya dua jalur tulis (Pusat Sinkronisasi + endpoint ini) — dikonfirmasi disengaja, keduanya melayani sistem yang sama (PMO).
- **PATCH .../connect** (sales & units): menghubungkan banyak resource sekaligus lewat `body.connections` (array), tiap butir diproses independen (respons per-butir `success`/`error`, HTTP selalu 200 kecuali bentuk permintaan tidak sah). Menimpa link yang sudah ada diperbolehkan; kalau rujukan yang dikirim sedang dipegang resource lain, rujukan itu dipindah, bukan ditolak sebagai duplikat.

## Verifikasi

Setiap endpoint diuji lewat DB transaction yang di-rollback (create, duplicate rejection, update, delete + blokir pemakaian ulang id, proteksi peran pada sales, bulk connect dengan pindah link dan kegagalan per butir, validasi field wajib), dan dikonfirmasi tampil benar di halaman publik `/api-docs/master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)