### PR TITLE
Fix: halaman /deploy/seed jadi blank putih setelah restore snapshot

### DIFF
--- a/app/Console/Commands/SnapshotRestoreCommand.php
+++ b/app/Console/Commands/SnapshotRestoreCommand.php
@@ -5,7 +5,6 @@ namespace App\Console\Commands;
 use App\Support\SnapshotRegistry;
 use Database\Seeders\SnapshotSeeder;
 use Illuminate\Console\Command;
-use Illuminate\Support\Facades\Artisan;
 
 /**
  * Restores a named snapshot (see `snapshot:list`) by pointing SnapshotSeeder
@@ -13,6 +12,17 @@ use Illuminate\Support\Facades\Artisan;
  * before and always restores the "default" snapshot — this command is the
  * only way to pick a different one, and is what DeployController's
  * /deploy/seed route calls under the hood.
+ *
+ * Deliberately uses $this->call() (Command::call(), which runs the target
+ * command against $this->output directly) rather than the Artisan facade's
+ * Artisan::call(). The facade version stashes its output in a shared
+ * Application::$lastOutput BufferedOutput and immediately fetch()es (which
+ * drains it) when relayed here — fine in isolation, but DeployController
+ * itself reaches this command THROUGH Artisan::call(), so the nested facade
+ * call overwrites and drains that same shared buffer before the controller
+ * ever reads Artisan::output(), producing an empty response body (blank
+ * page) even though the restore itself succeeded. $this->call() sidesteps
+ * this entirely by writing straight into the outer command's own output.
  */
 class SnapshotRestoreCommand extends Command
 {
@@ -33,9 +43,6 @@ class SnapshotRestoreCommand extends Command
 
         app()->instance('snapshot.dir', $dir);
 
-        Artisan::call('db:seed', ['--class' => SnapshotSeeder::class, '--force' => true]);
-        $this->output->write(Artisan::output());
-
-        return self::SUCCESS;
+        return $this->call('db:seed', ['--class' => SnapshotSeeder::class, '--force' => true]);
     }
 }

--- a/tests/Regression/SnapshotRestoreOutputWasSwallowedByNestedArtisanCallTest.php
+++ b/tests/Regression/SnapshotRestoreOutputWasSwallowedByNestedArtisanCallTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Tests\Regression;
+
+use Illuminate\Support\Facades\Artisan;
+use Tests\TestCase;
+
+/**
+ * Confirmed and fixed 2026-08-11 (found by the user after the multi-snapshot deploy console PR):
+ * `/deploy/seed` went from showing a full seed log to a blank white page.
+ *
+ * Root cause: App\Console\Commands\SnapshotRestoreCommand::handle() called the target seed command
+ * via the `Artisan::call()` FACADE (Illuminate\Console\Application::call()), which stashes its
+ * output in a single shared `$lastOutput` BufferedOutput on the console Application instance and
+ * whose `Artisan::output()` companion reads it via fetch() — which drains the buffer. DeployController
+ * itself reaches SnapshotRestoreCommand through `Artisan::call('snapshot:restore', ...)` too, so the
+ * nested facade call inside handle() overwrote `$lastOutput` to point at its OWN buffer and then
+ * immediately drained it via `Artisan::output()` to relay it — leaving `$lastOutput` referencing an
+ * already-empty buffer by the time DeployController::seedSnapshot() read `Artisan::output()` after
+ * the outer call returned. The restore itself ran fine; only the displayed log was lost.
+ *
+ * Fix: SnapshotRestoreCommand now uses `$this->call()` (Illuminate\Console\Command::call(), which
+ * runs the target command straight against $this->output, never touching Application::$lastOutput)
+ * instead of the Artisan facade. See SnapshotRestoreCommand's own docblock for the full trace.
+ *
+ * This test intentionally does NOT use a mocked Artisan facade (unlike DeployControllerTest, which
+ * mocks Artisan::call for exactly this route to avoid a real destructive db:seed touching
+ * pegasus_testing outside DatabaseTransactions' rollback safety net — TRUNCATE causes an implicit
+ * commit, so a transaction rollback would not undo it anyway). A mock would prove the right command
+ * was *requested*, not that its output survives the nested-call round trip, which is the actual bug.
+ * So this restores the "default" snapshot for real, then explicitly reseeds pegasus_testing back to
+ * its baseline in tearDown() regardless of pass/fail, exactly like the documented `php artisan
+ * db:seed --env=testing --force` reset step (cdocs/testing/README.md).
+ */
+class SnapshotRestoreOutputWasSwallowedByNestedArtisanCallTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Artisan::call('db:seed', ['--force' => true]);
+        parent::tearDown();
+    }
+
+    public function test_snapshot_restore_output_survives_a_nested_artisan_call_the_way_deploy_controller_makes_it(): void
+    {
+        // Mirrors exactly how DeployController::seedSnapshot() invokes this: Artisan::call() from
+        // outside, which is what exposed the shared-buffer bug (a direct $this->call() from a test,
+        // or calling SnapshotRestoreCommand directly, would not reproduce it).
+        Artisan::call('snapshot:restore', ['name' => 'default']);
+        $output = Artisan::output();
+
+        $this->assertNotSame('', $output, 'Artisan::output() was empty — the nested-call bug is back.');
+        $this->assertStringContainsString('roles', $output);
+        $this->assertMatchesRegularExpression('/\brows\b/', $output);
+    }
+}


