### PR TITLE
feat: pesan error izin akses (403) yang konsisten di semua popup ajax

### DIFF
--- a/app/Http/Middleware/checkLogin.php
+++ b/app/Http/Middleware/checkLogin.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Middleware;
 
+use App\Models\Role;
 use Closure;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Session;
@@ -16,9 +17,45 @@ class checkLogin
      */
     public function handle(Request $request, Closure $next)
     {
-        if(!Session::has('user')){ 
+        if(!Session::has('user')){
             return redirect('/login');
         }
+
+        $this->refreshRoleOnHardReload($request);
+
         return $next($request);
+    }
+
+    /**
+     * role_access dipatri ke session sejak login, jadi perubahan hak akses oleh admin
+     * baru kepakai kalau staff itu login ulang. Sebagai jalan pintas tanpa perlu logout,
+     * browser hard-refresh (Ctrl+Shift+R / Cmd+Shift+R) mengirim header Cache-Control/
+     * Pragma: no-cache yang tidak dikirim saat refresh biasa (F5, max-age=0) atau request
+     * AJAX biasa — jadi dipakai sebagai sinyal untuk menarik ulang role_access dari DB.
+     */
+    private function refreshRoleOnHardReload(Request $request): void
+    {
+        if ($request->ajax() || $request->wantsJson()) {
+            return;
+        }
+
+        $cacheControl = strtolower((string) $request->header('Cache-Control'));
+        $pragma = strtolower((string) $request->header('Pragma'));
+        $isHardReload = str_contains($cacheControl, 'no-cache') || str_contains($pragma, 'no-cache');
+        if (!$isHardReload) {
+            return;
+        }
+
+        $user = Session::get('user');
+        $roleId = (int) ($user->role_id ?? 0);
+        if ($roleId <= 0) {
+            return;
+        }
+
+        $role = Role::find($roleId);
+        if ($role) {
+            $user->role_access = $role->role_access;
+            Session::put('user', $user);
+        }
     }
 }

--- a/public/Custom_js/Backoffice/Area/Area.js
+++ b/public/Custom_js/Backoffice/Area/Area.js
@@ -77,6 +77,7 @@
                 feather.replace(); // Biar icon feather muncul lagi
             },
             error: function (err) {
+                if (handlePermissionError(err)) return;
                 console.error("Gagal load wilayah:", err);
             }
         });
@@ -125,7 +126,8 @@
                 afterInsert();
             },
             error:function(e){
-                ResetLoadingButton('.btn-save', mode == 1?"Tambah Wilayah" : "Update Wilayah"); 
+                ResetLoadingButton('.btn-save', mode == 1?"Tambah Wilayah" : "Update Wilayah");
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });
@@ -178,6 +180,7 @@
                 
             },
             error:function(e){
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });

--- a/public/Custom_js/Backoffice/Customers/Customer.js
+++ b/public/Custom_js/Backoffice/Customers/Customer.js
@@ -86,6 +86,7 @@
                 feather.replace(); // Biar icon feather muncul lagi
             },
             error: function (err) {
+                if (handlePermissionError(err)) return;
                 console.error("Gagal load:", err);
             }
         });
@@ -118,6 +119,7 @@
                 
             },
             error:function(e){
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });

--- a/public/Custom_js/Backoffice/Customers/Sales_Order.js
+++ b/public/Custom_js/Backoffice/Customers/Sales_Order.js
@@ -52,6 +52,7 @@
                 }
             },
             error: function (err) {
+                if (handlePermissionError(err)) return;
                 console.error('Gagal load detail SO:', err);
                 if (typeof onError === 'function') {
                     onError(err);
@@ -343,7 +344,8 @@
 
                 $('#so_scan_barcode').val('').focus();
             },
-            error: function () {
+            error: function (xhr) {
+                if (handlePermissionError(xhr)) return;
                 toastr.error('', 'Gagal mencari produk');
                 $('#so_scan_barcode').val('').focus();
             }
@@ -636,6 +638,7 @@
                 }
             },
             error: function (err) {
+                if (handlePermissionError(err)) return;
                 console.error("Gagal load so:", err);
             }
         });
@@ -846,6 +849,7 @@
             },
             error:function(e){
                 ResetLoadingButton(".btn-save", mode == 1?"Tambah Pengiriman" : "Update Pengiriman");
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });
@@ -977,6 +981,7 @@
                 
             },
             error:function(e){
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });
@@ -1033,8 +1038,9 @@
                 }                
             },
             error:function(e){
-                console.log(e);
                 ResetLoadingButton('.btn-konfirmasi', "Konfirmasi");
+                if (handlePermissionError(e)) return;
+                console.log(e);
             }
         });
     })
@@ -1072,8 +1078,9 @@
                 
             },
             error:function(e){
-                console.log(e);
                 ResetLoadingButton('.btn-konfirmasi', "Konfirmasi");
+                if (handlePermissionError(e)) return;
+                console.log(e);
             }
         });
     })

--- a/public/Custom_js/Backoffice/Customers/Sales_Order_detail.js
+++ b/public/Custom_js/Backoffice/Customers/Sales_Order_detail.js
@@ -195,6 +195,7 @@
                 feather.replace(); // Biar icon feather muncul lagi
             },
             error: function (err) {
+                if (handlePermissionError(err)) return;
                 console.error("Gagal load:", err);
             }
         });
@@ -246,6 +247,7 @@
                 feather.replace(); // Biar icon feather muncul lagi
             },
             error: function (err) {
+                if (handlePermissionError(err)) return;
                 console.error("Gagal load:", err);
             }
         });
@@ -432,6 +434,7 @@
             },
             error:function(e){
                 ResetLoadingButton(".save-qty", 'Simpan perubahan');
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });
@@ -519,6 +522,7 @@
             },
             error:function(e){
                 ResetLoadingButton(".btn-save-delivery", 'Simpan perubahan');
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });
@@ -577,6 +581,7 @@
             },
             error:function(e){
                 ResetLoadingButton(".btn-approve", 'Setujui');
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });
@@ -635,6 +640,7 @@
             },
             error:function(e){
                 ResetLoadingButton(".btn-decline", 'Tolak');
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });
@@ -705,6 +711,7 @@
                 
             },
             error:function(e){
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });
@@ -813,6 +820,7 @@
             },
             error: function (e) {
                 ResetLoadingButton('.btn-save-invoice', 'Simpan Perubahan');
+                if (handlePermissionError(e)) return;
                 console.log(e);
             },
         });
@@ -864,6 +872,7 @@
                 notifikasi('success', "Berhasil Delete", "Berhasil delete invoice");
             },
             error:function(e){
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });
@@ -888,6 +897,7 @@
             },
             error:function(e){
                 ResetLoadingButton(btn, 'Tolak');
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });
@@ -920,7 +930,8 @@
             },
             error:function(e){
                  ResetLoadingButton(btn, 'Setujui');
-                console.log(e);
+                 if (handlePermissionError(e)) return;
+                 console.log(e);
             }
         });
     });

--- a/public/Custom_js/Backoffice/Customers/insertCustomer.js
+++ b/public/Custom_js/Backoffice/Customers/insertCustomer.js
@@ -60,6 +60,7 @@ $(document).on("click", ".btn-save", function () {
         error: function (xhr) {
             // Re-enable button
             ResetLoadingButton(".btn-save", mode == 1?"Tambah Armada" : "Update Armada");
+            if (handlePermissionError(xhr)) return;
             console.log(xhr);
         },
     });

--- a/public/Custom_js/Backoffice/Dashboard/Dashboard-Admin.js
+++ b/public/Custom_js/Backoffice/Dashboard/Dashboard-Admin.js
@@ -297,7 +297,8 @@
             success: function () {
                 if (typeof done === "function") done(true);
             },
