### PR TITLE
feat: browser-based deploy runner for shared hosting without SSH

### DIFF
--- a/.cpanel.yml.example
+++ b/.cpanel.yml.example
@@ -1,0 +1,38 @@
+# Template for cPanel "Git™ Version Control" deploy automation.
+#
+# Rename to `.cpanel.yml` (repo root) and fix the paths below ONLY after you've
+# confirmed your hosting account has the Git Version Control feature (cPanel →
+# Files → Git Version Control) and you know your account's real home path.
+# cPanel runs this file server-side on every "Update from Remote" / deploy
+# click — no SSH session needed, even though it looks like a shell script.
+#
+# Left as `.example` on purpose: an unconfigured copy named `.cpanel.yml`
+# would silently no-op or fail with wrong paths the moment Git Version
+# Control is enabled, which is worse than not having it at all.
+#
+# See cdocs/docs/deploy-shared-hosting.md for the full runbook.
+
+---
+deployment:
+  tasks:
+    # 1. Copy the repo checkout into your actual public app directory.
+    #    Adjust DEPLOYPATH to your real path (cPanel shows this on the Git
+    #    Version Control page for this repo, usually something like
+    #    /home/USERNAME/public_html or /home/USERNAME/app if public_html
+    #    only holds /public and the app lives one level up).
+    - export DEPLOYPATH=/home/USERNAME/public_html/
+    - /bin/cp -R * $DEPLOYPATH
+
+    # 2. Install PHP deps without dev packages (composer must be available
+    #    as a cPanel-provided binary — check cPanel → Software → Composer).
+    - cd $DEPLOYPATH && composer install --no-dev --optimize-autoloader
+
+    # 3. Run pending migrations. Safe to run every deploy: Laravel's
+    #    `migrations` table skips anything already applied.
+    - cd $DEPLOYPATH && php artisan migrate --force
+
+    # 4. Clear/rebuild caches so config & route changes actually take effect.
+    - cd $DEPLOYPATH && php artisan config:clear
+    - cd $DEPLOYPATH && php artisan cache:clear
+    - cd $DEPLOYPATH && php artisan view:clear
+    - cd $DEPLOYPATH && php artisan route:clear

--- a/.env.example
+++ b/.env.example
@@ -70,3 +70,10 @@ PMO_BASE_URL=
 # PMO_TIMEOUT=60
 # PMO_CONNECT_TIMEOUT=10
 # PMO_VERIFY_SSL=true
+
+# Token untuk /deploy/* (migrate/migrate-status/optimize-clear) — dipakai di
+# shared hosting tanpa SSH/terminal. WAJIB diisi acak & panjang (>=32 char,
+# mis. hasil `php artisan tinker >>> Str::random(40)`) sebelum dipakai di
+# production. Kosongkan/hapus baris ini dan endpoint akan menolak semua request.
+# Lihat cdocs/docs/deploy-shared-hosting.md.
+DEPLOY_TOKEN="Str::random(40)"

