### PR TITLE
feat: modul Stok lewat External API v1 (POST /stock/check)

### DIFF
--- a/app/ExternalApi/Docs/Endpoints/V1/StockCheckDoc.php
+++ b/app/ExternalApi/Docs/Endpoints/V1/StockCheckDoc.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace App\ExternalApi\Docs\Endpoints\V1;
+
+use App\ExternalApi\Docs\ApiEndpointDoc;
+
+/**
+ * Dokumentasi POST /api/external/v1/stock/check.
+ */
+class StockCheckDoc extends ApiEndpointDoc
+{
+    public function key(): string
+    {
+        return 'stok-cek';
+    }
+
+    public function title(): string
+    {
+        return 'Cek Kekurangan Stok';
+    }
+
+    public function method(): string
+    {
+        return 'POST';
+    }
+
+    public function path(): string
+    {
+        return '/stock/check';
+    }
+
+    public function group(): string
+    {
+        return 'stok';
+    }
+
+    public function description(): string
+    {
+        return 'Mengecek ketersediaan stok banyak SKU sekaligus terhadap satu gudang, '
+            .'dan menghitung kekurangan (shortage) per item bila jumlah yang diminta '
+            .'melebihi stok yang tersedia. Hanya membaca — tidak memotong atau '
+            .'mengunci stok apa pun.';
+    }
+
+    public function bodyParameters(): array
+    {
+        return [
+            ['name' => 'ref_shipment_id', 'type' => 'string', 'required' => true,
+                'description' => 'Penanda milik sistem pemanggil untuk permintaan ini. Dikembalikan apa adanya pada respons, tidak disimpan di Pegasus.'],
+            ['name' => 'gudang_id', 'type' => 'integer', 'required' => false,
+                'description' => 'Merujuk warehouses.id (sama seperti {gudang_id} pada PUT/DELETE /master/warehouses). Tidak dikirim -> memakai gudang utama.'],
+            ['name' => 'items', 'type' => 'array', 'required' => true,
+                'description' => 'Daftar item yang dicek, minimal satu.'],
+            ['name' => 'items[].sku', 'type' => 'string', 'required' => true,
+                'description' => 'product_variants.product_variant_sku. Harus merujuk varian produk aktif.'],
+            ['name' => 'items[].qty', 'type' => 'integer', 'required' => true,
+                'description' => 'Jumlah yang diminta, dalam satuan items[].unit_id.'],
+            ['name' => 'items[].unit_id', 'type' => 'integer', 'required' => true,
+                'description' => 'Rujukan units.ref_unit_id (id satuan pada sistem PMO), BUKAN id internal Pegasus. Harus merujuk satuan aktif.'],
+        ];
+    }
+
+    public function requestExample(): ?array
+    {
+        return [
+            'ref_shipment_id' => 'SHP-2026-000123',
+            'gudang_id' => 1,
+            'items' => [
+                ['sku' => 'MRP300P', 'qty' => 50, 'unit_id' => 5],
+                ['sku' => 'SOHP', 'qty' => 10, 'unit_id' => 3],
+            ],
+        ];
+    }
+
+    public function responseExample(): array
+    {
+        return [
+            'success' => true,
+            'data' => [
+                'ref_shipment_id' => 'SHP-2026-000123',
+                'has_shortage' => true,
+                'items' => [
+                    ['sku' => 'MRP300P', 'unit_id' => 5, 'requested' => 50, 'available' => 50, 'shortage' => 0],
+                    ['sku' => 'SOHP', 'unit_id' => 3, 'requested' => 10, 'available' => 4, 'shortage' => 6],
+                ],
+            ],
+        ];
+    }
+
+    public function errors(): array
+    {
+        return [
+            ['code' => 'validation_failed', 'http_status' => 422,
+                'message' => 'items harus berisi minimal satu baris.'],
+            ['code' => 'validation_failed', 'http_status' => 422,
+                'message' => 'items.0.sku tidak ditemukan sebagai varian produk aktif.'],
+            ['code' => 'validation_failed', 'http_status' => 422,
+                'message' => 'items.0.unit_id tidak merujuk satuan aktif manapun.'],
+            ['code' => 'validation_failed', 'http_status' => 422,
+                'message' => 'gudang_id tidak ditemukan atau tidak aktif.'],
+        ];
+    }
+
+    public function notes(): array
+    {
+        return [
+            'Seluruh sku dan unit_id divalidasi lebih dulu: SKU yang tidak dikenal atau unit_id yang tidak merujuk satuan aktif manapun membuat SELURUH permintaan ditolak validation_failed, bukan diam-diam dianggap shortage penuh untuk item itu saja.',
+            'Kombinasi SKU + unit_id yang keduanya valid tapi bukan satuan produk itu (tidak sechain lewat product_relations) tetap lolos validasi — hasilnya wajar available: 0, karena memang tidak ada cara mengonversi stok ke satuan itu.',
+            'available dihitung setara satu satuan (items[].unit_id): stok pada satuan itu sendiri, ditambah stok pada satuan lebih besar dalam chain product_relations yang sama (dibongkar otomatis). Stok pada satuan lebih KECIL tidak digabungkan naik (tidak ada packing).',
+            'shortage tidak pernah negatif — selisih requested - available, dibulatkan ke 0 kalau stok mencukupi atau berlebih.',
+            'gudang_id merujuk warehouses.id langsung (bukan kolom rujukan eksternal seperti ref_unit_id/ref_product_id) — gudang tidak disinkronkan sistem PMO. Tidak dikirim berarti memakai gudang utama (warehouse_types.is_main_warehouse = 1), sama seperti default fitur stok lain di Pegasus.',
+            'Endpoint ini murni pengecekan (read-only). Tidak ada reservasi/kunci stok — status stok bisa berubah di antara pengecekan ini dan operasi berikutnya yang benar-benar memotong stok.',
+        ];
+    }
+}