-            error: function () {
+            error: function (xhr) {
+                if (handlePermissionError(xhr)) return;
                 if (typeof done === "function") done(false);
             },
         });
@@ -753,7 +754,8 @@
                 tryBrowserNotifyBahan(lastBahanPack);
                 renderChart(data);
             },
-            error: function () {
+            error: function (xhr) {
+                if (handlePermissionError(xhr)) return;
                 $("#dash_filter_label").text("Gagal memuat dashboard.");
             },
         });

--- a/public/Custom_js/Backoffice/ExternalApi/ApplicationDetail.js
+++ b/public/Custom_js/Backoffice/ExternalApi/ApplicationDetail.js
@@ -87,6 +87,7 @@ function refreshExternalApiKey() {
             feather.replace();
         },
         error: function (err) {
+            if (handlePermissionError(err)) return;
             console.error("Gagal load API Key:", err);
         }
     });
@@ -147,6 +148,7 @@ $(document).on('click', '.btn_edit', function () {
             $('#add_external_api_key').modal("show");
         },
         error: function (err) {
+            if (handlePermissionError(err)) return;
             console.error("Gagal load API Key:", err);
         }
     });
@@ -211,9 +213,10 @@ $(document).on("click", ".btn-save-key", function () {
             refreshExternalApiKey();
         },
         error: function (err) {
+            ResetLoadingButton('.btn-save-key', mode == 1 ? "Buat API Key" : "Update API Key");
+            if (handlePermissionError(err)) return;
             console.error("Gagal simpan API Key:", err);
             notifikasi('error', "Gagal", 'Terjadi kesalahan saat menyimpan');
-            ResetLoadingButton('.btn-save-key', mode == 1 ? "Buat API Key" : "Update API Key");
         }
     });
 });
@@ -263,6 +266,7 @@ $(document).on('click', '#btn-revoke-external-api-key', function () {
             notifikasi('success', "Berhasil Dicabut", "API Key sudah tidak berlaku");
         },
         error: function (err) {
+            if (handlePermissionError(err)) return;
             console.error("Gagal cabut API Key:", err);
             notifikasi('error', "Gagal", 'Terjadi kesalahan saat mencabut kunci');
         }
@@ -288,6 +292,7 @@ $(document).on('click', '#btn-delete-external-api-key', function () {
             notifikasi('success', "Berhasil Delete", "API Key berhasil dihapus");
         },
         error: function (err) {
+            if (handlePermissionError(err)) return;
             console.error("Gagal delete API Key:", err);
             notifikasi('error', "Gagal", 'Terjadi kesalahan saat menghapus');
         }

--- a/public/Custom_js/Backoffice/ExternalApi/Applications.js
+++ b/public/Custom_js/Backoffice/ExternalApi/Applications.js
@@ -91,6 +91,7 @@ function refreshExternalApplication() {
             feather.replace();
         },
         error: function (err) {
+            if (handlePermissionError(err)) return;
             console.error("Gagal load Aplikasi Eksternal:", err);
         }
     });
@@ -152,6 +153,7 @@ $(document).on('click', '.btn_edit', function () {
             $('#add_external_application').modal("show");
         },
         error: function (err) {
+            if (handlePermissionError(err)) return;
             console.error("Gagal load Aplikasi Eksternal:", err);
         }
     });
@@ -208,9 +210,10 @@ $(document).on("click", ".btn-save", function () {
             ResetLoadingButton('.btn-save', mode == 1 ? "Tambah Aplikasi" : "Update Aplikasi");
         },
         error: function (err) {
+            ResetLoadingButton('.btn-save', mode == 1 ? "Tambah Aplikasi" : "Update Aplikasi");
+            if (handlePermissionError(err)) return;
             console.error("Gagal simpan Aplikasi Eksternal:", err);
             notifikasi('error', "Gagal", 'Terjadi kesalahan saat menyimpan');
-            ResetLoadingButton('.btn-save', mode == 1 ? "Tambah Aplikasi" : "Update Aplikasi");
         }
     });
 });
@@ -237,6 +240,7 @@ $(document).on('click', '#btn-delete-external-application', function () {
             notifikasi('success', "Berhasil Delete", "Aplikasi eksternal berhasil dihapus");
         },
         error: function (err) {
+            if (handlePermissionError(err)) return;
             console.error("Gagal delete Aplikasi Eksternal:", err);
             notifikasi('error', "Gagal", 'Terjadi kesalahan saat menghapus');
         }

--- a/public/Custom_js/Backoffice/ExternalApi/Logs.js
+++ b/public/Custom_js/Backoffice/ExternalApi/Logs.js
@@ -78,6 +78,7 @@ function refreshExternalApiLog() {
             feather.replace();
         },
         error: function (err) {
+            if (handlePermissionError(err)) return;
             console.error("Gagal load Log API Eksternal:", err);
         }
     });
@@ -94,6 +95,7 @@ function refreshRingkasan() {
             $('#statNewest').html(e.newest_at ? moment(e.newest_at).format('D MMM YYYY HH:mm') : '-');
         },
         error: function (err) {
+            if (handlePermissionError(err)) return;
             console.error("Gagal load ringkasan log:", err);
         }
     });
@@ -148,6 +150,7 @@ $(document).on('change', '#toggleLogging', function () {
                 : "Pencatatan permintaan dinonaktifkan");
         },
         error: function (err) {
+            if (handlePermissionError(err)) return;
             console.error("Gagal ubah status pencatatan:", err);
             notifikasi('error', "Gagal", 'Terjadi kesalahan saat mengubah status pencatatan');
             $('#toggleLogging').prop('checked', !enabled);
@@ -230,9 +233,10 @@ $(document).on('click', '.btn-confirm-cleanup', function () {
             notifikasi('success', "Berhasil", e.message);
         },
         error: function (err) {
+            ResetLoadingButton('.btn-confirm-cleanup', "Hapus Log");
+            if (handlePermissionError(err)) return;
             console.error("Gagal bersihkan log:", err);
             notifikasi('error', "Gagal", 'Terjadi kesalahan saat membersihkan log');
-            ResetLoadingButton('.btn-confirm-cleanup', "Hapus Log");
         }
     });
 });

--- a/public/Custom_js/Backoffice/Inventory/CreateStockOpname.js
+++ b/public/Custom_js/Backoffice/Inventory/CreateStockOpname.js
@@ -214,7 +214,8 @@ function refreshStockOpname(callback) {
             if (typeof callback === "function") callback();
         },
         error: function (e) {
-            if (reqId !== stockOpnameReqSeq) return; // request lama yang dibatalkan (abort)
+            if (handlePermissionError(e)) return;
+            if (reqId !== stockOpnameReqSeq) return;
             console.log(e);
         },
     });
@@ -376,8 +377,9 @@ $(document).on("click", ".btn-ajukan", function () {
                         window.location.href = "/stockOpname";
                     },
                     error: function (e) {
-                        console.log(e);
                         ResetLoadingButton(".btn-ajukan", "Ajukan");
+                        if (handlePermissionError(e)) return;
+                        console.log(e);
                     },
                 });
             },
@@ -412,8 +414,9 @@ $(document).on("click", "#btn-delete-draft-confirm", function () {
             window.location.href = "/stockOpname";
         },
         error: function (e) {
-            console.log(e);
             ResetLoadingButton(".btn-konfirmasi", "Delete");
+            if (handlePermissionError(e)) return;
+            console.log(e);
         },
     });
 });
