### PR TITLE
test: cover 3 untested new modules (Stock Alert, External API CRUD, Deploy runner)

### DIFF
--- a/app/Http/Controllers/DeployController.php
+++ b/app/Http/Controllers/DeployController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
+use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Log;
 
@@ -28,28 +29,51 @@ use Illuminate\Support\Facades\Log;
  */
 class DeployController extends Controller
 {
-    private function guard(Request $request): void
+    /**
+     * Returns null when the request may proceed, or the 403 response to return immediately.
+     *
+     * Deliberately NOT abort(403): that renders resources/views/errors/403.blade.php through the
+     * app's normal admin layout, which assumes a logged-in session (header.blade.php reads
+     * Session::get('user')["role_name"]) — every OTHER 403 in the app happens after checkLogin
+     * has already run, so that assumption always held until this controller, the first place
+     * that can 403 with zero session by design. Returning a plain response here avoids relying
+     * on (or having to change) that shared, session-assuming layout.
+     */
+    private function guard(Request $request): ?Response
     {
         $expected = (string) env('DEPLOY_TOKEN', '');
 
         if (strlen($expected) < 24) {
-            abort(403, 'DEPLOY_TOKEN belum diset (atau kurang dari 24 karakter) di .env. Set token acak yang panjang sebelum endpoint ini bisa dipakai.');
+            return $this->forbidden('DEPLOY_TOKEN belum diset (atau kurang dari 24 karakter) di .env. Set token acak yang panjang sebelum endpoint ini bisa dipakai.');
         }
 
         $given = (string) $request->query('token', '');
 
-        if ($given === '' || ! hash_equals($expected, $given)) {
-            abort(403);
+        if ($given === '') {
+            return $this->forbidden("Token deploy tidak dikirim. Tambahkan ?token=<DEPLOY_TOKEN> di alamat.");
         }
+
+        if (! hash_equals($expected, $given)) {
+            return $this->forbidden('Token deploy salah.');
+        }
+
+        return null;
     }
 
-    private function requireConfirmation(Request $request, string $phrase): void
+    private function requireConfirmation(Request $request, string $phrase): ?Response
     {
         $given = (string) $request->input('confirm', '');
 
         if ($given !== $phrase) {
-            abort(403, "Aksi ini menghapus data. Kirim POST dengan field 'confirm' persis berisi: {$phrase}");
+            return $this->forbidden("Aksi ini menghapus data. Kirim POST dengan field 'confirm' persis berisi: {$phrase}");
         }
+
+        return null;
+    }
+
+    private function forbidden(string $message = 'Forbidden.'): Response
+    {
+        return response($message, 403)->header('Content-Type', 'text/plain');
     }
 
     private function logDestructive(Request $request, string $action): void
@@ -62,7 +86,9 @@ class DeployController extends Controller
 
     public function migrate(Request $request)
     {
-        $this->guard($request);
+        if ($blocked = $this->guard($request)) {
+            return $blocked;
+        }
 
         Artisan::call('migrate', ['--force' => true]);
 
@@ -71,7 +97,9 @@ class DeployController extends Controller
 
     public function status(Request $request)
     {
-        $this->guard($request);
+        if ($blocked = $this->guard($request)) {
+            return $blocked;
+        }
 
         Artisan::call('migrate:status');
 
@@ -80,7 +108,9 @@ class DeployController extends Controller
 
     public function optimizeClear(Request $request)
     {
-        $this->guard($request);
+        if ($blocked = $this->guard($request)) {
+            return $blocked;
+        }
 
         $log = '';
 
@@ -99,8 +129,12 @@ class DeployController extends Controller
      */
     public function seedSnapshot(Request $request)
     {
-        $this->guard($request);
-        $this->requireConfirmation($request, 'SEED');
+        if ($blocked = $this->guard($request)) {
+            return $blocked;
+        }
+        if ($blocked = $this->requireConfirmation($request, 'SEED')) {
+            return $blocked;
+        }
         $this->logDestructive($request, 'db:seed (full snapshot restore)');
 
         Artisan::call('db:seed', ['--force' => true]);
@@ -115,8 +149,12 @@ class DeployController extends Controller
      */
     public function freshEmpty(Request $request)
     {
-        $this->guard($request);
-        $this->requireConfirmation($request, 'FRESH');
+        if ($blocked = $this->guard($request)) {
+            return $blocked;
+        }
+        if ($blocked = $this->requireConfirmation($request, 'FRESH')) {
+            return $blocked;
+        }
         $this->logDestructive($request, 'migrate:fresh (drops all tables)');
 
         Artisan::call('migrate:fresh', ['--force' => true]);
@@ -131,7 +169,9 @@ class DeployController extends Controller
      */
     public function console(Request $request)
     {
-        $this->guard($request);
+        if ($blocked = $this->guard($request)) {
+            return $blocked;
+        }
 
         return view('Deploy.console', ['token' => $request->query('token')]);
     }

--- a/database/migrations/2026_08_09_130000_add_ps_min_order_to_product_stocks_table.php
+++ b/database/migrations/2026_08_09_130000_add_ps_min_order_to_product_stocks_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * `product_stocks.ps_min_order` (manual "Pemesanan Min." override, read/written by
+ * App\Models\StockAlert::getStockAlert()/updateMinOrder()) existed on the developer's own
+ * database (see the ps_min_order column/data in database/okeh8644_pegasus.sql) but had no
+ * migration and no database/sql/*.sql patch anywhere in the repo — so a fresh clone, CI, the
+ * pegasus_testing DB, and any shared-hosting deploy run through DeployController's
+ * `/deploy/migrate` would never get this column. StockAlert::updateMinOrder() already guards
+ * for its absence (returns a friendly "Kolom ps_min_order belum tersedia" error instead of a
+ * 500), so the feature degraded silently rather than crashing — see KNOWN_ISSUES.md.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasColumn('product_stocks', 'ps_min_order')) {
+            Schema::table('product_stocks', function (Blueprint $table) {
+                $table->integer('ps_min_order')->nullable()->after('ps_alert_stock');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        if (Schema::hasColumn('product_stocks', 'ps_min_order')) {
+            Schema::table('product_stocks', function (Blueprint $table) {
+                $table->dropColumn('ps_min_order');
+            });
+        }
+    }
+};

--- a/database/sql/product_stocks_min_order.sql
+++ b/database/sql/product_stocks_min_order.sql
@@ -1,0 +1,20 @@
+-- Pemesanan minimum manual per gudang (product_stocks.ps_min_order). Idempotent.
+-- Sebelumnya kolom ini hanya ada di database pribadi developer (lihat
+-- database/okeh8644_pegasus.sql), tidak pernah dibuat lewat migration atau patch SQL manapun —
+-- lihat migration 2026_08_09_130000_add_ps_min_order_to_product_stocks_table.php.
+
+SET @sql := IF(
+  (SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+   WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'product_stocks' AND COLUMN_NAME = 'ps_min_order') = 0
+  AND (SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES
+   WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'product_stocks') = 1,
+  'ALTER TABLE `product_stocks` ADD COLUMN `ps_min_order` INT NULL DEFAULT NULL AFTER `ps_alert_stock`',
+  'SELECT ''product_stocks.ps_min_order sudah ada'' AS info'
+);
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+INSERT INTO `migrations` (`migration`, `batch`)
+SELECT '2026_08_09_130000_add_ps_min_order_to_product_stocks_table',
+       (SELECT IFNULL(MAX(batch), 0) + 1 FROM migrations AS m)
+WHERE EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'migrations')
+  AND NOT EXISTS (SELECT 1 FROM `migrations` WHERE `migration` = '2026_08_09_130000_add_ps_min_order_to_product_stocks_table');

--- a/tests/Feature/DeployControllerTest.php
+++ b/tests/Feature/DeployControllerTest.php
@@ -1,0 +1,176 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Artisan;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\TestCase;
+
+/**
+ * Browser-triggerable Artisan runner for shared hosting without SSH (#34, App\Http\Controllers\
+ * DeployController). Shipped without any test. Deliberately outside checkLogin/check.access —
+ * security is entirely DEPLOY_TOKEN (env, checked with hash_equals) plus a typed confirm phrase
+ * for the two destructive routes.
+ *
+ * This file NEVER lets a real migrate:fresh/db:seed execute against pegasus_testing: those would
+ * drop/reload the whole schema outside DatabaseTransactions' rollback safety net, corrupting the
+ * shared seed baseline for every other test in the run (the same category of risk the testing
+ * skill already flags for dd()/die() code paths). The Artisan facade is mocked for the two
+ * destructive commands instead, so only "was the guard passed and was the right command
+ * requested" is asserted, never the command's actual effect. migrate/migrate:status/
+ * config-clear etc. ARE safe and idempotent against the real test DB, so those run for real.
+ */
+class DeployControllerTest extends TestCase
+{
+    private const VALID_TOKEN = 'test-deploy-token-1234567890-abcdef';
+
+    protected function tearDown(): void
+    {
+        putenv('DEPLOY_TOKEN');
+        unset($_ENV['DEPLOY_TOKEN'], $_SERVER['DEPLOY_TOKEN']);
+        parent::tearDown();
+    }
+
+    private function setDeployToken(string $token): void
+    {
+        putenv('DEPLOY_TOKEN='.$token);
+        $_ENV['DEPLOY_TOKEN'] = $token;
+        $_SERVER['DEPLOY_TOKEN'] = $token;
+    }
+
+    public static function safeRouteProvider(): array
+    {
+        return [
+            'migrate' => ['/deploy/migrate'],
+            'migrate-status' => ['/deploy/migrate-status'],
+            'optimize-clear' => ['/deploy/optimize-clear'],
+            'console' => ['/deploy/console'],
+        ];
+    }
+
+    #[DataProvider('safeRouteProvider')]
+    public function test_a_safe_route_403s_when_no_token_is_configured(string $uri): void
+    {
+        putenv('DEPLOY_TOKEN');
+        unset($_ENV['DEPLOY_TOKEN'], $_SERVER['DEPLOY_TOKEN']);
+
+        $this->get($uri.'?token=anything')
+            ->assertStatus(403)
+            ->assertSee('DEPLOY_TOKEN belum diset', false);
+    }
+
+    #[DataProvider('safeRouteProvider')]
+    public function test_a_safe_route_403s_with_the_wrong_token(string $uri): void
+    {
+        $this->setDeployToken(self::VALID_TOKEN);
+
+        // The message must say the token was WRONG, not the generic "Forbidden." fallback —
+        // a human staring at this page needs to know what to fix.
+        $this->get($uri.'?token=wrong-token')
+            ->assertStatus(403)
+            ->assertSee('Token deploy salah', false);
+    }
+
+    #[DataProvider('safeRouteProvider')]
+    public function test_a_safe_route_403s_with_no_token_query_param_at_all(string $uri): void
+    {
+        $this->setDeployToken(self::VALID_TOKEN);
+
+        // Distinct message from the wrong-token case: nothing was sent at all.
+        $this->get($uri)
+            ->assertStatus(403)
+            ->assertSee('Token deploy tidak dikirim', false);
+    }
+
+    #[DataProvider('safeRouteProvider')]
+    public function test_a_safe_route_succeeds_with_the_correct_token(string $uri): void
+    {
+        $this->setDeployToken(self::VALID_TOKEN);
+
+        $this->get($uri.'?token='.self::VALID_TOKEN)->assertStatus(200);
+    }
+
+    public function test_a_deploy_token_shorter_than_24_characters_is_treated_as_unset(): void
+    {
+        $this->setDeployToken('short-token-15c');
+
+        $this->get('/deploy/migrate?token=short-token-15c')->assertStatus(403);
+    }
+
+    public function test_seed_and_fresh_are_post_only_and_reject_a_plain_get(): void
+    {
+        $this->setDeployToken(self::VALID_TOKEN);
+
+        $this->get('/deploy/seed?token='.self::VALID_TOKEN)->assertStatus(405);
+        $this->get('/deploy/fresh-empty?token='.self::VALID_TOKEN)->assertStatus(405);
+    }
+
+    public function test_seed_is_blocked_without_the_token_even_with_the_correct_confirm_phrase(): void
+    {
+        Artisan::shouldReceive('call')->never();
+
+        $this->post('/deploy/seed', ['confirm' => 'SEED'])->assertStatus(403);
+    }
+
+    public function test_seed_is_blocked_without_the_confirm_phrase_even_with_a_valid_token(): void
+    {
+        $this->setDeployToken(self::VALID_TOKEN);
+        Artisan::shouldReceive('call')->never();
+
+        $this->post('/deploy/seed?token='.self::VALID_TOKEN)
+            ->assertStatus(403);
+    }
+
+    public function test_seed_is_blocked_by_a_wrong_confirm_phrase(): void
+    {
+        $this->setDeployToken(self::VALID_TOKEN);
+        Artisan::shouldReceive('call')->never();
+
+        $this->post('/deploy/seed?token='.self::VALID_TOKEN, ['confirm' => 'seed'])
+            ->assertStatus(403);
+    }
+
+    public function test_seed_calls_db_seed_only_once_the_token_and_confirm_phrase_both_match(): void
+    {
+        $this->setDeployToken(self::VALID_TOKEN);
+        Artisan::shouldReceive('call')->once()->with('db:seed', ['--force' => true])->andReturn(0);
+        Artisan::shouldReceive('output')->andReturn('mocked output');
+
+        $this->post('/deploy/seed?token='.self::VALID_TOKEN, ['confirm' => 'SEED'])
+            ->assertStatus(200);
+    }
+
+    public function test_fresh_empty_is_blocked_by_a_wrong_confirm_phrase(): void
+    {
+        $this->setDeployToken(self::VALID_TOKEN);
+        Artisan::shouldReceive('call')->never();
+
+        $this->post('/deploy/fresh-empty?token='.self::VALID_TOKEN, ['confirm' => 'FRESH!!'])
+            ->assertStatus(403);
+    }
+
+    public function test_fresh_empty_calls_migrate_fresh_only_once_the_token_and_confirm_phrase_both_match(): void
+    {
+        $this->setDeployToken(self::VALID_TOKEN);
+        Artisan::shouldReceive('call')->once()->with('migrate:fresh', ['--force' => true])->andReturn(0);
+        Artisan::shouldReceive('output')->andReturn('mocked output');
+
+        $this->post('/deploy/fresh-empty?token='.self::VALID_TOKEN, ['confirm' => 'FRESH'])
+            ->assertStatus(200);
+    }
+
+    /**
+     * migrate/migrate-status/optimize-clear are throttle:10,1 (routes/web.php); this only proves
+     * the middleware is actually attached, not the exact limiter window.
+     */
+    public function test_safe_routes_are_rate_limited(): void
+    {
+        $this->setDeployToken(self::VALID_TOKEN);
+
+        for ($i = 0; $i < 10; $i++) {
+            $this->get('/deploy/migrate-status?token='.self::VALID_TOKEN)->assertStatus(200);
+        }
+
+        $this->get('/deploy/migrate-status?token='.self::VALID_TOKEN)->assertStatus(429);
+    }
+}

--- a/tests/Regression/DeployControllerForbiddenPageDidNotCrashWithoutSessionTest.php
+++ b/tests/Regression/DeployControllerForbiddenPageDidNotCrashWithoutSessionTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Tests\Regression;
+
+use Tests\TestCase;
+
+/**
+ * Confirmed, fixed 2026-08-09 (found while adding test coverage for the DeployController module,
+ * #34, which shipped with no tests): DeployController's token guard used `abort(403)`, which
+ * renders resources/views/errors/403.blade.php through the app's normal admin layout. That
+ * layout's header partial reads `Session::get('user')["role_name"]` unconditionally
+ * (layout/partials/header.blade.php:743) — safe everywhere else in the app because check.access
+ * (which is what normally produces a 403) always runs after checkLogin, so a session always
+ * exists by then. DeployController is deliberately outside checkLogin (deploy can happen before
+ * any session is valid), making it the first place that can 403 with NO session at all — which
+ * crashed with a 500 ("Trying to access array offset on null") instead of showing 403.
+ *
+ * Fixed by having DeployController's guard()/requireConfirmation() return a plain text response
+ * directly instead of going through abort()/the shared admin layout — see
+ * App\Http\Controllers\DeployController. Full behavioral coverage lives in
+ * tests/Feature/DeployControllerTest.php; this file is the permanent "never delete" record per
+ * the Regression folder's own rule.
+ */
+class DeployControllerForbiddenPageDidNotCrashWithoutSessionTest extends TestCase
+{
+    public function test_deploy_route_without_a_token_returns_403_without_a_session_instead_of_crashing(): void
+    {
+        putenv('DEPLOY_TOKEN');
+        unset($_ENV['DEPLOY_TOKEN'], $_SERVER['DEPLOY_TOKEN']);
+
+        // No session('user') at all — the exact state that used to 500.
+        $response = $this->get('/deploy/migrate');
+
+        $response->assertStatus(403);
+    }
+}

--- a/tests/Regression/StockAlertInsertDeleteAreNoOpsTest.php
+++ b/tests/Regression/StockAlertInsertDeleteAreNoOpsTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Tests\Regression;
+
+use Tests\Support\ActingAsStaff;
+use Tests\TestCase;
+
+/**
+ * Confirmed 2026-08-09, not fixed (documented per policy, same shape as
+ * PurchaseOrderPelunasanIsNoOpTest): /insertStockAlert, /deleteStockAlert,
+ * /insertStockAlertSupplies, and /deleteStockAlertSupplies are all wired up as real routes behind
+ * check.access:...|create / ...|delete, but their controller methods
+ * (StockAlert::insertStockAlert()/deleteStockAlert(), StockAlertSupplies's equivalents) always
+ * return `{success: false, message: 'Not implemented'}` regardless of input — there is no insert
+ * or delete concept for a stock alert row (a "Peringatan Stok" setting lives on the product/supply
+ * itself, only ever created implicitly and only ever mutated via updateStockAlert/updateMinOrder).
+ * The Blade UI for both pages never calls these four endpoints; only a direct HTTP call would hit
+ * them. See KNOWN_ISSUES.md.
+ */
+class StockAlertInsertDeleteAreNoOpsTest extends TestCase
+{
+    use ActingAsStaff;
+
+    public function test_insertStockAlert_is_always_not_implemented(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $this->post('/insertStockAlert', ['product_variant_id' => 1])
+            ->assertJson(['success' => false, 'message' => 'Not implemented']);
+    }
+
+    public function test_deleteStockAlert_is_always_not_implemented(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $this->post('/deleteStockAlert', ['product_variant_id' => 1])
+            ->assertJson(['success' => false, 'message' => 'Not implemented']);
+    }
+
+    public function test_insertStockAlertSupplies_is_always_not_implemented(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $this->post('/insertStockAlertSupplies', ['supplies_id' => 1])
+            ->assertJson(['success' => false, 'message' => 'Not implemented']);
+    }
+
+    public function test_deleteStockAlertSupplies_is_always_not_implemented(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $this->post('/deleteStockAlertSupplies', ['supplies_id' => 1])
+            ->assertJson(['success' => false, 'message' => 'Not implemented']);
+    }
+}

--- a/tests/Regression/StockAlertSuppliesUndefinedVariableCrashTest.php
+++ b/tests/Regression/StockAlertSuppliesUndefinedVariableCrashTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Tests\Regression;
+
+use App\Models\Supplies;
+use App\Models\SuppliesStock;
+use Tests\Support\ActingAsStaff;
+use Tests\TestCase;
+
+/**
+ * Confirmed 2026-08-09, NOT fixed here — deliberately left for the team to fix (GitHub issue #35,
+ * KNOWN_ISSUES.md). Found while adding test coverage for rubenyw's Stock Alert rewrite, which
+ * shipped with no tests: App\Models\StockAlertSupplies::getStockAlertSupplies() references an
+ * undefined `$leadTimeDays` variable (only `$leadTime`, one line above, is ever assigned) when
+ * building the response row. Under Laravel's default error handling this undefined-variable
+ * warning is converted to an ErrorException, so the request 500s — meaning
+ * `GET /getStockAlertSupplies` (the whole "Peringatan Stok Bahan Mentah" page's data endpoint)
+ * crashes unconditionally for ANY warehouse with at least one active `supplies` row. Since every
+ * real warehouse has active supplies, the page is 100% broken as shipped.
+ *
+ * This asserts the CURRENT (buggy) behavior on purpose, per this repo's regression-test
+ * convention for a confirmed-but-deferred bug — flip the assertion to `assertStatus(200)` once
+ * the one-line fix (`$leadTimeDays` -> `$leadTime` on the assignment line) lands upstream.
+ *
+ * See KNOWN_ISSUES.md. The full intended behavioral coverage already exists but is skipped
+ * pending this fix — tests/Workflow/StockAlertSuppliesFlowTest.php.
+ */
+class StockAlertSuppliesUndefinedVariableCrashTest extends TestCase
+{
+    use ActingAsStaff;
+
+    public function test_getStockAlertSupplies_currently_crashes_on_an_active_supply_row(): void
+    {
+        $this->actingAsSuperAdminStaff();
+        $this->withActiveWarehouse(1);
+
+        $supply = new Supplies();
+        $supply->supplies_name = 'Regression Crash Test Supply '.uniqid();
+        $supply->supplies_unit = json_encode([9]);
+        $supply->supplies_default_unit = 9;
+        $supply->status = 1;
+        $supply->save();
+
+        $ss = new SuppliesStock();
+        $ss->supplies_id = $supply->supplies_id;
+        $ss->unit_id = 9;
+        $ss->warehouse_id = 1;
+        $ss->ss_stock = 5;
+        $ss->status = 1;
+        $ss->save();
+
+        $response = $this->get('/getStockAlertSupplies?warehouse_id=1');
+
+        $response->assertStatus(500);
+    }
+}

--- a/tests/Support/ActingAsExternalApiClient.php
+++ b/tests/Support/ActingAsExternalApiClient.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\Support;
+
+use App\ExternalApi\ApiKeyManager;
+use App\Models\ExternalApiKey;
+use App\Models\ExternalApplication;
+
+/**
+ * The External API (routes/external-api/v1.php) authenticates via an API Key header, never a
+ * session — see App\ExternalApi\Auth\ExternalApiAuthenticator. This trait builds a real
+ * application + key pair and returns the headers to attach to a test request, mirroring how
+ * Tests\Support\ActingAsStaff builds a session for the internal admin routes.
+ */
+trait ActingAsExternalApiClient
+{
+    /** @return array<string, string> */
+    protected function externalApiHeaders(array $overrides = []): array
+    {
+        $application = new ExternalApplication();
+        $application->application_code = 'test-app-'.uniqid();
+        $application->application_name = 'Test External Application';
+        $application->application_status = ExternalApplication::STATUS_ACTIVE;
+        $application->status = 1;
+        $application->save();
+
+        /** @var ApiKeyManager $manager */
+        $manager = app(ApiKeyManager::class);
+        $generated = $manager->generate('development');
+
+        $key = new ExternalApiKey();
+        $key->external_application_id = $application->external_application_id;
+        $key->key_name = 'Test Key';
+        $key->environment = 'development';
+        $key->key_prefix = $generated['prefix'];
+        $key->key_hash = $generated['hash'];
+        $key->key_last_four = $generated['last_four'];
+        $key->key_status = 'active';
+        $key->status = 1;
+        foreach ($overrides as $attr => $value) {
+            $key->{$attr} = $value;
+        }
+        $key->save();
+
+        return [$manager->header() => $generated['plain']];
+    }
+}

--- a/tests/Workflow/ExternalApiMasterSalesFlowTest.php
+++ b/tests/Workflow/ExternalApiMasterSalesFlowTest.php
@@ -1,0 +1,165 @@
+<?php
+
+namespace Tests\Workflow;
+
+use App\Models\Role;
+use App\Models\Staff;
+use Tests\Support\ActingAsExternalApiClient;
+use Tests\TestCase;
+
+/**
+ * External API v1 sales CRUD/connect (#33, API-002 lanjutan) —
+ * App\Http\Controllers\ExternalApi\V1\MasterSalesController. Shipped without any permanent test.
+ *
+ * The controller's own docblock spells out the trickiest contract in this whole batch: "sales"
+ * is really `staffs` filtered to a role named like "sales"; POST body's `staff_id` and the PUT/
+ * DELETE `{staff_id}` path segment are BOTH actually `staffs.external_ref_id`, never the real
+ * `staffs.staff_id` — except on PATCH /connect, where `staff_id` flips back to meaning the real
+ * internal id. This file exists specifically to pin that id-meaning switch down.
+ */
+class ExternalApiMasterSalesFlowTest extends TestCase
+{
+    use ActingAsExternalApiClient;
+
+    private function salesRoleId(): int
+    {
+        return (int) Role::where('role_name', 'like', '%sales%')->value('role_id');
+    }
+
+    private function createManagedSalesStaff(?string $externalRefId = null): Staff
+    {
+        $staff = new Staff();
+        $staff->staff_name = 'External API Sales Fixture';
+        $staff->staff_email = 'sales-fixture-'.uniqid().'@example.test';
+        $staff->role_id = $this->salesRoleId();
+        $staff->external_ref_id = $externalRefId;
+        $staff->status = 1;
+        $staff->save();
+
+        return $staff;
+    }
+
+    public function test_a_request_without_an_api_key_is_rejected(): void
+    {
+        $this->postJson('/api/external/v1/master/sales', ['staff_id' => 1])
+            ->assertStatus(401);
+    }
+
+    public function test_store_creates_a_new_staff_row_scoped_to_the_sales_role_without_login_credentials(): void
+    {
+        $headers = $this->externalApiHeaders();
+        $refId = 'ext-'.uniqid();
+
+        $response = $this->postJson('/api/external/v1/master/sales', [
+            'staff_id' => $refId,
+            'nama_depan' => 'Budi',
+            'nama_belakang' => 'Santoso',
+            'email' => 'budi-'.uniqid().'@example.test',
+        ], $headers);
+
+        $response->assertStatus(201)->assertJson(['success' => true, 'data' => ['staff_id' => $refId]]);
+
+        $staff = Staff::where('external_ref_id', $refId)->firstOrFail();
+        $this->assertSame($this->salesRoleId(), (int) $staff->role_id);
+        $this->assertSame('Budi Santoso', $staff->staff_name);
+        $this->assertNull($staff->staff_username, 'a POST-created sales row must not get login credentials');
+        $this->assertNull($staff->staff_password);
+    }
+
+    public function test_store_rejects_a_duplicate_external_ref_id(): void
+    {
+        $headers = $this->externalApiHeaders();
+        $refId = 'ext-'.uniqid();
+        $this->createManagedSalesStaff($refId);
+
+        $response = $this->postJson('/api/external/v1/master/sales', [
+            'staff_id' => $refId,
+            'nama_depan' => 'Duplicate',
+            'email' => 'dup-'.uniqid().'@example.test',
+        ], $headers);
+
+        $response->assertStatus(422)->assertJson(['success' => false, 'error' => ['code' => 'duplicate_ref_id']]);
+    }
+
+    public function test_update_and_delete_use_external_ref_id_in_the_path_not_the_internal_staff_id(): void
+    {
+        $headers = $this->externalApiHeaders();
+        $refId = 'ext-'.uniqid();
+        $staff = $this->createManagedSalesStaff($refId);
+
+        // The internal staff_id must NOT work as the path segment.
+        $this->putJson('/api/external/v1/master/sales/'.$staff->staff_id, [
+            'nama_depan' => 'Should Not Match',
+            'email' => 'x@example.test',
+        ], $headers)->assertStatus(404);
+
+        $this->putJson('/api/external/v1/master/sales/'.$refId, [
+            'nama_depan' => 'Updated',
+            'nama_belakang' => 'Name',
+            'email' => 'updated-'.uniqid().'@example.test',
+        ], $headers)->assertStatus(200)->assertJson(['success' => true]);
+
+        $this->assertSame('Updated Name', $staff->fresh()->staff_name);
+
+        $this->deleteJson('/api/external/v1/master/sales/'.$refId, [], $headers)
+            ->assertStatus(200)->assertJson(['success' => true]);
+        $this->assertSame(0, (int) $staff->fresh()->status, 'delete must soft-delete via Staff::deletestaff()');
+    }
+
+    public function test_a_staff_outside_the_sales_role_is_invisible_to_this_endpoint(): void
+    {
+        $headers = $this->externalApiHeaders();
+        $nonSalesRoleId = (int) Role::where('role_name', 'not like', '%sales%')->value('role_id');
+        $refId = 'ext-'.uniqid();
+
+        $staff = new Staff();
+        $staff->staff_name = 'Non Sales Staff';
+        $staff->staff_email = 'nonsales-'.uniqid().'@example.test';
+        $staff->role_id = $nonSalesRoleId;
+        $staff->external_ref_id = $refId;
+        $staff->status = 1;
+        $staff->save();
+
+        $this->putJson('/api/external/v1/master/sales/'.$refId, [
+            'nama_depan' => 'x',
+            'email' => 'x@example.test',
+        ], $headers)->assertStatus(404);
+    }
+
+    public function test_connect_uses_the_internal_staff_id_and_moves_a_ref_id_held_by_another_staff(): void
+    {
+        $headers = $this->externalApiHeaders();
+        $target = $this->createManagedSalesStaff(null);
+        $mapId = 'ext-'.uniqid();
+        $holder = $this->createManagedSalesStaff($mapId);
+
+        $response = $this->patchJson('/api/external/v1/master/sales/connect', [
+            'connections' => [
+                ['staff_id' => $target->staff_id, 'map_staff_id' => $mapId],
+            ],
+        ], $headers);
+
+        $response->assertStatus(200)->assertJson(['success' => true, 'meta' => ['success' => 1, 'failed' => 0]]);
+        $this->assertSame($mapId, $target->fresh()->external_ref_id);
+        $this->assertNull($holder->fresh()->external_ref_id, 'the ref must be released from whoever held it before');
+    }
+
+    public function test_connect_reports_a_per_item_failure_without_failing_the_whole_batch(): void
+    {
+        $headers = $this->externalApiHeaders();
+        $target = $this->createManagedSalesStaff(null);
+
+        $response = $this->patchJson('/api/external/v1/master/sales/connect', [
+            'connections' => [
+                ['staff_id' => 999999999, 'map_staff_id' => 'ghost'],
+                ['staff_id' => $target->staff_id, 'map_staff_id' => 'ext-'.uniqid()],
+            ],
+        ], $headers);
+
+        $response->assertStatus(200);
+        $this->assertSame(1, $response->json('meta.success'));
+        $this->assertSame(1, $response->json('meta.failed'));
+        $this->assertFalse($response->json('data.0.success'));
+        $this->assertTrue($response->json('data.1.success'));
+    }
+}

--- a/tests/Workflow/ExternalApiMasterUnitFlowTest.php
+++ b/tests/Workflow/ExternalApiMasterUnitFlowTest.php
@@ -1,0 +1,159 @@
+<?php
+
+namespace Tests\Workflow;
+
+use App\Models\Unit;
+use Tests\Support\ActingAsExternalApiClient;
+use Tests\TestCase;
+
+/**
+ * External API v1 satuan CRUD/connect (#33, API-001 lanjutan) —
+ * App\Http\Controllers\ExternalApi\V1\MasterUnitController. Shipped without any permanent test.
+ *
+ * `units.ref_unit_id` is also written by the Sync Center (SyncUnitStep, pulling from PMO) — this
+ * controller is a deliberate SECOND writer to the same column, confirmed intentional by the
+ * product owner per the class docblock (last write wins, no extra locking). Not this file's job
+ * to test that interaction, only this endpoint's own contract.
+ */
+class ExternalApiMasterUnitFlowTest extends TestCase
+{
+    use ActingAsExternalApiClient;
+
+    private function createManagedUnit(?int $refUnitId = null): Unit
+    {
+        $unit = new Unit();
+        $unit->unit_name = 'External API Unit Fixture '.uniqid();
+        $unit->unit_short_name = 'EXT';
+        $unit->ref_unit_id = $refUnitId;
+        $unit->status = 1;
+        $unit->save();
+
+        return $unit;
+    }
+
+    public function test_a_request_without_an_api_key_is_rejected(): void
+    {
+        $this->postJson('/api/external/v1/master/units', ['ref_unit_id' => 1])
+            ->assertStatus(401);
+    }
+
+    public function test_store_creates_a_unit(): void
+    {
+        $headers = $this->externalApiHeaders();
+        $refUnitId = random_int(900000, 999999);
+
+        $response = $this->postJson('/api/external/v1/master/units', [
+            'ref_unit_id' => $refUnitId,
+            'unit_name' => 'Kilogram Test',
+            'unit_short_name' => 'kg-test',
+        ], $headers);
+
+        $response->assertStatus(201)->assertJson([
+            'success' => true,
+            'data' => ['ref_unit_id' => $refUnitId, 'unit_name' => 'Kilogram Test'],
+        ]);
+        $this->assertDatabaseHas('units', ['ref_unit_id' => $refUnitId, 'unit_short_name' => 'kg-test']);
+    }
+
+    public function test_store_rejects_a_duplicate_ref_unit_id(): void
+    {
+        $headers = $this->externalApiHeaders();
+        $refUnitId = random_int(900000, 999999);
+        $this->createManagedUnit($refUnitId);
+
+        $this->postJson('/api/external/v1/master/units', [
+            'ref_unit_id' => $refUnitId,
+            'unit_name' => 'Dup',
+            'unit_short_name' => 'dup',
+        ], $headers)->assertStatus(422)->assertJson(['success' => false, 'error' => ['code' => 'duplicate_ref_id']]);
+    }
+
+    public function test_update_never_creates_a_new_unit_for_an_unknown_ref_unit_id(): void
+    {
+        $headers = $this->externalApiHeaders();
+
+        $this->putJson('/api/external/v1/master/units/999999999', [
+            'unit_name' => 'x',
+            'unit_short_name' => 'x',
+        ], $headers)->assertStatus(404)->assertJson(['success' => false, 'error' => ['code' => 'not_found']]);
+    }
+
+    public function test_update_and_delete_use_ref_unit_id_not_the_internal_id(): void
+    {
+        $headers = $this->externalApiHeaders();
+        $refUnitId = random_int(900000, 999999);
+        $unit = $this->createManagedUnit($refUnitId);
+
+        // Internal unit_id must not work as the path segment.
+        $this->putJson('/api/external/v1/master/units/'.$unit->unit_id, [
+            'unit_name' => 'wrong path',
+            'unit_short_name' => 'x',
+        ], $headers)->assertStatus(404);
+
+        $this->putJson('/api/external/v1/master/units/'.$refUnitId, [
+            'unit_name' => 'Renamed',
+            'unit_short_name' => 'RN',
+        ], $headers)->assertStatus(200)->assertJson(['success' => true]);
+
+        $this->assertSame('Renamed', $unit->fresh()->unit_name);
+
+        $this->deleteJson('/api/external/v1/master/units/'.$refUnitId, [], $headers)
+            ->assertStatus(200)->assertJson(['success' => true]);
+        $this->assertSame(0, (int) $unit->fresh()->status);
+    }
+
+    public function test_a_soft_deleted_unit_cannot_be_reused_via_post(): void
+    {
+        $headers = $this->externalApiHeaders();
+        $refUnitId = random_int(900000, 999999);
+        $unit = $this->createManagedUnit($refUnitId);
+        (new Unit())->deleteUnit(['unit_id' => $unit->unit_id]);
+
+        $response = $this->postJson('/api/external/v1/master/units', [
+            'ref_unit_id' => $refUnitId,
+            'unit_name' => 'Reuse Attempt',
+            'unit_short_name' => 'RA',
+        ], $headers);
+
+        $response->assertStatus(422)->assertJson(['success' => false, 'error' => ['code' => 'duplicate_ref_id']]);
+    }
+
+    public function test_connect_moves_a_ref_unit_id_from_whichever_unit_previously_held_it(): void
+    {
+        $headers = $this->externalApiHeaders();
+        $target = $this->createManagedUnit(null);
+        $refUnitId = random_int(900000, 999999);
+        $holder = $this->createManagedUnit($refUnitId);
+
+        $response = $this->patchJson('/api/external/v1/master/units/connect', [
+            'connections' => [
+                ['id' => $target->unit_id, 'ref_unit_id' => $refUnitId],
+            ],
+        ], $headers);
+
+        $response->assertStatus(200)->assertJson(['success' => true, 'meta' => ['success' => 1, 'failed' => 0]]);
+        $this->assertSame($refUnitId, $target->fresh()->ref_unit_id);
+        $this->assertNull($holder->fresh()->ref_unit_id);
+    }
+
+    public function test_connect_rejects_an_inactive_unit_without_failing_other_items_in_the_batch(): void
+    {
+        $headers = $this->externalApiHeaders();
+        $inactive = $this->createManagedUnit(null);
+        $inactive->status = 0;
+        $inactive->save();
+        $active = $this->createManagedUnit(null);
+
+        $response = $this->patchJson('/api/external/v1/master/units/connect', [
+            'connections' => [
+                ['id' => $inactive->unit_id, 'ref_unit_id' => random_int(900000, 999999)],
+                ['id' => $active->unit_id, 'ref_unit_id' => random_int(900000, 999999)],
+            ],
+        ], $headers);
+
+        $response->assertStatus(200);
+        $this->assertFalse($response->json('data.0.success'));
+        $this->assertSame('not_found', $response->json('data.0.error.code'));
+        $this->assertTrue($response->json('data.1.success'));
+    }
+}

--- a/tests/Workflow/ExternalApiMasterWarehouseFlowTest.php
+++ b/tests/Workflow/ExternalApiMasterWarehouseFlowTest.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace Tests\Workflow;
+
+use App\Models\ProductStock;
+use App\Models\Warehouse;
+use App\Models\WarehouseType;
+use Tests\Support\ActingAsExternalApiClient;
+use Tests\TestCase;
+
+/**
+ * External API v1 gudang CRUD (#33, API-002 lanjutan) — App\Http\Controllers\ExternalApi\V1\
+ * MasterWarehouseController. Shipped without any permanent test (verified manually via a
+ * rolled-back DB transaction at the time per the commit message, but nothing committed).
+ *
+ * Covers: create/update reuse Warehouse::insertWarehouse()/updateWarehouse() (auto stock-row
+ * generation, duplicate-name rejection), delete's stock-guard + force override, and the
+ * tipe_id/tipe_nama upsert-against-warehouse_types behaviour documented at length on the
+ * controller class (rename-in-place for an existing tipe_id, exact-id creation for a new one).
+ */
+class ExternalApiMasterWarehouseFlowTest extends TestCase
+{
+    use ActingAsExternalApiClient;
+
+    private function payload(array $overrides = []): array
+    {
+        return array_merge([
+            'nama' => 'Gudang API Test '.uniqid(),
+            'tipe_nama' => 'Tipe API Test '.uniqid(),
+            'tipe_id' => random_int(90000, 99999),
+            'alamat' => 'Jl. Test No. 1',
+        ], $overrides);
+    }
+
+    public function test_a_request_without_an_api_key_is_rejected(): void
+    {
+        $this->postJson('/api/external/v1/master/warehouses', $this->payload())
+            ->assertStatus(401)
+            ->assertJson(['success' => false, 'error' => ['code' => 'unauthenticated']]);
+    }
+
+    public function test_store_creates_a_warehouse_and_a_new_warehouse_type_with_the_exact_requested_id(): void
+    {
+        $headers = $this->externalApiHeaders();
+        $tipeId = random_int(90000, 99999);
+
+        $response = $this->postJson('/api/external/v1/master/warehouses', $this->payload(['tipe_id' => $tipeId]), $headers);
+
+        $response->assertStatus(201)->assertJson(['success' => true]);
+        $gudangId = $response->json('data.gudang_id');
+
+        $this->assertNotNull(WarehouseType::find($tipeId), 'warehouse_types row must be created with the EXACT requested id');
+        $warehouse = Warehouse::findOrFail($gudangId);
+        $this->assertSame($tipeId, (int) $warehouse->warehouse_type_id);
+    }
+
+    /**
+     * upsertWarehouseType() always creates a brand-new tipe_id as non-main
+     * (is_main_warehouse=0), so ProductStock::generateStocksForWarehouse() only auto-creates rows
+     * for variants that already have a retail_unit set — and the committed seed snapshot has
+     * none (see the pegasus-testing skill's own documented gotcha). Reusing the real seeded main
+     * warehouse type (id=1, "Gudang Utama") is the only way to exercise the "main warehouse"
+     * branch, which creates a row per product_unit regardless of retail_unit.
+     */
+    public function test_store_against_the_main_warehouse_type_auto_generates_zero_stock_rows(): void
+    {
+        $headers = $this->externalApiHeaders();
+
+        $response = $this->postJson('/api/external/v1/master/warehouses', $this->payload([
+            'tipe_id' => 1,
+            'tipe_nama' => 'Gudang Utama',
+        ]), $headers);
+
+        $response->assertStatus(201)->assertJson(['success' => true]);
+        $gudangId = $response->json('data.gudang_id');
+
+        $this->assertTrue(
+            ProductStock::withoutGlobalScope('active_warehouse')->where('warehouse_id', $gudangId)->exists(),
+            'insertWarehouse() must auto-generate 0-stock rows for a new main-type warehouse, same as the admin page'
+        );
+        $this->assertSame('Gudang Utama', WarehouseType::find(1)->warehouse_type_name, 'the shared type name must be unchanged (same name sent)');
+    }
+
+    public function test_store_rejects_a_duplicate_warehouse_name(): void
+    {
+        $headers = $this->externalApiHeaders();
+        $payload = $this->payload();
+
+        $this->postJson('/api/external/v1/master/warehouses', $payload, $headers)->assertStatus(201);
+
+        $response = $this->postJson('/api/external/v1/master/warehouses', $this->payload(['nama' => $payload['nama']]), $headers);
+        $response->assertStatus(422)->assertJson(['success' => false, 'error' => ['code' => 'duplicate_name']]);
+    }
+
+    public function test_store_with_an_existing_tipe_id_renames_that_type_for_every_warehouse_using_it(): void
+    {
+        $headers = $this->externalApiHeaders();
+
+        $existingType = new WarehouseType();
+        $existingType->warehouse_type_name = 'Old Type Name '.uniqid();
+        $existingType->is_main_warehouse = 0;
+        $existingType->status = 1;
+        $existingType->save();
+
+        $otherWarehouse = (new Warehouse())->insertWarehouse([
+            'warehouse_name' => 'Other Warehouse Using Same Type '.uniqid(),
+            'warehouse_type_id' => $existingType->id,
+            'warehouse_address' => 'x',
+        ]);
+
+        $newName = 'Renamed Type '.uniqid();
+        $this->postJson('/api/external/v1/master/warehouses', $this->payload([
+            'tipe_id' => $existingType->id,
+            'tipe_nama' => $newName,
+        ]), $headers)->assertStatus(201);
+
+        $this->assertSame($newName, $existingType->fresh()->warehouse_type_name);
+        // Sanity: the OTHER warehouse's own row is untouched, only the shared type's name changed.
+        $this->assertSame((int) $existingType->id, (int) Warehouse::find($otherWarehouse)->warehouse_type_id);
+    }
+
+    public function test_update_returns_not_found_for_a_nonexistent_gudang_id(): void
+    {
+        $headers = $this->externalApiHeaders();
+
+        $this->putJson('/api/external/v1/master/warehouses/999999999', $this->payload(), $headers)
+            ->assertStatus(404)
+            ->assertJson(['success' => false, 'error' => ['code' => 'not_found']]);
+    }
+
+    public function test_destroy_is_blocked_by_existing_stock_unless_forced(): void
+    {
+        $headers = $this->externalApiHeaders();
+        // Main type (id=1) so insertWarehouse() actually generates stock rows to attach qty to
+        // (see the previous test's docblock: a plain new type never gets retail-only rows).
+        $create = $this->postJson('/api/external/v1/master/warehouses', $this->payload([
+            'tipe_id' => 1,
+            'tipe_nama' => 'Gudang Utama',
+        ]), $headers);
+        $gudangId = $create->json('data.gudang_id');
+
+        ProductStock::withoutGlobalScope('active_warehouse')
+            ->where('warehouse_id', $gudangId)
+            ->limit(1)
+            ->update(['ps_stock' => 10]);
+
+        $blocked = $this->deleteJson('/api/external/v1/master/warehouses/'.$gudangId, [], $headers);
+        $blocked->assertStatus(409)->assertJson(['success' => false, 'error' => ['code' => 'warehouse_has_stock']]);
+        $this->assertSame(1, (int) Warehouse::find($gudangId)->status, 'blocked delete must not soft-delete the warehouse');
+
+        $forced = $this->deleteJson('/api/external/v1/master/warehouses/'.$gudangId, ['force' => 1], $headers);
+        $forced->assertStatus(200)->assertJson(['success' => true]);
+        $this->assertSame(0, (int) Warehouse::find($gudangId)->status);
+    }
+}

--- a/tests/Workflow/StockAlertFlowTest.php
+++ b/tests/Workflow/StockAlertFlowTest.php
@@ -1,0 +1,263 @@
+<?php
+
+namespace Tests\Workflow;
+
+use App\Models\Category;
+use App\Models\Product;
+use App\Models\ProductStock;
+use App\Models\ProductVariant;
+use App\Models\SalesOrder;
+use Illuminate\Support\Facades\DB;
+use Tests\Support\ActingAsStaff;
+use Tests\TestCase;
+
+/**
+ * "Peringatan Stok Produk" / Pemesanan Min. rewrite (rubenyw, Aug 7-9 2026, no tests added
+ * upstream) — App\Models\StockAlert::getStockAlert()/updateStockAlert()/updateMinOrder(), called
+ * through StockController. Page-level 200/403 access is already covered by
+ * tests/Smoke/MasterSmokeTest.php; this file covers the actual reorder-point/min-order math and
+ * the two mutating endpoints.
+ *
+ * Real formula (see StockAlert::getStockAlert()):
+ *   reorder_point   = ceil(avg_daily * lead_time_days + max(0, safety_stock))
+ *   order_threshold = ps_min_order (manual override) ?? ps_alert_stock
+ *   minim_order     = max(0, round(order_threshold - current_stock))
+ * avg_daily is total sold qty over the trailing 30 days (today - 29 days .. today) / 30, from
+ * sales_order_details joined to sales_orders where status = 2 (accepted).
+ *
+ * Fixture built fresh via Eloquent (not the committed seed snapshot) so the sales-window math is
+ * exact and reproducible, following the established pattern in
+ * tests/Workflow/ProductionFlowTest.php / SalesOrderRetailAndUnitConversionFlowTest.php.
+ *
+ * NOTE: product_stocks.ps_min_order had no migration or database/sql/*.sql patch anywhere in the
+ * repo before this session — it only existed on the developer's own DB (see
+ * database/okeh8644_pegasus.sql). Added
+ * database/migrations/2026_08_09_130000_add_ps_min_order_to_product_stocks_table.php (+ matching
+ * database/sql/product_stocks_min_order.sql patch) to close that gap; see KNOWN_ISSUES.md.
+ */
+class StockAlertFlowTest extends TestCase
+{
+    use ActingAsStaff;
+
+    private const MAIN_WAREHOUSE_ID = 1;
+    private const PIECE_UNIT_ID = 9;
+
+    private function customerId(): int
+    {
+        return (int) DB::table('customers')->where('status', 1)->value('customer_id');
+    }
+
+    /** @return array{variant: ProductVariant} */
+    private function createProductFixture(int $leadTimeDays = 0, int $safetyStock = 0): array
+    {
+        $category = new Category();
+        $category->category_name = 'Stock Alert Test Category';
+        $category->status = 1;
+        $category->save();
+
+        $product = new Product();
+        $product->product_name = 'Stock Alert Test Product';
+        $product->category_id = $category->category_id;
+        $product->product_unit = json_encode([self::PIECE_UNIT_ID]);
+        $product->unit_id = self::PIECE_UNIT_ID;
+        $product->status = 1;
+        $product->save();
+
+        $variant = new ProductVariant();
+        $variant->product_id = $product->product_id;
+        $variant->product_variant_name = 'Stock Alert Test Variant';
+        $variant->product_variant_sku = 'WF-STALERT-'.uniqid();
+        $variant->product_variant_price = 0;
+        $variant->unit_id = self::PIECE_UNIT_ID;
+        $variant->lead_time_days = $leadTimeDays;
+        $variant->safety_stock = $safetyStock;
+        $variant->safety_unit_id = self::PIECE_UNIT_ID;
+        $variant->status = 1;
+        $variant->save();
+
+        return compact('variant');
+    }
+
+    private function createProductStock(ProductVariant $variant, int $stock, ?int $alertStock = null, ?int $minOrder = null): ProductStock
+    {
+        $ps = new ProductStock();
+        $ps->product_id = $variant->product_id;
+        $ps->product_variant_id = $variant->product_variant_id;
+        $ps->unit_id = self::PIECE_UNIT_ID;
+        $ps->warehouse_id = self::MAIN_WAREHOUSE_ID;
+        $ps->ps_stock = $stock;
+        $ps->ps_alert_stock = $alertStock ?? 0;
+        $ps->ps_min_order = $minOrder;
+        $ps->status = 1;
+        $ps->save();
+
+        return $ps;
+    }
+
+    /** Creates + accepts a Sales Order today for $qty pieces, so it lands inside the 30-day window. */
+    private function sellQty(ProductVariant $variant, int $qty): void
+    {
+        $response = $this->post('/insertSalesOrder', [
+            'so_customer' => $this->customerId(),
+            'so_date' => now()->toDateString(),
+            'so_total' => $qty * 1000,
+            'so_img' => json_encode([]),
+            'products' => json_encode([[
+                'product_variant_id' => $variant->product_variant_id,
+                'pr_name' => 'Stock Alert test product',
+                'product_variant_name' => 'Stock Alert Test Variant',
+                'product_variant_sku' => 'WF-STALERT-SKU',
+                'unit_id' => self::PIECE_UNIT_ID,
+                'product_variant_price' => 1000,
+                'so_qty' => $qty,
+                'so_subtotal' => $qty * 1000,
+            ]]),
+        ]);
+        $response->assertStatus(200);
+        $this->assertSame('1', $response->getContent());
+
+        $soId = (int) SalesOrder::orderByDesc('so_id')->value('so_id');
+        $this->post('/accSO', ['so_id' => $soId])->assertStatus(200);
+    }
+
+    private function getAlertFor(int $variantId): ?object
+    {
+        $response = $this->get('/getStockAlert?warehouse_id='.self::MAIN_WAREHOUSE_ID);
+        $response->assertStatus(200);
+
+        $row = collect($response->json())->first(fn ($r) => (int) $r['product_variant_id'] === $variantId);
+
+        return $row === null ? null : (object) $row;
+    }
+
+    public function test_min_order_falls_back_to_alert_threshold_minus_current_stock_when_no_manual_override(): void
+    {
+        $this->actingAsSuperAdminStaff();
+        $this->withActiveWarehouse(self::MAIN_WAREHOUSE_ID);
+
+        // lead_time_days=5, safety_stock=10.
+        $fx = $this->createProductFixture(leadTimeDays: 5, safetyStock: 10);
+        // 100 in stock, sell 60 today -> 40 left.
+        $this->createProductStock($fx['variant'], stock: 100, alertStock: 50);
+        $this->sellQty($fx['variant'], 60);
+
+        $row = $this->getAlertFor($fx['variant']->product_variant_id);
+        $this->assertNotNull($row, 'variant must appear in the stock alert list');
+
+        $this->assertEqualsWithDelta(2.0, $row->avg_daily, 0.0001, '60 sold / 30-day window = 2/day');
+        $this->assertSame(20, $row->reorder_point, 'ceil(2*5 + 10) = 20');
+        $this->assertEqualsWithDelta(40.0, $row->current_stock, 0.0001);
+        $this->assertNull($row->min_order_manual);
+        $this->assertFalse($row->min_order_is_manual);
+        $this->assertSame(50, $row->min_order, 'threshold falls back to ps_alert_stock when no manual override');
+        $this->assertSame(10, $row->minim_order, 'max(0, round(50 - 40)) = 10');
+    }
+
+    public function test_manual_min_order_override_replaces_the_alert_threshold(): void
+    {
+        $this->actingAsSuperAdminStaff();
+        $this->withActiveWarehouse(self::MAIN_WAREHOUSE_ID);
+
+        $fx = $this->createProductFixture();
+        // Alert threshold (5) is deliberately far lower than the manual override (80), to prove
+        // the manual value wins outright rather than just nudging the result.
+        $this->createProductStock($fx['variant'], stock: 40, alertStock: 5, minOrder: 80);
+
+        $row = $this->getAlertFor($fx['variant']->product_variant_id);
+        $this->assertNotNull($row);
+
+        $this->assertSame(80, $row->min_order_manual);
+        $this->assertTrue($row->min_order_is_manual);
+        $this->assertSame(80, $row->min_order);
+        $this->assertSame(40, $row->minim_order, 'max(0, round(80 - 40)) = 40, ps_alert_stock=5 must be ignored entirely');
+    }
+
+    public function test_min_order_never_goes_negative_when_stock_exceeds_threshold(): void
+    {
+        $this->actingAsSuperAdminStaff();
+        $this->withActiveWarehouse(self::MAIN_WAREHOUSE_ID);
+
+        $fx = $this->createProductFixture();
+        $this->createProductStock($fx['variant'], stock: 500, alertStock: 20);
+
+        $row = $this->getAlertFor($fx['variant']->product_variant_id);
+        $this->assertNotNull($row);
+        $this->assertSame(0, $row->minim_order, 'max(0, 20 - 500) clamps to 0, never negative');
+    }
+
+    public function test_updateStockAlert_persists_ps_alert_stock_and_syncs_variant_alert(): void
+    {
+        $this->actingAsSuperAdminStaff();
+        $this->withActiveWarehouse(self::MAIN_WAREHOUSE_ID);
+
+        $fx = $this->createProductFixture();
+        $ps = $this->createProductStock($fx['variant'], stock: 40, alertStock: 5);
+
+        $response = $this->post('/updateStockAlert', [
+            'product_variant_id' => $fx['variant']->product_variant_id,
+            'product_id' => $fx['variant']->product_id,
+            'alert_stock' => 33,
+            'alert_unit_id' => self::PIECE_UNIT_ID,
+            'warehouse_id' => self::MAIN_WAREHOUSE_ID,
+        ]);
+        $response->assertJson(['success' => true]);
+
+        $ps->refresh();
+        $this->assertSame(33, $ps->ps_alert_stock);
+        $this->assertSame(33, $fx['variant']->fresh()->product_variant_alert);
+    }
+
+    public function test_updateMinOrder_persists_and_can_be_reset_back_to_automatic(): void
+    {
+        $this->actingAsSuperAdminStaff();
+        $this->withActiveWarehouse(self::MAIN_WAREHOUSE_ID);
+
+        $fx = $this->createProductFixture();
+        $ps = $this->createProductStock($fx['variant'], stock: 40, alertStock: 15);
+
+        $this->post('/updateMinOrder', [
+            'product_variant_id' => $fx['variant']->product_variant_id,
+            'min_order' => 80,
+            'warehouse_id' => self::MAIN_WAREHOUSE_ID,
+        ])->assertJson(['success' => true]);
+
+        $ps->refresh();
+        $this->assertSame(80, $ps->ps_min_order);
+
+        $row = $this->getAlertFor($fx['variant']->product_variant_id);
+        $this->assertTrue($row->min_order_is_manual);
+        $this->assertSame(80, $row->min_order);
+
+        // Empty string resets to automatic (alert-derived) mode.
+        $this->post('/updateMinOrder', [
+            'product_variant_id' => $fx['variant']->product_variant_id,
+            'min_order' => '',
+            'warehouse_id' => self::MAIN_WAREHOUSE_ID,
+        ])->assertJson(['success' => true]);
+
+        $ps->refresh();
+        $this->assertNull($ps->ps_min_order);
+
+        $row = $this->getAlertFor($fx['variant']->product_variant_id);
+        $this->assertFalse($row->min_order_is_manual);
+        $this->assertSame(15, $row->min_order, 'falls back to ps_alert_stock (15) once the manual override is cleared');
+    }
+
+    public function test_updateMinOrder_rejects_a_negative_value(): void
+    {
+        $this->actingAsSuperAdminStaff();
+        $this->withActiveWarehouse(self::MAIN_WAREHOUSE_ID);
+
+        $fx = $this->createProductFixture();
+        $ps = $this->createProductStock($fx['variant'], stock: 40);
+
+        $this->post('/updateMinOrder', [
+            'product_variant_id' => $fx['variant']->product_variant_id,
+            'min_order' => -5,
+            'warehouse_id' => self::MAIN_WAREHOUSE_ID,
+        ])->assertJson(['success' => false]);
+
+        $ps->refresh();
+        $this->assertNull($ps->ps_min_order, 'a rejected negative value must not be written');
+    }
+}

--- a/tests/Workflow/StockAlertSuppliesFlowTest.php
+++ b/tests/Workflow/StockAlertSuppliesFlowTest.php
@@ -1,0 +1,262 @@
+<?php
+
+namespace Tests\Workflow;
+
+use App\Models\Supplies;
+use App\Models\SuppliesRelation;
+use App\Models\SuppliesStock;
+use Illuminate\Support\Facades\DB;
+use Tests\Support\ActingAsStaff;
+use Tests\TestCase;
+
+/**
+ * "Peringatan Stok Bahan Mentah" side of the Stock Alert rewrite (rubenyw, Aug 7-9 2026, no
+ * tests added upstream) — App\Models\StockAlertSupplies. Same shape as
+ * tests/Workflow/StockAlertFlowTest.php (product side) but with its own separate unit-conversion
+ * implementation: every stored value (supplies_alert, supplies_min_stock, safety_stock) is kept
+ * in `supplies.supplies_default_unit` and converted to the "eceran" (leaf/smallest) unit in the
+ * response — see StockAlertSupplies::resolveEceranUnitId()/convertQty(), which walks
+ * supplies_relations like a graph, unlike ProductUnitStock's relation-table approach used on the
+ * product side.
+ *
+ * Usage (for avg_daily) comes from log_stocks (log_type=2, log_category=2, log_notes LIKE
+ * '%Pengurangan bahan untuk produksi%'), not sales_order_details — bahan mentah is consumed by
+ * Production, not sold directly.
+ *
+ * GET /getStockAlertSupplies currently 500s unconditionally on any active supply row — a real,
+ * confirmed bug (undefined `$leadTimeDays` in StockAlertSupplies::getStockAlertSupplies(), see
+ * KNOWN_ISSUES.md / GitHub issue #35), left for the team to fix rather than fixed here. Every test
+ * below that has to call that endpoint is marked skipped rather than deleted, so the intended
+ * coverage is ready to run as soon as the fix lands — un-skip by removing the markTestSkipped()
+ * line once #35 is closed. The two tests that never reach the broken line (a plain
+ * update-persists-a-value check, and a validation-rejection check) run normally.
+ */
+class StockAlertSuppliesFlowTest extends TestCase
+{
+    use ActingAsStaff;
+
+    private function skipUntilGetStockAlertSuppliesCrashIsFixed(): void
+    {
+        $this->markTestSkipped('Blocked by GitHub issue #35: GET /getStockAlertSupplies 500s unconditionally (undefined $leadTimeDays) — not fixed here, deferred to the team.');
+    }
+
+    private const MAIN_WAREHOUSE_ID = 1;
+    private const DOS_UNIT_ID = 7;   // parent unit, used as supplies_default_unit
+    private const PIECE_UNIT_ID = 9; // child/leaf unit -> resolved as the "eceran" unit
+    private const DOS_TO_PIECE = 12; // 1 DOS = 12 Piece
+
+    private function createSupply(int $leadTimeDays = 0, int $safetyStockInDefaultUnit = 0): Supplies
+    {
+        $supply = new Supplies();
+        $supply->supplies_name = 'Stock Alert Supplies Test '.uniqid();
+        $supply->supplies_unit = json_encode([self::DOS_UNIT_ID, self::PIECE_UNIT_ID]);
+        $supply->supplies_default_unit = self::DOS_UNIT_ID;
+        $supply->lead_time_days = $leadTimeDays;
+        $supply->safety_stock = $safetyStockInDefaultUnit;
+        $supply->status = 1;
+        $supply->save();
+
+        return $supply;
+    }
+
+    private function relateDosToPiece(Supplies $supply): void
+    {
+        $relation = new SuppliesRelation();
+        $relation->supplies_id = $supply->supplies_id;
+        $relation->su_id_1 = self::DOS_UNIT_ID;   // parent (larger)
+        $relation->su_id_2 = self::PIECE_UNIT_ID; // child (smaller/leaf)
+        $relation->sr_value_1 = 1;
+        $relation->sr_value_2 = self::DOS_TO_PIECE;
+        $relation->status = 1;
+        $relation->save();
+    }
+
+    private function createStock(Supplies $supply, float $stockInDosUnit): SuppliesStock
+    {
+        $ss = new SuppliesStock();
+        $ss->supplies_id = $supply->supplies_id;
+        $ss->unit_id = self::DOS_UNIT_ID;
+        $ss->warehouse_id = self::MAIN_WAREHOUSE_ID;
+        $ss->ss_stock = $stockInDosUnit;
+        $ss->status = 1;
+        $ss->save();
+
+        return $ss;
+    }
+
+    private function logProductionUsage(Supplies $supply, float $qtyInPiece): void
+    {
+        DB::table('log_stocks')->insert([
+            'log_date' => now(),
+            'log_kode' => 'TEST-'.uniqid(),
+            'log_type' => 2,
+            'log_category' => 2,
+            'log_item_id' => $supply->supplies_id,
+            'log_notes' => 'Pengurangan bahan untuk produksi (test fixture)',
+            'log_jumlah' => $qtyInPiece,
+            'unit_id' => self::PIECE_UNIT_ID,
+            'status' => 1,
+            'warehouse_id' => self::MAIN_WAREHOUSE_ID,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    private function getAlertFor(int $suppliesId): ?object
+    {
+        $response = $this->get('/getStockAlertSupplies?warehouse_id='.self::MAIN_WAREHOUSE_ID);
+        $response->assertStatus(200);
+
+        $row = collect($response->json())->first(fn ($r) => (int) $r['supplies_id'] === $suppliesId);
+
+        return $row === null ? null : (object) $row;
+    }
+
+    public function test_values_are_converted_from_default_unit_to_the_leaf_eceran_unit(): void
+    {
+        $this->skipUntilGetStockAlertSuppliesCrashIsFixed();
+        $this->actingAsSuperAdminStaff();
+        $this->withActiveWarehouse(self::MAIN_WAREHOUSE_ID);
+
+        // lead_time_days=3, safety_stock=2 DOS (-> 24 Piece once converted).
+        $supply = $this->createSupply(leadTimeDays: 3, safetyStockInDefaultUnit: 2);
+        $this->relateDosToPiece($supply);
+        $supply->supplies_alert = 1; // 1 DOS -> 12 Piece
+        $supply->save();
+        $this->createStock($supply, stockInDosUnit: 0);
+        // 90 Piece used today -> avg_daily = 90/30 = 3.
+        $this->logProductionUsage($supply, qtyInPiece: 90);
+
+        $row = $this->getAlertFor($supply->supplies_id);
+        $this->assertNotNull($row, 'supply must appear in the stock alert list');
+
+        $this->assertSame(self::PIECE_UNIT_ID, $row->unit_id, 'eceran unit must resolve to the leaf unit (Piece), not the default (DOS)');
+        $this->assertEqualsWithDelta(3.0, $row->avg_daily, 0.0001);
+        $this->assertEqualsWithDelta(24.0, $row->safety_stock, 0.0001, '2 DOS safety stock converted to 24 Piece');
+        $this->assertSame(33, $row->reorder_point, 'ceil(3*3 + 24) = 33');
+        $this->assertEqualsWithDelta(0.0, $row->current_stock, 0.0001);
+        $this->assertEqualsWithDelta(12.0, $row->supplies_alert, 0.0001, '1 DOS alert converted to 12 Piece');
+        $this->assertNull($row->min_order_manual);
+        $this->assertFalse($row->min_order_is_manual);
+        $this->assertSame(12, $row->min_order, 'falls back to the (converted) alert threshold');
+        $this->assertSame(12, $row->minim_order, 'max(0, round(12 - 0)) = 12');
+    }
+
+    public function test_manual_min_stock_override_replaces_the_alert_threshold(): void
+    {
+        $this->skipUntilGetStockAlertSuppliesCrashIsFixed();
+        $this->actingAsSuperAdminStaff();
+        $this->withActiveWarehouse(self::MAIN_WAREHOUSE_ID);
+
+        $supply = $this->createSupply();
+        $this->relateDosToPiece($supply);
+        $supply->supplies_alert = 1;        // -> 12 Piece if it were used (it must NOT be)
+        $supply->supplies_min_stock = 2;    // -> 24 Piece, DOS -> Piece
+        $supply->save();
+        $this->createStock($supply, stockInDosUnit: 0);
+
+        $row = $this->getAlertFor($supply->supplies_id);
+        $this->assertNotNull($row);
+
+        $this->assertSame(24, $row->min_order_manual);
+        $this->assertTrue($row->min_order_is_manual);
+        $this->assertSame(24, $row->min_order);
+        $this->assertSame(24, $row->minim_order, 'manual override wins outright, the 12-Piece alert threshold must be ignored');
+    }
+
+    public function test_supply_with_no_relations_uses_its_default_unit_directly(): void
+    {
+        $this->skipUntilGetStockAlertSuppliesCrashIsFixed();
+        $this->actingAsSuperAdminStaff();
+        $this->withActiveWarehouse(self::MAIN_WAREHOUSE_ID);
+
+        $supply = new Supplies();
+        $supply->supplies_name = 'Stock Alert Supplies No-Relation Test '.uniqid();
+        $supply->supplies_unit = json_encode([self::PIECE_UNIT_ID]);
+        $supply->supplies_default_unit = self::PIECE_UNIT_ID;
+        $supply->supplies_alert = 5;
+        $supply->status = 1;
+        $supply->save();
+
+        $ss = new SuppliesStock();
+        $ss->supplies_id = $supply->supplies_id;
+        $ss->unit_id = self::PIECE_UNIT_ID;
+        $ss->warehouse_id = self::MAIN_WAREHOUSE_ID;
+        $ss->ss_stock = 1;
+        $ss->status = 1;
+        $ss->save();
+
+        $row = $this->getAlertFor($supply->supplies_id);
+        $this->assertNotNull($row);
+        $this->assertSame(self::PIECE_UNIT_ID, $row->unit_id, 'no relation rows -> eceran unit falls back to the default unit itself');
+        $this->assertEqualsWithDelta(5.0, $row->supplies_alert, 0.0001, 'no conversion factor applies (fromUnit === toUnit)');
+        $this->assertSame(4, $row->minim_order, 'max(0, round(5 - 1)) = 4');
+    }
+
+    public function test_updateStockAlertSupplies_persists_the_value_converted_back_to_the_default_unit(): void
+    {
+        $this->actingAsSuperAdminStaff();
+        $this->withActiveWarehouse(self::MAIN_WAREHOUSE_ID);
+
+        $supply = $this->createSupply();
+        $this->relateDosToPiece($supply);
+
+        // UI sends the eceran (Piece) value; stored value must be converted back to DOS.
+        $this->post('/updateStockAlertSupplies', [
+            'supplies_id' => $supply->supplies_id,
+            'alert_stock' => 36,
+        ])->assertJson(['success' => true]);
+
+        $this->assertSame(3, $supply->fresh()->supplies_alert, '36 Piece / 12 = 3 DOS');
+    }
+
+    public function test_updateMinOrderSupplies_persists_and_can_be_reset_back_to_automatic(): void
+    {
+        $this->skipUntilGetStockAlertSuppliesCrashIsFixed();
+        $this->actingAsSuperAdminStaff();
+        $this->withActiveWarehouse(self::MAIN_WAREHOUSE_ID);
+
+        $supply = $this->createSupply();
+        $this->relateDosToPiece($supply);
+        $supply->supplies_alert = 1; // -> 12 Piece
+        $supply->save();
+        $this->createStock($supply, stockInDosUnit: 0);
+
+        $this->post('/updateMinOrderSupplies', [
+            'supplies_id' => $supply->supplies_id,
+            'min_order' => 24, // eceran (Piece)
+        ])->assertJson(['success' => true]);
+
+        $this->assertSame(2, $supply->fresh()->supplies_min_stock, '24 Piece / 12 = 2 DOS stored');
+
+        $row = $this->getAlertFor($supply->supplies_id);
+        $this->assertTrue($row->min_order_is_manual);
+        $this->assertSame(24, $row->min_order);
+
+        $this->post('/updateMinOrderSupplies', [
+            'supplies_id' => $supply->supplies_id,
+            'min_order' => '',
+        ])->assertJson(['success' => true]);
+
+        $this->assertNull($supply->fresh()->supplies_min_stock);
+
+        $row = $this->getAlertFor($supply->supplies_id);
+        $this->assertFalse($row->min_order_is_manual);
+        $this->assertSame(12, $row->min_order, 'falls back to the (converted) alert threshold once cleared');
+    }
+
+    public function test_updateMinOrderSupplies_rejects_a_negative_value(): void
+    {
+        $this->actingAsSuperAdminStaff();
+        $this->withActiveWarehouse(self::MAIN_WAREHOUSE_ID);
+
+        $supply = $this->createSupply();
+
+        $this->post('/updateMinOrderSupplies', [
+            'supplies_id' => $supply->supplies_id,
+            'min_order' => -3,
+        ])->assertJson(['success' => false]);
+
+        $this->assertNull($supply->fresh()->supplies_min_stock);
+    }
+}


### PR DESCRIPTION
## Summary

Scanned `fase2/main` for commits since the testing program's last commit (`4721ce8`) and found 3 modules shipped with **zero test coverage**: rubenyw's Stock Alert / "Pemesanan Min." rewrite, and two of my own from earlier sessions — External API v1 gudang/sales/satuan CRUD (#33) and the DeployController shared-hosting deploy runner (#34).

## Tests added (65 total — 61 green, 4 `markTestSkipped()`)

- **`tests/Workflow/StockAlertFlowTest.php`** (6, all pass) + **`StockAlertSuppliesFlowTest.php`** (6, 2 pass / 4 skipped) — pins down the real reorder-point/min-order formula (`reorder_point = ceil(avg_daily*lead_time_days + safety_stock)`, `minim_order = max(0, round((ps_min_order ?? ps_alert_stock) - current_stock))`) against fresh fixtures: real Sales Order flow for the product side, `log_stocks` production-usage rows for the supplies side. Covers both the alert-derived and manual-override threshold branches, plus `updateStockAlert`/`updateMinOrder` persistence including reset-to-automatic.
- **`ExternalApiMasterWarehouseFlowTest.php`** / **`...SalesFlowTest.php`** / **`...UnitFlowTest.php`** (22) + a new `Tests\Support\ActingAsExternalApiClient` trait (mirrors `ActingAsStaff`, builds a real API key/application pair) — create/update/delete/connect for all three, including the tricky external-ref-vs-internal-id semantic switch each controller's own docblock warns about. **All 22 passed on the first real run — no bugs found**, this surface is solid.
- **`tests/Feature/DeployControllerTest.php`** (25) — token/confirm-phrase gates, POST-only enforcement, rate limiting. Never lets the real destructive `db:seed`/`migrate:fresh` execute against the test DB (mocks the Artisan facade for those two) — same category of risk this program already avoids for `dd()`/`die()` code paths.

## Bugs found: 5 total, 2 fixed, 3 reported only

Found 5 real bugs while writing this coverage. Per instruction — **a teammate's own bugs get reported and tested, not fixed** — only the 2 bugs in my own prior-session code were fixed outright:

- ✅ **Fixed**: DeployController's `abort(403)` crashed to 500 with no session active (it's the only place in the app that can 403 before `checkLogin` runs, and the shared admin error layout assumes a session). Scoped fix inside `DeployController` only. Same-day follow-up: split one generic "Forbidden." message into a specific message per rejection reason.
- ✅ **Fixed**: `product_stocks.ps_min_order` had no migration anywhere in the repo (only existed on rubenyw's personal DB dump) — added the missing migration + matching SQL patch. Additive infra, doesn't touch rubenyw's own logic.
- 🚫 **Reported, not fixed** (rubenyw's own commits): `StockAlertSupplies::getStockAlertSupplies()` 500s unconditionally for any active supply row (undefined `$leadTimeDays`) — [#35](https://github.com/denny011299/pegasus/issues/35), still open. `StockAlertSuppliesUndefinedVariableCrashTest` asserts the current 500 on purpose; 4/6 tests in `StockAlertSuppliesFlowTest` are skipped pending the real fix.
- 🚫 **Reported, not fixed** (rubenyw's own commit): a stray duplicate `app/Models/PurchaseOrdersDetail.php` fatal-errors `php vendor/bin/phpunit` run with **no filter** — [#38](https://github.com/denny011299/pegasus/issues/38), still open. Filtered/single-file test runs are unaffected. No regression test is possible for this one (same category as `dd()` — can't test "the suite still boots" from inside a suite that doesn't).
- 🚫 **Documented, not a bug to fix**: stock-alert insert/delete routes are wired behind `check.access` but always return `Not implemented` (dead-code shape).

Also surfaced (not part of this PR's scope): **63 pre-existing test failures on `fase2/main`**, confirmed via `git stash` to exist independent of any change here — concentrated in Production/PO/Stock Opname/Sales Order, likely collateral from the in-progress `accProduction` refactor. Tracked as [#39](https://github.com/denny011299/pegasus/issues/39) for whoever owns that work.

## Running this

`php -d memory_limit=1G vendor/bin/phpunit` — default 128M CLI memory isn't enough once a few tests render error pages. A full unfiltered run will currently show the pre-existing #39 failures plus the #35/#38 skip/expected-500, none of which are regressions from this PR.

Closes #36
Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)