--- a/app/Http/Controllers/ExternalApi/V1/StockController.php
+++ b/app/Http/Controllers/ExternalApi/V1/StockController.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace App\Http\Controllers\ExternalApi\V1;
+
+use App\ExternalApi\Http\ApiResponse;
+use App\Http\Controllers\Controller;
+use App\Models\ProductStock;
+use App\Models\ProductVariant;
+use App\Models\Unit;
+use App\Support\ProductUnitStock;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+
+/**
+ * Modul Stok untuk sistem eksternal.
+ *
+ * Berbeda dengan modul lain (units, sales, armada, produk): modul ini tidak
+ * membuat/mengubah/menghapus data, hanya membaca — jadi tidak ada konsep
+ * "dikelola API ini" atau endpoint connect di sini.
+ */
+class StockController extends Controller
+{
+    /**
+     * POST /api/external/v1/stock/check
+     *
+     * Mengecek kekurangan stok (shortage) per item berdasarkan SKU, memakai
+     * ulang App\Support\ProductUnitStock::totalAvailable() — persis logika
+     * yang sama dipakai Sales Order (App\Support\SalesOrderStock) untuk
+     * menghitung stok tersedia setara satu satuan, termasuk bongkar satuan
+     * lebih besar (mis. stok di DOS ikut dihitung untuk permintaan dalam
+     * Piece) selama satu chain product_relations. TIDAK menyusun ulang
+     * (packing) stok satuan kecil ke satuan besar — hanya arah bongkar.
+     *
+     * unit_id pada tiap item BUKAN units.unit_id (id internal Pegasus),
+     * melainkan units.ref_unit_id (rujukan sistem PMO) — sama seperti
+     * konvensi PUT/DELETE /master/units/{ref_unit_id}. Namanya sengaja
+     * tetap "unit_id" di body/respons endpoint ini (bukan diganti jadi
+     * "ref_unit_id") sesuai kontrak yang diminta pemanggil.
+     *
+     * gudang_id opsional, merujuk warehouses.id (id yang sama dipakai
+     * PUT/DELETE /master/warehouses/{gudang_id}) — BUKAN kolom rujukan
+     * eksternal seperti ref_unit_id/ref_product_id, karena gudang sendiri
+     * tidak disinkronkan PMO. Tidak dikirim -> memakai
+     * ProductStock::resolveWarehouseId(null): gudang utama (is_main_warehouse
+     * = 1), sama seperti default seluruh fitur stok lain di aplikasi ini.
+     *
+     * sku dan unit_id divalidasi harus benar-benar ada (aktif) sebelum
+     * dihitung sama sekali — permintaan yang memuat SKU tak dikenal atau
+     * unit_id yang tidak merujuk satuan aktif manapun ditolak validation_failed
+     * secara keseluruhan, tidak diam-diam dianggap shortage penuh. Kombinasi
+     * SKU + unit_id yang keduanya valid tapi tidak sechain (mis. satuan produk
+     * lain) TETAP dihitung — itu bukan data tidak dikenal, hasilnya wajar
+     * available: 0 lewat totalAvailable().
+     */
+    public function check(Request $request): JsonResponse
+    {
+        $data = $request->validate([
+            'ref_shipment_id' => ['required', 'string', 'max:100'],
+            'gudang_id' => ['nullable', 'integer', Rule::exists('warehouses', 'id')->where('status', 1)],
+            'items' => ['required', 'array', 'min:1'],
+            'items.*.sku' => [
+                'required', 'string',
+                Rule::exists('product_variants', 'product_variant_sku')->where('status', 1),
+            ],
+            'items.*.qty' => ['required', 'integer', 'min:1'],
+            'items.*.unit_id' => [
+                'required', 'integer',
+                Rule::exists('units', 'ref_unit_id')->where('status', 1),
+            ],
+        ]);
+
+        $warehouseId = ProductStock::resolveWarehouseId($data['gudang_id'] ?? null);
+
+        $variantsBySku = ProductVariant::whereIn('product_variant_sku', array_column($data['items'], 'sku'))
+            ->where('status', 1)
+            ->orderBy('product_variant_id')
+            ->get(['product_variant_id', 'product_variant_sku'])
+            ->keyBy('product_variant_sku');
+
+        $unitsByRef = Unit::whereIn('ref_unit_id', array_column($data['items'], 'unit_id'))
+            ->where('status', 1)
+            ->get(['unit_id', 'ref_unit_id'])
+            ->keyBy('ref_unit_id');
+
+        $hasShortage = false;
+        $items = array_map(function (array $item) use ($variantsBySku, $unitsByRef, $warehouseId, &$hasShortage) {
+            $variant = $variantsBySku->get($item['sku']);
+            $unit = $unitsByRef->get((int) $item['unit_id']);
+            $requested = (int) $item['qty'];
+
+            // Sudah divalidasi ada di atas — null di sini hanya kemungkinan
+            // race condition (baris dinonaktifkan tepat setelah validate()).
+            // Diperlakukan sebagai shortage penuh, bukan galat 500.
+            $available = ($variant && $unit)
+                ? (int) round(ProductUnitStock::totalAvailable(
+                    $warehouseId,
+                    (int) $variant->product_variant_id,
+                    (int) $unit->unit_id,
+                ))
+                : 0;
+
+            $shortage = max(0, $requested - $available);
+            if ($shortage > 0) {
+                $hasShortage = true;
+            }
+
+            return [
+                'sku' => (string) $item['sku'],
+                'unit_id' => (int) $item['unit_id'],
+                'requested' => $requested,
+                'available' => $available,
+                'shortage' => $shortage,
+            ];
+        }, $data['items']);
+
+        return ApiResponse::success([
+            'ref_shipment_id' => (string) $data['ref_shipment_id'],
+            'has_shortage' => $hasShortage,
+            'items' => $items,
+        ]);
+    }
+}