@@ -579,8 +582,9 @@ function insertData(options) {
             window.location.href = "/stockOpname";
         },
         error: function (e) {
-            toastr.success("", "Terjadi Kesalahan Saat Tambah Stok Opname");
             ResetLoadingButton(btnSelector, doneText);
+            if (handlePermissionError(e)) return;
+            toastr.success("", "Terjadi Kesalahan Saat Tambah Stok Opname");
             console.log(e);
         },
     });
@@ -686,8 +690,9 @@ $(document).on("click", "#btn-acc-sto", function () {
             window.open("/stockOpname", "_self");
         },
         error: function (e) {
-            console.log(e);
             ResetLoadingButton(".btn-konfirmasi", "Konfirmasi");
+            if (handlePermissionError(e)) return;
+            console.log(e);
         },
     });
 });
@@ -721,8 +726,9 @@ $(document).on("click", "#btn-tolak-sto", function () {
             window.open("/stockOpname", "_self");
         },
         error: function (e) {
-            console.log(e);
             ResetLoadingButton(".btn-konfirmasi", "Delete");
+            if (handlePermissionError(e)) return;
+            console.log(e);
         },
     });
 });

--- a/public/Custom_js/Backoffice/Inventory/CreateStockOpnameSupplies.js
+++ b/public/Custom_js/Backoffice/Inventory/CreateStockOpnameSupplies.js
@@ -243,7 +243,8 @@ function refreshStockOpname(callback) {
             supplies = e;
         },
         error: function (e) {
-            if (reqId !== stockOpnameReqSeq) return; // request lama yang dibatalkan (abort)
+            if (handlePermissionError(e)) return;
+            if (reqId !== stockOpnameReqSeq) return;
             console.log(e);
         },
     });
@@ -440,8 +441,9 @@ $(document).on("click", ".btn-ajukan", function () {
                         window.location.href = "/stockOpnameBahan";
                     },
                     error: function (e) {
-                        console.log(e);
                         ResetLoadingButton(".btn-ajukan", "Ajukan");
+                        if (handlePermissionError(e)) return;
+                        console.log(e);
                     },
                 });
             },
@@ -476,8 +478,9 @@ $(document).on("click", "#btn-delete-draft-confirm", function () {
             window.location.href = "/stockOpnameBahan";
         },
         error: function (e) {
-            console.log(e);
             ResetLoadingButton(".btn-konfirmasi", "Delete");
+            if (handlePermissionError(e)) return;
+            console.log(e);
         },
     });
 });
@@ -642,8 +645,9 @@ function insertData(options) {
             window.location.href = "/stockOpnameBahan";
         },
         error: function (e) {
-            toastr.success("", "Terjadi Kesalahan Saat Tambah Stok Opname");
             ResetLoadingButton(btnSelector, doneText);
+            if (handlePermissionError(e)) return;
+            toastr.success("", "Terjadi Kesalahan Saat Tambah Stok Opname");
             console.log(e);
         },
     });
@@ -748,8 +752,9 @@ $(document).on("click", "#btn-acc-stob", function () {
             window.open("/stockOpnameBahan", "_self");
         },
         error: function (e) {
-            console.log(e);
             ResetLoadingButton(".btn-konfirmasi", "Konfirmasi");
+            if (handlePermissionError(e)) return;
+            console.log(e);
         },
     });
 });
@@ -784,6 +789,7 @@ $(document).on("click", "#btn-tolak-stob", function () {
         },
         error: function (e) {
             ResetLoadingButton(".btn-konfirmasi", "Delete");
+            if (handlePermissionError(e)) return;
             console.log(e);
         },
     });

--- a/public/Custom_js/Backoffice/Inventory/Manage_Stock.js
+++ b/public/Custom_js/Backoffice/Inventory/Manage_Stock.js
@@ -180,6 +180,7 @@ function refreshManageStock(){
             feather.replace();
         },
         error: function (e) {
+            if (handlePermissionError(e)) return;
             console.log(e.responseText);
         },
     });
@@ -323,7 +324,8 @@ function insertData() {
             afterInsert();
         },
         error:function(e){
-            $('.row-input input').attr("disabled",false); // reset input
+            if (handlePermissionError(e)) return;
+            $('.row-input input').attr("disabled",false);
             $('#input_barcode').val("");
             $('#input_barcode').trigger("focus");
             console.log(e);

--- a/public/Custom_js/Backoffice/Inventory/Product_Issues.js
+++ b/public/Custom_js/Backoffice/Inventory/Product_Issues.js
@@ -239,6 +239,7 @@
                 openProductIssueFromDashboardLink();
             },
             error: function (err) {
+                if (handlePermissionError(err)) return;
                 console.error("Gagal load:", err);
             }
         });
@@ -499,8 +500,9 @@ function loadPiType() {
                 afterInsert();
             },
             error: function (e) {
-                console.log(e);
-                ResetLoadingButton('.btn-save', mode == 1?"Tambah Produk" : "Update Produk"); 
+                ResetLoadingButton('.btn-save', mode == 1?"Tambah Produk" : "Update Produk");
+                if (handlePermissionError(e)) return;
+                console.log(e); 
             },
         });
     });
@@ -885,8 +887,9 @@ $(document).on("click", ".btn_view", function () {
                 }                
             },
             error:function(e){
-                console.log(e);
                 ResetLoadingButton('.btn-konfirmasi', "Konfirmasi");
+                if (handlePermissionError(e)) return;
+                console.log(e);
             }
         });
     })
@@ -921,8 +924,9 @@ $(document).on("click", ".btn_view", function () {
                 
             },
             error:function(e){
-                console.log(e);
                 ResetLoadingButton('.btn-konfirmasi', "Konfirmasi");
+                if (handlePermissionError(e)) return;
+                console.log(e);
             }
         });
     })
@@ -1009,8 +1013,9 @@ $(document).on("click", "#btn-delete-issues", function () {
             }
         },
         error: function (e) {
-            console.log(e);
             ResetLoadingButton(".btn-konfirmasi", "Delete");
+            if (handlePermissionError(e)) return;
+            console.log(e);
         },
     });
 });

--- a/public/Custom_js/Backoffice/Inventory/Stock_Alert.js
+++ b/public/Custom_js/Backoffice/Inventory/Stock_Alert.js
@@ -258,6 +258,7 @@
                 feather.replace(); // Biar icon feather muncul lagi
             },
             error: function (err) {
+                if (handlePermissionError(err)) return;
                 console.error("Gagal load:", err);
             }
         });

--- a/public/Custom_js/Backoffice/Inventory/Stock_Alert_Supplies.js
+++ b/public/Custom_js/Backoffice/Inventory/Stock_Alert_Supplies.js
@@ -251,6 +251,7 @@
                 feather.replace(); // Biar icon feather muncul lagi
             },
             error: function (err) {
+                if (handlePermissionError(err)) return;
                 console.error("Gagal load:", err);
             }
         });

--- a/public/Custom_js/Backoffice/Inventory/Stock_Opname.js
+++ b/public/Custom_js/Backoffice/Inventory/Stock_Opname.js
@@ -92,6 +92,7 @@
                 feather.replace(); // Biar icon feather muncul lagi
             },
             error: function (err) {
+                if (handlePermissionError(err)) return;
                 console.error("Gagal load:", err);
             }
         });
@@ -123,6 +124,7 @@ function loadCategory() {
             }
         },
         error: function (e) {
+            if (handlePermissionError(e)) return;
             console.log(e);
         },
     });

--- a/public/Custom_js/Backoffice/Inventory/Stock_Opname_Bahan.js
+++ b/public/Custom_js/Backoffice/Inventory/Stock_Opname_Bahan.js
@@ -92,6 +92,7 @@
                 feather.replace(); // Biar icon feather muncul lagi
             },
             error: function (err) {
+                if (handlePermissionError(err)) return;
                 console.error("Gagal load:", err);
             }
         });