--- a/app/Http/Controllers/DeployController.php
+++ b/app/Http/Controllers/DeployController.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Browser-triggerable Artisan runner for shared hosting without SSH/terminal
+ * access (no cPanel "Terminal" app, no remote DB access). Hit these routes
+ * from a browser after uploading new code (File Manager/FTP/Git) to run
+ * pending migrations and clear caches — Laravel's own `migrations` table
+ * keeps track of what's already applied, so there's nothing to track by hand.
+ *
+ * Security relies entirely on DEPLOY_TOKEN in .env being long/secret — these
+ * routes are intentionally NOT behind checkLogin (deploy can happen before
+ * any session/user setup is valid) and are NOT registered under check.access.
+ * See cdocs/docs/deploy-shared-hosting.md for the full runbook, including the
+ * cron-job and .cpanel.yml alternatives.
+ *
+ * seedSnapshot() and freshEmpty() are DATA-DESTRUCTIVE (db:seed truncates
+ * every snapshot table and reloads dev fixtures; migrate:fresh drops every
+ * table). They're POST-only (so a leaked link/crawler/prefetch can't trigger
+ * them via a plain GET) and require a typed confirm phrase on top of the
+ * token, and every call is logged. Use console() for a browser form that
+ * enforces the confirm-phrase typing without needing curl.
+ */
+class DeployController extends Controller
+{
+    private function guard(Request $request): void
+    {
+        $expected = (string) env('DEPLOY_TOKEN', '');
+
+        if (strlen($expected) < 24) {
+            abort(403, 'DEPLOY_TOKEN belum diset (atau kurang dari 24 karakter) di .env. Set token acak yang panjang sebelum endpoint ini bisa dipakai.');
+        }
+
+        $given = (string) $request->query('token', '');
+
+        if ($given === '' || ! hash_equals($expected, $given)) {
+            abort(403);
+        }
+    }
+
+    private function requireConfirmation(Request $request, string $phrase): void
+    {
+        $given = (string) $request->input('confirm', '');
+
+        if ($given !== $phrase) {
+            abort(403, "Aksi ini menghapus data. Kirim POST dengan field 'confirm' persis berisi: {$phrase}");
+        }
+    }
+
+    private function logDestructive(Request $request, string $action): void
+    {
+        Log::warning("[deploy] {$action} triggered via /deploy console", [
+            'ip' => $request->ip(),
+            'at' => now()->toDateTimeString(),
+        ]);
+    }
+
+    public function migrate(Request $request)
+    {
+        $this->guard($request);
+
+        Artisan::call('migrate', ['--force' => true]);
+
+        return response('<pre>'.e(Artisan::output()).'</pre>');
+    }
+
+    public function status(Request $request)
+    {
+        $this->guard($request);
+
+        Artisan::call('migrate:status');
+
+        return response('<pre>'.e(Artisan::output()).'</pre>');
+    }
+
+    public function optimizeClear(Request $request)
+    {
+        $this->guard($request);
+
+        $log = '';
+
+        foreach (['config:clear', 'cache:clear', 'view:clear', 'route:clear'] as $command) {
+            Artisan::call($command);
+            $log .= "$ php artisan {$command}\n".Artisan::output()."\n";
+        }
+
+        return response('<pre>'.e($log).'</pre>');
+    }
+
+    /**
+     * Full dev-data snapshot restore (database/seeders/data/*.json). Truncates
+     * every table the snapshot covers and reloads it — intended for staging,
+     * not for a production DB holding real data.
+     */
+    public function seedSnapshot(Request $request)
+    {
+        $this->guard($request);
+        $this->requireConfirmation($request, 'SEED');
+        $this->logDestructive($request, 'db:seed (full snapshot restore)');
+
+        Artisan::call('db:seed', ['--force' => true]);
+
+        return response('<pre>'.e(Artisan::output()).'</pre>');
+    }
+
+    /**
+     * Drops every table and reruns all migrations, leaving an empty schema
+     * with NO data — for standing up a fresh production DB before real usage
+     * starts. Does not seed; call seedSnapshot() after if dev data is wanted.
+     */
+    public function freshEmpty(Request $request)
+    {
+        $this->guard($request);
+        $this->requireConfirmation($request, 'FRESH');
+        $this->logDestructive($request, 'migrate:fresh (drops all tables)');
+
+        Artisan::call('migrate:fresh', ['--force' => true]);
+
+        return response('<pre>'.e(Artisan::output()).'</pre>');
+    }
+
+    /**
+     * Small standalone HTML form so seed/fresh can be triggered from a
+     * browser without curl, while still forcing the operator to type the
+     * confirm phrase by hand (never pre-filled).
+     */
+    public function console(Request $request)
+    {
+        $this->guard($request);
+
+        return view('Deploy.console', ['token' => $request->query('token')]);
+    }
+}