--- a/config/externalapi.php
+++ b/config/externalapi.php
@@ -180,6 +180,9 @@ return [
         \App\ExternalApi\Docs\Endpoints\V1\MasterProductUpdateDoc::class,
         \App\ExternalApi\Docs\Endpoints\V1\MasterProductDeleteDoc::class,
         \App\ExternalApi\Docs\Endpoints\V1\MasterProductLinkDoc::class,
+
+        // Stok — modul baru, hanya baca (tidak ada create/update/delete).
+        \App\ExternalApi\Docs\Endpoints\V1\StockCheckDoc::class,
     ],
 
     /*

--- a/routes/external-api/v1.php
+++ b/routes/external-api/v1.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\ExternalApi\V1\MasterProductController;
 use App\Http\Controllers\ExternalApi\V1\MasterSalesController;
 use App\Http\Controllers\ExternalApi\V1\MasterUnitController;
 use App\Http\Controllers\ExternalApi\V1\MasterWarehouseController;
+use App\Http\Controllers\ExternalApi\V1\StockController;
 use Illuminate\Support\Facades\Route;
 
 /*
@@ -122,4 +123,18 @@ Route::prefix('produk')->name('produk.')->group(function () {
     Route::put('/{ref_product_id}', [MasterProductController::class, 'update'])->name('update');
     Route::delete('/{ref_product_id}', [MasterProductController::class, 'destroy'])->name('destroy');
     Route::patch('/connect', [MasterProductController::class, 'connect'])->name('connect');
+});
+
+/*
+ * Stok.
+ *
+ * Beda dengan modul lain: hanya baca, tidak ada create/update/delete di
+ * sini, jadi tidak ada konsep "dikelola API ini" atau endpoint connect.
+ * check() memakai ulang App\Support\ProductUnitStock (logika stok yang sama
+ * dipakai Sales Order) untuk menghitung stok tersedia setara satu satuan per
+ * SKU, termasuk bongkar satuan lebih besar dalam satu chain
+ * product_relations. Lihat catatan kelas StockController.
+ */
+Route::prefix('stock')->name('stock.')->group(function () {
+    Route::post('/check', [StockController::class, 'check'])->name('check');
 });