--- a/public/Custom_js/Backoffice/Inventory/Stock_Product.js
+++ b/public/Custom_js/Backoffice/Inventory/Stock_Product.js
@@ -82,6 +82,7 @@
                 feather.replace(); // Biar icon feather muncul lagi
             },
             error: function (err) {
+                if (handlePermissionError(err)) return;
                 console.error("Gagal load:", err);
             }
         });
@@ -108,6 +109,7 @@
                 viewHistory(e);
             },
             error: function(e){
+                if (handlePermissionError(e)) return;
                 console.error("Gagal load:", e);
             }
         });

--- a/public/Custom_js/Backoffice/Inventory/Stock_Supplies.js
+++ b/public/Custom_js/Backoffice/Inventory/Stock_Supplies.js
@@ -65,6 +65,7 @@
                 feather.replace(); // Biar icon feather muncul lagi
             },
             error: function (err) {
+                if (handlePermissionError(err)) return;
                 console.error("Gagal load:", err);
             }
         });
@@ -91,6 +92,7 @@
                 viewHistory(e);
             },
             error: function(e){
+                if (handlePermissionError(e)) return;
                 console.error("Gagal load:", e);
             }
         });

--- a/public/Custom_js/Backoffice/Login.js
+++ b/public/Custom_js/Backoffice/Login.js
@@ -47,6 +47,7 @@ $(document).on("click", "#btn-login", function () {
         },
         error: function (xhr, status, error) {
             ResetLoadingButton("#btn-login", "Login");
+            if (handlePermissionError(xhr)) return;
             notifikasi("error", "Login Gagal", "");
         },
     });

--- a/public/Custom_js/Backoffice/Product/Barcode.js
+++ b/public/Custom_js/Backoffice/Product/Barcode.js
@@ -132,7 +132,8 @@
             success: function (rows) {
                 renderResults(rows || []);
             },
-            error: function () {
+            error: function (xhr) {
+                if (handlePermissionError(xhr)) return;
                 renderResults([]);
             },
             complete: function () {

--- a/public/Custom_js/Backoffice/Product/Category.js
+++ b/public/Custom_js/Backoffice/Product/Category.js
@@ -82,6 +82,7 @@
                 feather.replace(); // Biar icon feather muncul lagi
             },
             error: function (err) {
+                if (handlePermissionError(err)) return;
                 console.error("Gagal load kategori:", err);
             }
         });
@@ -130,6 +131,7 @@
             },
             error:function(e){
                 ResetLoadingButton('.btn-save', mode == 1?"Tambah Kategori" : "Update Kategori");
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });
@@ -181,6 +183,7 @@
                 
             },
             error:function(e){
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });

--- a/public/Custom_js/Backoffice/Product/Product.js
+++ b/public/Custom_js/Backoffice/Product/Product.js
@@ -88,6 +88,7 @@
                 feather.replace(); // Biar icon feather muncul lagi
             },
             error: function (err) {
+                if (handlePermissionError(err)) return;
                 console.error("Gagal load:", err);
             }
         });
@@ -116,6 +117,7 @@
                 
             },
             error:function(e){
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });

--- a/public/Custom_js/Backoffice/Product/Supplies.js
+++ b/public/Custom_js/Backoffice/Product/Supplies.js
@@ -155,6 +155,7 @@
                 feather.replace(); // Biar icon feather muncul lagi
             },
             error: function (err) {
+                if (handlePermissionError(err)) return;
                 console.error("Gagal load:", err);
             }
         });
@@ -251,7 +252,8 @@
                 }
             },
             error:function(e){
-                ResetLoadingButton('.btn-save', mode == 1?"Tambah Bahan Mentah" : "Update Bahan Mentah"); 
+                ResetLoadingButton('.btn-save', mode == 1?"Tambah Bahan Mentah" : "Update Bahan Mentah");
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });
@@ -378,6 +380,7 @@
                 
             },
             error:function(e){
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });

--- a/public/Custom_js/Backoffice/Product/Units.js
+++ b/public/Custom_js/Backoffice/Product/Units.js
@@ -86,6 +86,7 @@
                 feather.replace(); // Biar icon feather muncul lagi
             },
             error: function (err) {
+                if (handlePermissionError(err)) return;
                 console.error("Gagal load unit:", err);
             }
         });
@@ -134,7 +135,8 @@
                 afterInsert();
             },
             error:function(e){
-                ResetLoadingButton('.btn-save', mode == 1?"Tambah Satuan" : "Update Satuan"); 
+                ResetLoadingButton('.btn-save', mode == 1?"Tambah Satuan" : "Update Satuan");
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });
@@ -187,6 +189,7 @@
                 
             },
             error:function(e){
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });

--- a/public/Custom_js/Backoffice/Product/Variants.js
+++ b/public/Custom_js/Backoffice/Product/Variants.js
@@ -89,7 +89,8 @@
                 feather.replace();
             },
             error:function(e){
-                ResetLoadingButton('.btn-save', mode == 1?"Tambah Variasi" : "Update Variasi"); 
+                ResetLoadingButton('.btn-save', mode == 1?"Tambah Variasi" : "Update Variasi");
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });
@@ -139,7 +140,8 @@
                 afterInsert();
             },
             error:function(e){
-                ResetLoadingButton('.btn-save', mode == 1?"Tambah Variasi" : "Update Variasi"); 
+                ResetLoadingButton('.btn-save', mode == 1?"Tambah Variasi" : "Update Variasi");
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });
@@ -195,6 +197,7 @@
                 
             },
             error:function(e){
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });

--- a/public/Custom_js/Backoffice/Product/insertProduct.js
+++ b/public/Custom_js/Backoffice/Product/insertProduct.js
@@ -239,6 +239,7 @@ $(document).on("click",".btn-save",function(){
         },
         error:function(e){
             ResetLoadingButton(".btn-save", mode == 1?"Tambah Produk" : "Update Produk");
+            if (handlePermissionError(e)) return;
             console.log(e);
         }
     });

--- a/public/Custom_js/Backoffice/Production/Bom.js
+++ b/public/Custom_js/Backoffice/Production/Bom.js
@@ -168,6 +168,7 @@
                 feather.replace(); // Biar icon feather muncul lagi
             },
             error: function (err) {
+                if (handlePermissionError(err)) return;
                 console.error("Gagal load bom:", err);
             }
         });
@@ -243,7 +244,8 @@
                 ResetLoadingButton('.btn-save', mode == 1?"Tambah Resep" : "Update Resep");       
             },
             error:function(e){
-                ResetLoadingButton('.btn-save', mode == 1?"Tambah Resep" : "Update Resep"); 
+                ResetLoadingButton('.btn-save', mode == 1?"Tambah Resep" : "Update Resep");
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });
@@ -363,6 +365,7 @@
                 }
             },
             error: function (err) {
+                if (handlePermissionError(err)) return;
                 console.error('Gagal load detail BOM:', err);
                 notifikasi('error', 'Gagal', 'Gagal memuat detail resep.');
             }
@@ -659,6 +662,7 @@
                 notifikasi('success', "Berhasil Delete", "Berhasil delete resep bahan mentah");
             },
             error:function(e){
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });

--- a/public/Custom_js/Backoffice/Production/Production.js
+++ b/public/Custom_js/Backoffice/Production/Production.js
@@ -57,10 +57,10 @@
             method: "get",
             data: { bom_id: bomId, with_details: 1 },
             success: function (response) {
-                callback(response && response[0] ? response[0] : null);
+                callback(response && response[0] ? response[0] : null, false);
             },
-            error: function () {
-                callback(null);
+            error: function (xhr) {
+                callback(null, handlePermissionError(xhr));
             }
         });
     }