### PR DESCRIPTION
## Bug

Setelah PR #42 (multi-snapshot) merge, halaman hasil `/deploy/seed` yang sebelumnya menampilkan log daftar tabel/baris yang di-seed sekarang jadi **halaman putih kosong**. Proses restore-nya sendiri tetap jalan benar (data tetap ke-restore) — cuma log yang tampil ke user hilang.

## Penyebab

`SnapshotRestoreCommand::handle()` memanggil command `db:seed` lewat **facade** `Artisan::call()`, lalu langsung `Artisan::output()`-kan hasilnya untuk ditulis ulang ke `$this->output`.

Masalahnya, `Artisan::call()` (`Illuminate\Console\Application::call()`) menyimpan output-nya di satu buffer bersama (`$lastOutput`) di level Application, dipakai bareng oleh **semua** pemanggilan `Artisan::call()` — termasuk pemanggilan terluar yang dipakai `DeployController` untuk menjalankan `snapshot:restore` itu sendiri. Urutan kejadiannya:

1. `DeployController` → `Artisan::call('snapshot:restore', ...)` → buffer A dibuat.
2. Di dalam `handle()`, dipanggil lagi `Artisan::call('db:seed', ...)` → buffer A ditimpa jadi buffer B.
3. `handle()` langsung `Artisan::output()` untuk relay ke `$this->output` → buffer B **dibaca sekaligus dikosongkan** (`fetch()` di Symfony BufferedOutput memang menguras isinya).
4. `DeployController` balik ke luar, baca `Artisan::output()` lagi → yang kebaca sekarang buffer B tadi, yang **sudah kosong**.

Hasilnya: response HTTP kosong walau proses seed-nya sukses.

## Perbaikan

Ganti pemanggilan nested itu dari `Artisan::call()` (facade) jadi `$this->call()` (`Illuminate\Console\Command::call()`), yang menjalankan command target langsung ke `$this->output` milik command pemanggil — tidak pernah menyentuh `Application::$lastOutput` sama sekali, jadi tidak ada buffer yang saling timpa.

## Testing

- Regression test baru (`tests/Regression/SnapshotRestoreOutputWasSwallowedByNestedArtisanCallTest.php`) yang benar-benar mereproduksi pola nested `Artisan::call()` persis seperti yang dipakai `DeployController` (test lama di `DeployControllerTest` me-mock `Artisan::call` untuk route ini, jadi tidak akan pernah menangkap bug ini) — restore snapshot `default` sungguhan, assert output tidak kosong, lalu `tearDown()`-nya selalu reseed `pegasus_testing` balik ke baseline.
- Reproduksi manual lewat `php artisan tinker` sebelum fix (output kosong) dan sesudah fix (log lengkap muncul).
- `tests/Feature/DeployControllerTest.php` + `tests/Regression/DeployControllerForbiddenPageDidNotCrashWithoutSessionTest.php` + test baru: **33/33 lulus**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)