--- a/tests/Workflow/ExternalApiStockCheckFlowTest.php
+++ b/tests/Workflow/ExternalApiStockCheckFlowTest.php
@@ -1,0 +1,341 @@
+<?php
+
+namespace Tests\Workflow;
+
+use App\Models\Category;
+use App\Models\Product;
+use App\Models\ProductRelation;
+use App\Models\ProductStock;
+use App\Models\ProductVariant;
+use App\Models\Unit;
+use Tests\Support\ActingAsExternalApiClient;
+use Tests\TestCase;
+
+/**
+ * External API v1 stock check — App\Http\Controllers\ExternalApi\V1\StockController::check().
+ *
+ * Real warehouse ids from the committed seed snapshot: 1 = Gudang Pusat (main), 2 = Gudang
+ * Eceran Toko (retail) — see SalesOrderRetailAndUnitConversionFlowTest's docblock. Units are
+ * built fresh per test instead of reusing seeded ones, because this endpoint's unit_id is
+ * looked up by units.ref_unit_id (an external reference), not the internal unit_id, and the
+ * fixture needs full control over that column.
+ */
+class ExternalApiStockCheckFlowTest extends TestCase
+{
+    use ActingAsExternalApiClient;
+
+    private const MAIN_WAREHOUSE_ID = 1;
+    private const RETAIL_WAREHOUSE_ID = 2;
+
+    private function createUnit(?int $refUnitId): Unit
+    {
+        $unit = new Unit();
+        $unit->unit_name = 'Stock Check Unit '.uniqid();
+        $unit->unit_short_name = 'SC-'.random_int(1000, 9999);
+        $unit->ref_unit_id = $refUnitId;
+        $unit->status = 1;
+        $unit->save();
+
+        return $unit;
+    }
+
+    /** @return array{variant: ProductVariant, sku: string} */
+    private function createProductFixture(Unit $unit): array
+    {
+        $category = new Category();
+        $category->category_name = 'Stock Check Test Category';
+        $category->status = 1;
+        $category->save();
+
+        $product = new Product();
+        $product->product_name = 'Stock Check Test Product';
+        $product->category_id = $category->category_id;
+        $product->product_unit = json_encode([$unit->unit_id]);
+        $product->unit_id = $unit->unit_id;
+        $product->status = 1;
+        $product->save();
+
+        $sku = 'SC-TEST-'.uniqid();
+        $variant = new ProductVariant();
+        $variant->product_id = $product->product_id;
+        $variant->product_variant_name = 'Stock Check Test Variant';
+        $variant->product_variant_sku = $sku;
+        $variant->product_variant_price = 0;
+        $variant->status = 1;
+        $variant->save();
+
+        return ['variant' => $variant, 'sku' => $sku];
+    }
+
+    private function createStock(ProductVariant $variant, int $warehouseId, int $unitId, int $qty): ProductStock
+    {
+        $ps = new ProductStock();
+        $ps->product_id = $variant->product_id;
+        $ps->product_variant_id = $variant->product_variant_id;
+        $ps->unit_id = $unitId;
+        $ps->warehouse_id = $warehouseId;
+        $ps->ps_stock = $qty;
+        $ps->status = 1;
+        $ps->save();
+
+        return $ps;
+    }
+
+    public function test_a_request_without_an_api_key_is_rejected(): void
+    {
+        $this->postJson('/api/external/v1/stock/check', [
+            'ref_shipment_id' => 'SHP-1',
+            'items' => [],
+        ])->assertStatus(401)->assertJson(['success' => false, 'error' => ['code' => 'unauthenticated']]);
+    }
+
+    public function test_check_returns_zero_shortage_when_stock_is_sufficient(): void
+    {
+        $headers = $this->externalApiHeaders();
+        $refUnitId = random_int(900000, 999999);
+        $unit = $this->createUnit($refUnitId);
+        $fx = $this->createProductFixture($unit);
+        $this->createStock($fx['variant'], self::MAIN_WAREHOUSE_ID, $unit->unit_id, 10);
+
+        $response = $this->postJson('/api/external/v1/stock/check', [
+            'ref_shipment_id' => 'SHP-SUFFICIENT',
+            'items' => [
+                ['sku' => $fx['sku'], 'qty' => 5, 'unit_id' => $refUnitId],
+            ],
+        ], $headers);
+
+        $response->assertStatus(200)->assertJson([
+            'success' => true,
+            'data' => [
+                'ref_shipment_id' => 'SHP-SUFFICIENT',
+                'has_shortage' => false,
+                'items' => [
+                    ['sku' => $fx['sku'], 'unit_id' => $refUnitId, 'requested' => 5, 'available' => 10, 'shortage' => 0],
+                ],
+            ],
+        ]);
+    }
+
+    public function test_check_reports_shortage_when_stock_is_insufficient(): void
+    {
+        $headers = $this->externalApiHeaders();
+        $refUnitId = random_int(900000, 999999);
+        $unit = $this->createUnit($refUnitId);
+        $fx = $this->createProductFixture($unit);
+        $this->createStock($fx['variant'], self::MAIN_WAREHOUSE_ID, $unit->unit_id, 10);
+
+        $response = $this->postJson('/api/external/v1/stock/check', [
+            'ref_shipment_id' => 'SHP-SHORT',
+            'items' => [
+                ['sku' => $fx['sku'], 'qty' => 20, 'unit_id' => $refUnitId],
+            ],
+        ], $headers);
+
+        $response->assertStatus(200)->assertJson([
+            'success' => true,
+            'data' => [
+                'has_shortage' => true,
+                'items' => [
+                    ['sku' => $fx['sku'], 'unit_id' => $refUnitId, 'requested' => 20, 'available' => 10, 'shortage' => 10],
+                ],
+            ],
+        ]);
+    }
+
+    public function test_check_unpacks_ancestor_unit_stock_into_the_requested_unit(): void
+    {
+        $headers = $this->externalApiHeaders();
+        $bigRefUnitId = random_int(900000, 949999);
+        $smallRefUnitId = random_int(950000, 999999);
+        $bigUnit = $this->createUnit($bigRefUnitId);
+        $smallUnit = $this->createUnit($smallRefUnitId);
+        $fx = $this->createProductFixture($smallUnit);
+
+        // 1 x bigUnit = 12 x smallUnit, scoped to this variant only.
+        $relation = new ProductRelation();
+        $relation->product_variant_id = $fx['variant']->product_variant_id;
+        $relation->pr_unit_id_1 = $bigUnit->unit_id;
+        $relation->pr_unit_value_1 = 1;
+        $relation->pr_unit_id_2 = $smallUnit->unit_id;
+        $relation->pr_unit_value_2 = 12;
+        $relation->status = 1;
+        $relation->save();
+
+        // Stock only exists in the bigger unit — none directly in smallUnit.
+        $this->createStock($fx['variant'], self::MAIN_WAREHOUSE_ID, $bigUnit->unit_id, 3);
+
+        $response = $this->postJson('/api/external/v1/stock/check', [
+            'ref_shipment_id' => 'SHP-UNPACK',
+            'items' => [
+                ['sku' => $fx['sku'], 'qty' => 30, 'unit_id' => $smallRefUnitId],
+            ],
+        ], $headers);
+
+        $response->assertStatus(200)->assertJson([
+            'success' => true,
+            'data' => [
+                'has_shortage' => false,
+                'items' => [
+                    // 3 big units x 12 = 36 available in the requested small unit.
+                    ['sku' => $fx['sku'], 'unit_id' => $smallRefUnitId, 'requested' => 30, 'available' => 36, 'shortage' => 0],
+                ],
+            ],
+        ]);
+    }
+
+    public function test_check_does_not_unpack_the_smaller_unit_upward(): void
+    {
+        $headers = $this->externalApiHeaders();
+        $bigRefUnitId = random_int(900000, 949999);
+        $smallRefUnitId = random_int(950000, 999999);
+        $bigUnit = $this->createUnit($bigRefUnitId);
+        $smallUnit = $this->createUnit($smallRefUnitId);
+        $fx = $this->createProductFixture($bigUnit);
+
+        $relation = new ProductRelation();
+        $relation->product_variant_id = $fx['variant']->product_variant_id;
+        $relation->pr_unit_id_1 = $bigUnit->unit_id;
+        $relation->pr_unit_value_1 = 1;
+        $relation->pr_unit_id_2 = $smallUnit->unit_id;
+        $relation->pr_unit_value_2 = 12;
+        $relation->status = 1;
+        $relation->save();
+
+        // Plenty of stock in the SMALLER unit, none in the bigger one being requested.
+        $this->createStock($fx['variant'], self::MAIN_WAREHOUSE_ID, $smallUnit->unit_id, 120);
+
+        $response = $this->postJson('/api/external/v1/stock/check', [
+            'ref_shipment_id' => 'SHP-NO-PACK',
+            'items' => [
+                ['sku' => $fx['sku'], 'qty' => 1, 'unit_id' => $bigRefUnitId],
+            ],
+        ], $headers);
+
+        $response->assertStatus(200)->assertJson([
+            'success' => true,
+            'data' => [
+                'has_shortage' => true,
+                'items' => [
+                    ['sku' => $fx['sku'], 'unit_id' => $bigRefUnitId, 'requested' => 1, 'available' => 0, 'shortage' => 1],
+                ],
+            ],
+        ]);
+    }
+
+    public function test_check_rejects_an_unknown_sku(): void
+    {
+        $headers = $this->externalApiHeaders();
+        $refUnitId = random_int(900000, 999999);
+        $this->createUnit($refUnitId);
+
+        $this->postJson('/api/external/v1/stock/check', [
+            'ref_shipment_id' => 'SHP-BAD-SKU',
+            'items' => [
+                ['sku' => 'DOES-NOT-EXIST-'.uniqid(), 'qty' => 1, 'unit_id' => $refUnitId],
+            ],
+        ], $headers)->assertStatus(422)->assertJson(['success' => false, 'error' => ['code' => 'validation_failed']]);
+    }
+
+    public function test_check_rejects_an_unmapped_unit_id(): void
+    {
+        $headers = $this->externalApiHeaders();
+        $unit = $this->createUnit(random_int(900000, 999999));
+        $fx = $this->createProductFixture($unit);
+
+        $this->postJson('/api/external/v1/stock/check', [
+            'ref_shipment_id' => 'SHP-BAD-UNIT',
+            'items' => [
+                ['sku' => $fx['sku'], 'qty' => 1, 'unit_id' => random_int(100000000, 199999999)],
+            ],
+        ], $headers)->assertStatus(422)->assertJson(['success' => false, 'error' => ['code' => 'validation_failed']]);
+    }
+
+    public function test_check_defaults_to_the_main_warehouse_when_gudang_id_is_omitted(): void
+    {
+        $headers = $this->externalApiHeaders();
+        $refUnitId = random_int(900000, 999999);
+        $unit = $this->createUnit($refUnitId);
+        $fx = $this->createProductFixture($unit);
+        $this->createStock($fx['variant'], self::MAIN_WAREHOUSE_ID, $unit->unit_id, 7);
+        $this->createStock($fx['variant'], self::RETAIL_WAREHOUSE_ID, $unit->unit_id, 999);
+
+        $response = $this->postJson('/api/external/v1/stock/check', [
+            'ref_shipment_id' => 'SHP-DEFAULT-WH',
+            'items' => [
+                ['sku' => $fx['sku'], 'qty' => 1, 'unit_id' => $refUnitId],
+            ],
+        ], $headers);
+
+        $response->assertStatus(200);
+        $this->assertSame(7, $response->json('data.items.0.available'), 'omitting gudang_id must resolve to the main warehouse, not the retail one');
+    }
+
+    public function test_check_uses_the_explicit_gudang_id_when_given(): void
+    {
+        $headers = $this->externalApiHeaders();
+        $refUnitId = random_int(900000, 999999);
+        $unit = $this->createUnit($refUnitId);
+        $fx = $this->createProductFixture($unit);
+        $this->createStock($fx['variant'], self::MAIN_WAREHOUSE_ID, $unit->unit_id, 7);
+        $this->createStock($fx['variant'], self::RETAIL_WAREHOUSE_ID, $unit->unit_id, 42);
+
+        $response = $this->postJson('/api/external/v1/stock/check', [
+            'ref_shipment_id' => 'SHP-EXPLICIT-WH',
+            'gudang_id' => self::RETAIL_WAREHOUSE_ID,
+            'items' => [
+                ['sku' => $fx['sku'], 'qty' => 1, 'unit_id' => $refUnitId],
+            ],
+        ], $headers);
+
+        $response->assertStatus(200);
+        $this->assertSame(42, $response->json('data.items.0.available'));
+    }
+
+    public function test_check_rejects_an_unknown_gudang_id(): void
+    {
+        $headers = $this->externalApiHeaders();
+        $refUnitId = random_int(900000, 999999);
+        $unit = $this->createUnit($refUnitId);
+        $fx = $this->createProductFixture($unit);
+
+        $this->postJson('/api/external/v1/stock/check', [
+            'ref_shipment_id' => 'SHP-BAD-WH',
+            'gudang_id' => 999999999,
+            'items' => [
+                ['sku' => $fx['sku'], 'qty' => 1, 'unit_id' => $refUnitId],
+            ],
+        ], $headers)->assertStatus(422)->assertJson(['success' => false, 'error' => ['code' => 'validation_failed']]);
+    }
+
+    public function test_check_handles_multiple_items_independently(): void
+    {
+        $headers = $this->externalApiHeaders();
+        $refUnitIdA = random_int(900000, 949999);
+        $refUnitIdB = random_int(950000, 999999);
+        $unitA = $this->createUnit($refUnitIdA);
+        $unitB = $this->createUnit($refUnitIdB);
+        $fxA = $this->createProductFixture($unitA);
+        $fxB = $this->createProductFixture($unitB);
+        $this->createStock($fxA['variant'], self::MAIN_WAREHOUSE_ID, $unitA->unit_id, 100);
+        $this->createStock($fxB['variant'], self::MAIN_WAREHOUSE_ID, $unitB->unit_id, 2);
+
+        $response = $this->postJson('/api/external/v1/stock/check', [
+            'ref_shipment_id' => 'SHP-MULTI',
+            'items' => [
+                ['sku' => $fxA['sku'], 'qty' => 10, 'unit_id' => $refUnitIdA],
+                ['sku' => $fxB['sku'], 'qty' => 10, 'unit_id' => $refUnitIdB],
+            ],
+        ], $headers);
+
+        $response->assertStatus(200)->assertJson([
+            'success' => true,
+            'data' => [
+                'has_shortage' => true,
+                'items' => [
+                    ['sku' => $fxA['sku'], 'requested' => 10, 'available' => 100, 'shortage' => 0],
+                    ['sku' => $fxB['sku'], 'requested' => 10, 'available' => 2, 'shortage' => 8],
+                ],
+            ],
+        ]);
+    }
+}