@@ -369,6 +369,7 @@
                 openProductionFromDashboardLink();
             },
             error: function (err) {
+                if (handlePermissionError(err)) return;
                 console.error("Gagal load kategori:", err);
             }
         });
@@ -551,6 +552,7 @@
             },
             error:function(a){
                 ResetLoadingButton('.btn-save', mode == 1?"Tambah Produksi" : "Update Produksi");
+                if (handlePermissionError(a)) return;
                 console.log(a);
             }
         });
@@ -665,10 +667,12 @@
         }
 
         LoadingButton('.btn-add-product');
-        loadBomForValidation(tempBom.bom_id, function (fullBom) {
+        loadBomForValidation(tempBom.bom_id, function (fullBom, permissionHandled) {
             ResetLoadingButton('.btn-add-product', '+');
             if (!fullBom) {
-                notifikasi('error', 'Gagal Memuat Resep', 'Tidak dapat memuat detail resep. Silakan coba lagi.');
+                if (!permissionHandled) {
+                    notifikasi('error', 'Gagal Memuat Resep', 'Tidak dapat memuat detail resep. Silakan coba lagi.');
+                }
                 return;
             }
             continueAddProduct(fullBom);
@@ -866,6 +870,9 @@
                     });
                 }
                 console.log(list_bahan);
+            },
+            error: function (xhr) {
+                handlePermissionError(xhr);
             }
         });
     }
@@ -947,6 +954,7 @@ $(document).on("click", "#btn-delete-production", function () {
         },
         error: function (e) {
             ResetLoadingButton(".btn-konfirmasi", "Batal Produksi");
+            if (handlePermissionError(e)) return;
             console.log(e);
         },
     });
@@ -1002,6 +1010,7 @@ $(document).on("click", "#btn-acc-delete-production", function () {
         },
         error: function (e) {
             ResetLoadingButton(".btn-konfirmasi", "Batal Produksi");
+            if (handlePermissionError(e)) return;
             console.log(e);
         },
     });
@@ -1046,6 +1055,7 @@ $(document).on("click", "#btn-cancel-delete-production", function () {
         },
         error: function (e) {
             ResetLoadingButton(".btn-konfirmasi", "Konfirmasi Batal Produksi");
+            if (handlePermissionError(e)) return;
             console.log(e);
         },
     });
@@ -1108,8 +1118,9 @@ $(document).on("click", "#btn-cancel-delete-production", function () {
                 }
             },
             error:function(e){
-                console.log(e);
                 ResetLoadingButton('.btn-konfirmasi', "Konfirmasi");
+                if (handlePermissionError(e)) return;
+                console.log(e);
             }
         });
     }
@@ -1157,8 +1168,9 @@ $(document).on("click", "#btn-cancel-delete-production", function () {
 
             },
             error:function(e){
-                console.log(e);
                 ResetLoadingButton('.btn-konfirmasi', "Konfirmasi");
+                if (handlePermissionError(e)) return;
+                console.log(e);
             }
         });
     })
@@ -1208,6 +1220,7 @@ $(document).on('click', '.LihatfotoProduksi', function(){
             $('#modalViewPhoto').modal('show');
         },
         error: function (e) {
+            if (handlePermissionError(e)) return;
             console.log(e);
         },
     });

--- a/public/Custom_js/Backoffice/Reports/Bahan_Baku.js
+++ b/public/Custom_js/Backoffice/Reports/Bahan_Baku.js
@@ -153,6 +153,7 @@
                 feather.replace();
             },
             error: function (err) {
+                if (handlePermissionError(err)) return;
                 console.error("Gagal load pemakaian bahan:", err);
             }
         });

--- a/public/Custom_js/Backoffice/Reports/Cash.js
+++ b/public/Custom_js/Backoffice/Reports/Cash.js
@@ -191,6 +191,7 @@
                 }, 100);
             },
             error: function (err) {
+                if (handlePermissionError(err)) return;
                 console.error("Gagal load kas:", err);
             }
         });
@@ -616,6 +617,7 @@
             },
             error:function(e){
                 ResetLoadingButton(".btn-save", mode == 1?"Tambah Pencatatan" : "Update Pencatatan");
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });
@@ -686,6 +688,7 @@
             },
             error:function(e){
                 ResetLoadingButton('.btn-konfirmasi', "Konfirmasi");
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });
@@ -723,6 +726,7 @@
             },
             error:function(e){
                 ResetLoadingButton('.btn-konfirmasi', "Konfirmasi");
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });

--- a/public/Custom_js/Backoffice/Reports/Cash_Operational.js
+++ b/public/Custom_js/Backoffice/Reports/Cash_Operational.js
@@ -707,6 +707,7 @@
                 openCashFromDashboardLink();
             },
             error: function (err) {
+                if (handlePermissionError(err)) return;
                 console.error("Gagal load kategori:", err);
             }
         });
@@ -807,6 +808,7 @@
                 openCashFromDashboardLink();
             },
             error: function (err) {
+                if (handlePermissionError(err)) return;
                 console.error("Gagal load kategori:", err);
             }
         });
@@ -917,6 +919,7 @@
                 openCashFromDashboardLink();
             },
             error: function (err) {
+                if (handlePermissionError(err)) return;
                 console.error("Gagal load kategori:", err);
             }
         });
@@ -1019,6 +1022,7 @@
                 openCashFromDashboardLink();
             },
             error: function (err) {
+                if (handlePermissionError(err)) return;
                 console.error("Gagal load kategori:", err);
             }
         });
@@ -1516,6 +1520,7 @@
             },
             error:function(e){
                 ResetLoadingButton(".btn-save-admin", mode == 1?"Tambah Aktivitas" : "Update Aktivitas");
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });
@@ -1710,6 +1715,7 @@
             },
             error:function(e){
                 ResetLoadingButton(".btn-save-gudang", mode == 1?"Tambah Aktivitas" : "Update Aktivitas");
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });
@@ -1914,6 +1920,7 @@
             },
             error:function(e){
                 ResetLoadingButton(".btn-save-armada", mode == 1?"Tambah Aktivitas" : "Update Aktivitas");
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });
@@ -2147,6 +2154,7 @@
             },
             error:function(e){
                 ResetLoadingButton(".btn-save-sales", mode == 1?"Tambah Aktivitas" : "Update Aktivitas");
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });
@@ -2292,6 +2300,7 @@
             },
             error:function(e){
                 ResetLoadingButton('#btn-delete-admin', "Delete");
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });
@@ -2427,6 +2436,7 @@
             },
             error:function(e){
                 ResetLoadingButton('#btn-delete-gudang', "Delete");
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });
@@ -2585,6 +2595,7 @@
             },
             error:function(e){
                 ResetLoadingButton('#btn-delete-armada', "Delete");
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });
@@ -2743,6 +2754,7 @@
             },
             error:function(e){
                 ResetLoadingButton('#btn-delete-sales', "Delete");
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });
@@ -2821,8 +2833,9 @@
                 
             },
             error:function(e){
-                console.log(e);
                 ResetLoadingButton('.btn-konfirmasi', "Konfirmasi");
+                if (handlePermissionError(e)) return;
+                console.log(e);
             }
         });
     })
@@ -2896,8 +2909,9 @@
                 
             },
             error:function(e){
-                console.log(e);
                 ResetLoadingButton('.btn-konfirmasi', "Konfirmasi");
+                if (handlePermissionError(e)) return;
+                console.log(e);
             }
         });
     })

--- a/public/Custom_js/Backoffice/Reports/Cash_Out_Report.js
+++ b/public/Custom_js/Backoffice/Reports/Cash_Out_Report.js
@@ -85,7 +85,8 @@
                 $("#cash_out_total_pengeluaran").text(fmtRp(summary.total_pengeluaran || 0));
                 $("#cash_out_total_transaksi").text(String(summary.jumlah_transaksi || 0));
             },