--- a/resources/views/Deploy/console.blade.php
+++ b/resources/views/Deploy/console.blade.php
@@ -1,0 +1,63 @@
+<!doctype html>
+<html lang="id">
+<head>
+<meta charset="utf-8">
+<title>Deploy Console</title>
+<meta name="robots" content="noindex, nofollow">
+<style>
+  body { font-family: -apple-system, Segoe UI, Arial, sans-serif; max-width: 640px; margin: 40px auto; padding: 0 16px; color: #222; }
+  h1 { font-size: 20px; }
+  h2 { font-size: 15px; margin-top: 32px; border-top: 1px solid #ddd; padding-top: 16px; }
+  .card { border: 1px solid #ddd; border-radius: 8px; padding: 16px; margin: 10px 0; }
+  .card.danger { border-color: #d33; background: #fff5f5; }
+  button, a.btn { display: inline-block; background: #2563eb; color: #fff; border: none; border-radius: 6px; padding: 8px 14px; font-size: 14px; cursor: pointer; text-decoration: none; }
+  .danger button { background: #d33; }
+  input[type=text] { padding: 6px 8px; border: 1px solid #bbb; border-radius: 4px; font-size: 14px; width: 140px; }
+  small { color: #666; }
+  pre { background: #111; color: #ddd; padding: 12px; overflow-x: auto; border-radius: 6px; }
+</style>
+</head>
+<body>
+<h1>Deploy Console</h1>
+<p><small>Token-gated Artisan runner. See <code>cdocs/docs/deploy-shared-hosting.md</code>.</small></p>
+
+<h2>Safe / read-only</h2>
+<div class="card">
+  <a class="btn" href="{{ url('/deploy/migrate-status?token=' . $token) }}" target="_blank">Cek status migrasi</a>
+</div>
+
+<h2>Aman dijalankan berkali-kali (idempotent)</h2>
+<div class="card">
+  <a class="btn" href="{{ url('/deploy/migrate?token=' . $token) }}" target="_blank">Jalankan migrate</a>
+  <p><small>Hanya menjalankan migration yang belum pernah dijalankan.</small></p>
+</div>
+<div class="card">
+  <a class="btn" href="{{ url('/deploy/optimize-clear?token=' . $token) }}" target="_blank">Clear cache (config/cache/view/route)</a>
+</div>
+
+<h2>⚠️ Destruktif — hapus data</h2>
+
+<div class="card danger">
+  <strong>Seed snapshot penuh</strong> (untuk staging/testing)
+  <p><small>Meng-truncate semua tabel di snapshot lalu memuat ulang data dev dari <code>database/seeders/data</code>. <u>Jangan jalankan di database produksi berisi data asli.</u></small></p>
+  <form method="POST" action="{{ url('/deploy/seed?token=' . $token) }}"
+        onsubmit="return confirm('Ini akan MENGHAPUS data di semua tabel snapshot dan menggantinya dengan data dev. Lanjutkan?');">
+    @csrf
+    <label>Ketik <code>SEED</code> untuk konfirmasi: <input type="text" name="confirm" autocomplete="off"></label>
+    <button type="submit">Jalankan db:seed</button>
+  </form>
+</div>
+
+<div class="card danger">
+  <strong>Fresh kosong</strong> (untuk setup awal DB baru/production sebelum ada data asli)
+  <p><small>Drop semua tabel lalu jalankan ulang semua migration. Hasilnya schema kosong, <u>tanpa data sama sekali</u> (tidak seeding). Setelah ini bisa jalankan "Seed snapshot" terpisah kalau perlu data dev.</small></p>
+  <form method="POST" action="{{ url('/deploy/fresh-empty?token=' . $token) }}"
+        onsubmit="return confirm('Ini akan MENGHAPUS SELURUH TABEL dan datanya, lalu membuat ulang schema kosong. Lanjutkan?');">
+    @csrf
+    <label>Ketik <code>FRESH</code> untuk konfirmasi: <input type="text" name="confirm" autocomplete="off"></label>
+    <button type="submit">Jalankan migrate:fresh</button>
+  </form>
+</div>
+
+</body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -5,6 +5,7 @@ use App\Http\Controllers\CustomerController;
 use App\Http\Controllers\CustomerProductReturnController;
 use App\Http\Controllers\CustomerReturnController;
 use App\Http\Controllers\CustomerSupplyReturnController;
+use App\Http\Controllers\DeployController;
 use App\Http\Controllers\ExternalApiController;
 use App\Http\Controllers\GeneralController;
 use App\Http\Controllers\ProductController;
@@ -29,6 +30,25 @@ Route::post('/loginUser', [UserController::class, 'loginUser'])->name('loginUser
 Route::middleware('throttle:60,1')->group(function () {
     Route::get('/api-docs', [ExternalApiController::class, 'publicApiDocumentation'])->name('apiDocsPublic');
     Route::get('/api-docs/{group}', [ExternalApiController::class, 'publicApiDocumentation'])->name('apiDocsPublicGroup');
+});
+
+// Deploy runner untuk shared hosting tanpa SSH/terminal (lihat DeployController
+// dan cdocs/docs/deploy-shared-hosting.md). Sengaja di luar checkLogin — proteksi
+// murni via DEPLOY_TOKEN acak di .env, bukan session. Rate-limited ketat karena
+// endpoint ini bisa dipakai untuk brute-force token kalau tidak dibatasi.
+Route::middleware('throttle:10,1')->prefix('deploy')->group(function () {
+    Route::get('/migrate', [DeployController::class, 'migrate'])->name('deploy.migrate');
+    Route::get('/migrate-status', [DeployController::class, 'status'])->name('deploy.migrateStatus');
+    Route::get('/optimize-clear', [DeployController::class, 'optimizeClear'])->name('deploy.optimizeClear');
+    Route::get('/console', [DeployController::class, 'console'])->name('deploy.console');
+});
+
+// Seed/fresh are data-destructive (truncate/drop tables) — POST-only so a
+// leaked link, crawler, or browser prefetch can never trigger them via GET,
+// and rate-limited tighter than the read/migrate routes above.
+Route::middleware('throttle:5,1')->prefix('deploy')->group(function () {
+    Route::post('/seed', [DeployController::class, 'seedSnapshot'])->name('deploy.seed');
+    Route::post('/fresh-empty', [DeployController::class, 'freshEmpty'])->name('deploy.freshEmpty');
 });
 
 Route::middleware(checkLogin::class)->group(function () {


### PR DESCRIPTION
## Why

Production is going on shared hosting with **no SSH, no cPanel Terminal, and no remote DB access** — `php artisan migrate` can't be run from a local terminal or the server directly, and manually pasting SQL into phpMyAdmin loses Laravel's own migration-tracking.

## What

Token-gated `/deploy/*` routes (`DeployController`) as a browser-triggerable Artisan runner:

**Safe / idempotent (`GET`)**
- `/deploy/migrate` — `php artisan migrate --force`
- `/deploy/migrate-status` — read-only status check
- `/deploy/optimize-clear` — clears config/cache/view/route caches
- `/deploy/console` — standalone HTML page with buttons/forms for everything, so no `curl` needed from a browser/phone

**Data-destructive (`POST`-only)**
- `/deploy/seed` — full dev-data snapshot restore (`db:seed`). Truncates every snapshot table and reloads dev fixtures — for staging, not a live production DB.
- `/deploy/fresh-empty` — drops every table and reruns migrations (`migrate:fresh`), leaving an empty schema with no data — for standing up a brand-new production DB.

POST-only on the destructive routes so a leaked link/crawler/prefetch can never trigger them via a plain `GET`. Both also require a typed confirm phrase (`SEED`/`FRESH`, exact match) in addition to the token, and every call is logged (`Log::warning`, IP + timestamp).

All routes refuse to run (403) unless `DEPLOY_TOKEN` is set in `.env` to a string ≥24 chars — nothing works out of the box until deliberately configured.

Also adds `.cpanel.yml.example`, a template for cPanel's Git Version Control deploy automation (`composer install` + `migrate --force` + cache-clear on every push). Left as `.example` (not `.cpanel.yml`) since the paths inside are host-specific placeholders — activating it requires deliberately filling those in first.

## Rate limits
- 10/min on read/migrate routes
- 5/min on seed/fresh

## Testing
- `php -l` on changed PHP files
- `php artisan route:list` confirms all 6 routes register correctly
- Reflection-based unit checks on the token guard and confirm-phrase guard (403 on missing/wrong token, 403 on missing/wrong confirm phrase, passes through on correct values)
- Blade view renders standalone via `view(...)->render()`

Not tested through the full HTTP stack — this local dev environment's session DB table isn't set up (pre-existing, unrelated to this change; `/login` 500s here the same way).

🤖 Generated with [Claude Code](https://claude.com/claude-code)