### PR DESCRIPTION
## Ringkasan

Endpoint baru **POST /api/external/v1/stock/check** — modul "Stok" tersendiri di External API v1. Beda dengan seluruh modul sebelumnya (units, sales, armada, produk): modul ini **hanya baca**, tidak ada create/update/delete/connect.

Fungsinya: mengecek kekurangan stok (shortage) banyak SKU sekaligus terhadap satu gudang, dipakai pemanggil eksternal sebelum memproses pengiriman.

## Bentuk permintaan/respons

```json
// Request
{
  "ref_shipment_id": "SHP-2026-000123",
  "gudang_id": 1,
  "items": [
    { "sku": "MRP300P", "qty": 50, "unit_id": 5 }
  ]
}

// Response
{
  "success": true,
  "data": {
    "ref_shipment_id": "SHP-2026-000123",
    "has_shortage": true,
    "items": [
      { "sku": "MRP300P", "unit_id": 5, "requested": 50, "available": 50, "shortage": 0 }
    ]
  }
}
```

## Keputusan desain

- **`items[].unit_id`** merujuk `units.ref_unit_id` (rujukan sistem PMO), bukan id internal Pegasus — namanya sengaja tetap `unit_id` di body/respons sesuai kontrak yang diminta (bukan `ref_unit_id`).
- **`gudang_id`** opsional, merujuk `warehouses.id` langsung (sama seperti `{gudang_id}` pada PUT/DELETE `/master/warehouses`) — bukan kolom rujukan eksternal, karena gudang tidak disinkronkan PMO. Tidak dikirim → memakai `ProductStock::resolveWarehouseId(null)`: gudang utama.
- **`available`** dihitung lewat `App\Support\ProductUnitStock::totalAvailable()` — reuse logika yang sama persis dipakai Sales Order (`App\Support\SalesOrderStock`): stok pada satuan yang diminta ditambah stok pada satuan lebih besar dalam satu chain `product_relations` (dibongkar otomatis ke satuan yang diminta), TANPA packing ke arah sebaliknya (stok satuan kecil tidak digabung naik ke satuan besar).
- **SKU tak dikenal atau `unit_id` yang tidak merujuk satuan aktif manapun menolak SELURUH permintaan** (`validation_failed`, 422) — bukan diam-diam dianggap shortage penuh untuk item itu saja. Sebaliknya, kombinasi SKU + unit_id yang keduanya valid tapi memang tidak sechain (bukan satuan produk itu) tetap lolos validasi dan wajar menghasilkan `available: 0`.
- `shortage` tidak pernah negatif (`max(0, requested - available)`).
- Murni pengecekan — tidak ada reservasi/kunci stok.

## Test

`tests/Workflow/ExternalApiStockCheckFlowTest.php` — 11 test baru, semua hijau:
- autentikasi (401 tanpa API key)
- stok cukup / stok kurang
- bongkar satuan besar → kecil, dan **bukan** sebaliknya (satuan kecil tidak dibongkar naik)
- SKU tak dikenal, unit_id tak termapping, gudang_id tak dikenal → 422
- default ke gudang utama vs `gudang_id` eksplisit
- banyak item sekaligus, diproses independen

```
OK (11 tests, 22 assertions)
```

Sudah dicek juga: 38 kegagalan pre-existing di test suite Workflow (Production/PurchaseOrder/StockOpname + fatal duplicate class `PurchaseOrderDetail`/`PurchaseOrdersDetail`) tidak terkait perubahan ini — diff PR ini hanya menyentuh `config/externalapi.php`, `routes/external-api/v1.php`, dan 2 file baru (controller + doc class).

🤖 Generated with [Claude Code](https://claude.com/claude-code)