-            error: function () {
+            error: function (xhr) {
+                if (handlePermissionError(xhr)) return;
                 table.clear().draw();
                 $("#cash_out_period_label").text("Gagal memuat data");
                 $("#cash_out_total_pengeluaran").text("Rp 0");

--- a/public/Custom_js/Backoffice/Reports/Category_Cash.js
+++ b/public/Custom_js/Backoffice/Reports/Category_Cash.js
@@ -82,6 +82,7 @@
                 feather.replace(); // Biar icon feather muncul lagi
             },
             error: function (err) {
+                if (handlePermissionError(err)) return;
                 console.error("Gagal load kategori:", err);
             }
         });
@@ -130,7 +131,8 @@
                 afterInsert();
             },
             error:function(e){
-                ResetLoadingButton('.btn-save', mode == 1?"Tambah Kategori Kas" : "Update Kategori Kas");  
+                ResetLoadingButton('.btn-save', mode == 1?"Tambah Kategori Kas" : "Update Kategori Kas");
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });
@@ -183,6 +185,7 @@
                 
             },
             error:function(e){
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });

--- a/public/Custom_js/Backoffice/Reports/DashboardPemakaianBahan.js
+++ b/public/Custom_js/Backoffice/Reports/DashboardPemakaianBahan.js
@@ -222,7 +222,8 @@
             success: function (payload) {
                 fillProcurementTables(payload);
             },
-            error: function () {
+            error: function (xhr) {
+                if (handlePermissionError(xhr)) return;
                 var errFull =
                     '<tr><td colspan="7" class="text-center text-danger py-3">Gagal memuat estimasi pembelian.</td></tr>';
                 var $a = $("#dash_procurement_body_kemasan");
@@ -258,7 +259,8 @@
                 renderChart(payload);
                 loadProcurementEstimate();
             },
-            error: function () {
+            error: function (xhr) {
+                if (handlePermissionError(xhr)) return;
                 var err =
                     '<tr><td colspan="3" class="text-center text-danger py-3">Gagal memuat data</td></tr>';
                 $("#dash_top_body_kemasan").html(err);

--- a/public/Custom_js/Backoffice/Reports/Inward_Outward.js
+++ b/public/Custom_js/Backoffice/Reports/Inward_Outward.js
@@ -55,6 +55,7 @@
                 feather.replace(); // Biar icon feather muncul lagi
             },
             error: function (err) {
+                if (handlePermissionError(err)) return;
                 console.error("Gagal load:", err);
             }
         });

--- a/public/Custom_js/Backoffice/Reports/Pay_Receive.js
+++ b/public/Custom_js/Backoffice/Reports/Pay_Receive.js
@@ -114,6 +114,7 @@
                 $('#totalInvoice').html(e.length);
             },
             error: function (err) {
+                if (handlePermissionError(err)) return;
                 console.error("Gagal load:", err);
             }
         });
@@ -208,6 +209,7 @@
                 $('#jumlah_terpilih').text("0 Selected");
             },
             error:function(e){
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });
@@ -233,6 +235,7 @@
                 window.open('/generateHutang?' + $.param(params), '_self');
             },
             error: function(e){
+                if (handlePermissionError(e)) return;
                 console.error(e);
             }
         })

--- a/public/Custom_js/Backoffice/Reports/Petty_Cash.js
+++ b/public/Custom_js/Backoffice/Reports/Petty_Cash.js
@@ -115,6 +115,7 @@
                 feather.replace(); // Biar icon feather muncul lagi
             },
             error: function (err) {
+                if (handlePermissionError(err)) return;
                 console.error("Gagal load kategori:", err);
             }
         });
@@ -168,6 +169,7 @@
             },
             error:function(e){
                 ResetLoadingButton(".btn-save", mode == 1?"Tambah Kas" : "Update Kas");
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });

--- a/public/Custom_js/Backoffice/Reports/ProductReturn.js
+++ b/public/Custom_js/Backoffice/Reports/ProductReturn.js
@@ -167,6 +167,7 @@
                 feather.replace();
             },
             error: function (err) {
+                if (handlePermissionError(err)) return;
                 console.error("Gagal load retur:", err);
             }
         });

--- a/public/Custom_js/Backoffice/Reports/Profit_Loss.js
+++ b/public/Custom_js/Backoffice/Reports/Profit_Loss.js
@@ -74,6 +74,7 @@
                 tableProfit.clear().rows.add(e).draw();
             },
             error: function (err) {
+                if (handlePermissionError(err)) return;
                 console.error("Gagal load:", err);
             }
         });
@@ -93,6 +94,7 @@
                 tableLoss.clear().rows.add(e).draw();
             },
             error: function (err) {
+                if (handlePermissionError(err)) return;
                 console.error("Gagal load:", err);
             }
         });

--- a/public/Custom_js/Backoffice/Reports/ReportEfisiensiProduksi.js
+++ b/public/Custom_js/Backoffice/Reports/ReportEfisiensiProduksi.js
@@ -201,6 +201,7 @@ function refreshEfisiensi() {
             feather.replace();
         },
         error: function (err) {
+            if (handlePermissionError(err)) return;
             console.error("Gagal load report efisiensi produksi:", err);
             updateKpiSummary([]);
         },

--- a/public/Custom_js/Backoffice/Reports/ReportProduction.js
+++ b/public/Custom_js/Backoffice/Reports/ReportProduction.js
@@ -187,6 +187,7 @@
                 feather.replace(); // Biar icon feather muncul lagi
             },
             error: function (err) {
+                if (handlePermissionError(err)) return;
                 console.error("Gagal load produksi:", err);
             }
         });

--- a/public/Custom_js/Backoffice/Reports/ReportReturProdukArmada.js
+++ b/public/Custom_js/Backoffice/Reports/ReportReturProdukArmada.js
@@ -164,6 +164,7 @@ function refreshReturArmada() {
             if (typeof feather !== 'undefined') feather.replace();
         },
         error: function (err) {
+            if (handlePermissionError(err)) return;
             console.error('Gagal load laporan retur armada:', err);
         },
     });

--- a/public/Custom_js/Backoffice/Reports/StockAging.js
+++ b/public/Custom_js/Backoffice/Reports/StockAging.js
@@ -111,6 +111,7 @@ function refreshStockAging() {
             feather.replace();
         },
         error: function (err) {
+            if (handlePermissionError(err)) return;
             console.error("Gagal load stock aging:", err);
         },
     });

--- a/public/Custom_js/Backoffice/Reports/StockOpnameDifference.js
+++ b/public/Custom_js/Backoffice/Reports/StockOpnameDifference.js
@@ -155,6 +155,7 @@ function refreshSelisihOpname() {
             feather.replace();
         },
         error: function (err) {
+            if (handlePermissionError(err)) return;
             console.error("Gagal load report selisih opname:", err);
         },
     });

--- a/public/Custom_js/Backoffice/Settings/Profiles.js
+++ b/public/Custom_js/Backoffice/Settings/Profiles.js
@@ -105,6 +105,7 @@ $(document).on('click', '.btn-save', function(){
         error: function (xhr) {
             // Re-enable button
             ResetLoadingButton(".btn-save", 'Simpan perubahan');
+            if (handlePermissionError(xhr)) return;
             console.log(xhr);
         },
     });

--- a/public/Custom_js/Backoffice/Settings/Settings.js
+++ b/public/Custom_js/Backoffice/Settings/Settings.js
@@ -51,6 +51,7 @@ $(document).on('click', '.btn-save', function(){
            
         },
         error: function(e) {
+            if (handlePermissionError(e)) return;
             notifikasi('error', "Terjadi Kesalahan", "");
             console.log(e);
         }

--- a/public/Custom_js/Backoffice/Suppliers/Purchase_Order.js
+++ b/public/Custom_js/Backoffice/Suppliers/Purchase_Order.js
@@ -160,7 +160,8 @@
 
                 $('#po_scan_barcode').val('').focus();
             },
-            error: function () {
+            error: function (xhr) {
+                if (handlePermissionError(xhr)) return;
                 toastr.error('', 'Gagal mencari produk');
                 $('#po_scan_barcode').val('').focus();
             }
@@ -388,6 +389,7 @@
                 feather.replace(); // Biar icon feather muncul lagi
             },
             error: function (err) {
+                if (handlePermissionError(err)) return;
                 console.error("Gagal load so:", err);
             }
         });
@@ -527,7 +529,8 @@
                 afterInsert();
             },
             error:function(e){
-                ResetLoadingButton('.btn-save', mode == 1?"Tambah Pembelian" : "Update Pembelian"); 
+                ResetLoadingButton('.btn-save', mode == 1?"Tambah Pembelian" : "Update Pembelian");
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });
@@ -582,6 +585,7 @@
                 
             },
             error:function(e){
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });

--- a/public/Custom_js/Backoffice/Suppliers/Purchase_Order_Detail.js
+++ b/public/Custom_js/Backoffice/Suppliers/Purchase_Order_Detail.js
@@ -262,6 +262,7 @@
                 feather.replace(); // Biar icon feather muncul lagi
             },
             error: function (err) {
+                if (handlePermissionError(err)) return;
                 console.error("Gagal load:", err);
             }
         });
@@ -320,6 +321,7 @@
                 feather.replace(); // Biar icon feather muncul lagi
             },
             error: function (err) {
+                if (handlePermissionError(err)) return;
                 console.error("Gagal load:", err);
             }
         });
@@ -376,6 +378,7 @@
                 feather.replace(); // Biar icon feather muncul lagi
             },
             error: function (err) {
+                if (handlePermissionError(err)) return;
                 console.error("Gagal load:", err);
             }
         });
@@ -636,8 +639,9 @@
                 ResetLoadingButton('.btn-save-retur', mode == 1?"Tambah Retur" : "Update Retur");
             },
             error: function (e) {
-                console.log(e);
-                ResetLoadingButton('.btn-save-retur', mode == 1?"Tambah Retur" : "Update Retur"); 
+                ResetLoadingButton('.btn-save-retur', mode == 1?"Tambah Retur" : "Update Retur");
+                if (handlePermissionError(e)) return;
+                console.log(e); 
             },
         });
     })
@@ -673,6 +677,7 @@
             },
             error:function(e){
                 ResetLoadingButton("#btn-delete-retur", "Delete");
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });
@@ -881,6 +886,7 @@
             },
             error:function(e){
                 ResetLoadingButton(".save-qty", 'Simpan perubahan');
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });
@@ -964,6 +970,7 @@
             },
             error:function(e){
                 ResetLoadingButton(".btn-save-delivery", 'Simpan perubahan');
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });
@@ -1024,6 +1031,7 @@
             },
             error:function(e){
                 ResetLoadingButton(".btn-approve", 'Setujui');
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });
@@ -1080,6 +1088,7 @@
             },
             error:function(e){
                 ResetLoadingButton(".btn-decline", 'Tolak');
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });
@@ -1156,6 +1165,7 @@
                 
             },
             error:function(e){
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });
@@ -1261,6 +1271,7 @@
                 
             },
             error: function (e) {
+                if (handlePermissionError(e)) return;
                 console.log(e);
             },
         });
@@ -1323,6 +1334,7 @@
                 notifikasi('success', "Berhasil Delete", "Berhasil delete invoice");
             },
             error:function(e){
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });
@@ -1347,6 +1359,7 @@
             },
             error:function(e){
                 ResetLoadingButton(btn, 'Tolak');
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });
@@ -1384,7 +1397,8 @@
             },
             error:function(e){
                  ResetLoadingButton(btn, 'Setujui');
-                console.log(e);
+                 if (handlePermissionError(e)) return;
+                 console.log(e);
             }
         });
     });
@@ -1422,7 +1436,8 @@
             },
             error:function(e){
                  ResetLoadingButton(btn, 'Setujui');
-                console.log(e);
+                 if (handlePermissionError(e)) return;
+                 console.log(e);
             }
         });
     });
@@ -1473,8 +1488,9 @@ $(document).on("click", "#btn-acc-po", function () {
             window.open('/purchaseOrder', '_self');
         },
         error: function (e) {
-            console.log(e);
             ResetLoadingButton("#btn-acc-po", "Terima");
+            if (handlePermissionError(e)) return;
+            console.log(e);
         },
     });
 });
@@ -1522,6 +1538,7 @@ $(document).on("click", "#btn-acc-po", function () {
             },
             error:function(e){
                 ResetLoadingButton("#btn-tolak-po", "Tolak");
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });

--- a/public/Custom_js/Backoffice/Suppliers/Supplier.js
+++ b/public/Custom_js/Backoffice/Suppliers/Supplier.js
@@ -91,6 +91,7 @@
                 feather.replace(); // Biar icon feather muncul lagi
             },
             error: function (err) {
+                if (handlePermissionError(err)) return;
                 console.error("Gagal load:", err);
             }
         });
@@ -134,6 +135,7 @@
                 viewHistory(e);
             },
             error: function(e){
+                if (handlePermissionError(e)) return;
                 console.error("Gagal load:", e);
             }
         });
@@ -194,6 +196,7 @@
                 
             },
             error:function(e){
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });

--- a/public/Custom_js/Backoffice/Suppliers/insertSupplier.js
+++ b/public/Custom_js/Backoffice/Suppliers/insertSupplier.js
@@ -116,6 +116,7 @@ $(document).on("click", ".btn-save", function () {
         error: function (xhr) {
             // Re-enable button
             ResetLoadingButton(".btn-save", mode == 1?"Tambah Pemasok" : "Update Pemasok");
+            if (handlePermissionError(xhr)) return;
             console.log(xhr);
         },
     });

--- a/public/Custom_js/Backoffice/Suppliers/tt.js
+++ b/public/Custom_js/Backoffice/Suppliers/tt.js
@@ -123,6 +123,7 @@ function updateTtUploadProgress(percent) {
                 feather.replace(); // Biar icon feather muncul lagi
             },
             error: function (err) {
+                if (handlePermissionError(err)) return;
                 console.error("Gagal load so:", err);
             }
         });
@@ -186,9 +187,10 @@ function updateTtUploadProgress(percent) {
                 
             },
             error:function(e){
+                ResetLoadingButton('#add_acc_tt .btn-save', "Konfirmasi");
+                if (handlePermissionError(e)) return;
                 console.log(e);
                 resetTtUploadProgress();
-                ResetLoadingButton('#add_acc_tt .btn-save', "Konfirmasi");
             }
         });
     });
@@ -250,6 +252,7 @@ $(document).on("change", "#image", function () {
             $("#file_name").text(compressedImageFile.name + " (" + kb + " KB)");
         },
         error(err) {
+            if (handlePermissionError(err)) return;
             console.error("Gagal kompres gambar:", err);
             compressedImageFile = file;
             let reader = new FileReader();
@@ -301,6 +304,7 @@ $(document).on("change", "#image", function () {
                 
             },
             error:function(e){
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });

--- a/public/Custom_js/Backoffice/Synchronization/Wizard.js
+++ b/public/Custom_js/Backoffice/Synchronization/Wizard.js
@@ -96,6 +96,7 @@
                 }
             },
             error: function (xhr) {
+                if (handlePermissionError(xhr)) return;
                 var res = xhr.responseJSON || {};
                 if (res.state) {
                     renderState(res.state);

--- a/public/Custom_js/Backoffice/User/Bank.js
+++ b/public/Custom_js/Backoffice/User/Bank.js
@@ -82,6 +82,7 @@
                 feather.replace(); // Biar icon feather muncul lagi
             },
             error: function (err) {
+                if (handlePermissionError(err)) return;
                 console.error("Gagal load Bank:", err);
             }
         });
@@ -130,6 +131,7 @@
             },
             error:function(e){
                 ResetLoadingButton('.btn-save', mode == 1?"Tambah Bank" : "Update Bank");
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });
@@ -182,6 +184,7 @@
                 
             },
             error:function(e){
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });

--- a/public/Custom_js/Backoffice/User/Permission.js
+++ b/public/Custom_js/Backoffice/User/Permission.js
@@ -123,6 +123,7 @@
             },
             error:function(e){
                 ResetLoadingButton(".btn-save", 'Perbarui');
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });

--- a/public/Custom_js/Backoffice/User/Role.js
+++ b/public/Custom_js/Backoffice/User/Role.js
@@ -80,6 +80,7 @@
                 feather.replace(); // Biar icon feather muncul lagi
             },
             error: function (err) {
+                if (handlePermissionError(err)) return;
                 console.error("Gagal load role:", err);
             }
         });
@@ -128,6 +129,7 @@
             },
             error:function(e){
                 ResetLoadingButton(".btn-save", 'Simpan perubahan');
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });
@@ -227,6 +229,7 @@
             },
             error: function (e) {
                 ResetLoadingButton("#btn_save_dash_widgets", "Simpan Widget");
+                if (handlePermissionError(e)) return;
                 console.log(e);
                 notifikasi('error', "Gagal Update", "Gagal update widget dashboard role");
             }

--- a/public/Custom_js/Backoffice/User/Staff.js
+++ b/public/Custom_js/Backoffice/User/Staff.js
@@ -87,6 +87,7 @@
                 feather.replace(); // Biar icon feather muncul lagi
             },
             error: function (err) {
+                if (handlePermissionError(err)) return;
                 console.error("Gagal load:", err);
             }
         });
@@ -119,6 +120,7 @@
                 
             },
             error:function(e){
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });

--- a/public/Custom_js/Backoffice/User/insertStaff.js
+++ b/public/Custom_js/Backoffice/User/insertStaff.js
@@ -124,6 +124,7 @@ $(document).on("click", ".btn-save", function () {
         error: function (xhr) {
             // Re-enable button
             ResetLoadingButton(".btn-save", mode == 1?"Tambah Staff" : "Update Staff");
+            if (handlePermissionError(xhr)) return;
             console.log(xhr);
         },
     });

--- a/resources/views/layout/partials/footer-scripts.blade.php
+++ b/resources/views/layout/partials/footer-scripts.blade.php
@@ -270,6 +270,21 @@ https://cdn.jsdelivr.net/npm/toastr@2.1.4/toastr.min.js
             text: deskripsi,
         });
     }
+    /**
+     * Panggil ini di awal setiap ajax error callback (terutama di popup) supaya pesan
+     * 403 (ditolak middleware permission) konsisten di seluruh aplikasi dan tidak
+     * membocorkan modul/permission apa yang kurang ke user.
+     * Return true kalau sudah ditangani (403) — caller tinggal `return` tanpa
+     * menampilkan notifikasi generiknya sendiri. Return false untuk error lain,
+     * silakan lanjut pakai handling yang sudah ada di masing-masing pemanggil.
+     */
+    function handlePermissionError(xhr) {
+        if (xhr && xhr.status === 403) {
+            notifikasi('error', 'Akses Ditolak', 'Anda tidak memiliki akses terhadap aksi ini, mohon hubungi Admin!');
+            return true;
+        }
+        return false;
+    }
        //munculin modal delete
     function showModalDelete(text, button_id) {
         if ($('#modalDelete .modal-body').is(':empty')) {


### PR DESCRIPTION
## Latar belakang

Issue #41: staff baru (Alam, role *Staf QC & Gudang*) dapat error saat "Tambah Produksi" — popup menampilkan pesan generik *"Gagal Memuat Resep... Silakan coba lagi"*, padahal akar masalahnya adalah izin akses (403 dari middleware permission) yang belum ke-refresh di session staff tersebut sejak role-nya diedit.

Sudah dikerjakan & di-*commit* ke branch `production` (`ba50065`). PR ini adalah port yang sama ke `main`, disesuaikan dengan kode `main` yang sudah lebih berkembang (`Production.js` di `main` punya panel info produksi, panel info pembatalan, dan alur `submitAccProduction()`/"confirm create stock" yang tidak ada di `production`).

## Perubahan

**1. Role permission tidak perlu logout untuk ke-refresh**
`app/Http/Middleware/checkLogin.php` — `role_access` dulunya nyantol di session sejak login dan baru kepakai kalau staff itu login ulang. Sekarang, hard refresh (Ctrl+Shift+R / Cmd+Shift+R — terdeteksi lewat header `Cache-Control`/`Pragma: no-cache`, yang tidak dikirim saat refresh biasa/F5 atau request AJAX biasa) menarik ulang `role_access` dari tabel `roles`.

**2. Pesan error 403 yang konsisten & tidak bocorin detail**
`resources/views/layout/partials/footer-scripts.blade.php` — helper baru `handlePermissionError(xhr)`. Kalau `xhr.status === 403`, tampilkan **"Anda tidak memiliki akses terhadap aksi ini, mohon hubungi Admin!"** — tanpa menyebutkan modul/permission apa yang kurang.

**3. Diterapkan ke semua popup/flow ajax di seluruh aplikasi**
179 `error:` callback di 58 file `Backoffice/**/*.js` sekarang memanggil `handlePermissionError(xhr)` di awal dan `return` kalau memang 403 — kalau bukan 403, behavior lama (console.log, reset tombol, dst) tetap jalan seperti biasa.

Dikerjakan pakai tool kecil berbasis AST (`acorn`) supaya konsisten di semua file besar ini, bukan tempel manual satu-satu — otomatis skip kode yang di-comment (dead code) dan callback yang sudah pernah dipatch. Ada 1 pengecualian yang butuh penanganan manual: `loadBomForValidation()` di `Production.js` meneruskan ke `callback(...)` milik pemanggilnya, jadi early-return polos bakal ikut nge-skip callback itu — sudah ditangani lewat flag `permissionHandled` supaya pesan generik lama tetap tampil kalau errornya BUKAN soal akses.

**Perhatian khusus:** setiap `error:` callback yang punya panggilan `ResetLoadingButton(...)`/`LoadingButton(...)` — pemanggilan itu tetap dijalankan duluan sebelum pengecekan 403, supaya tombol tidak "nyangkut" loading kalau errornya karena akses ditolak.

## Verifikasi

- Semua 63 file JS di `public/Custom_js/` di-parse ulang (`new Function(...)`) — tidak ada syntax error.
- Re-run tool bersifat idempotent — 0 perubahan lagi kalau dijalankan ulang (tidak ada yang ke-skip atau ter-duplikat).
- Discan ulang seluruh diff untuk memastikan tidak ada `ResetLoadingButton`/`LoadingButton` yang jadi ke-skip gara-gara guard baru — 0 ditemukan.
- 2 file js yang sudah tidak dipakai (`Sales_Order_detail copy.js`, `CreateStockOpname cop.js` — tidak direferensikan di view manapun) sengaja tidak disentuh.

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)