### PR TITLE
feat: tambah waktu cetak pada header PDF Tanda Terima

### DIFF
--- a/resources/views/Backoffice/PDF/TandaTerima.blade.php
+++ b/resources/views/Backoffice/PDF/TandaTerima.blade.php
@@ -150,7 +150,7 @@
             <div class="info-section">
                 <div class="info-row">
                     <div class="info-label">Tanggal Surat Terima</div>
-                    <div class="info-value">: {{ date('d F Y', strtotime($tt["tt_date"]))??null }}</div>
+                    <div class="info-value">: {{ $tt["tt_date"] ? date('d F Y', strtotime($tt["tt_date"])) . ', ' . now()->format('H:i:s') : null }}</div>
                 </div>
                
                 <div class="info-row">


### PR DESCRIPTION
## Ringkasan
Menambahkan informasi jam pada bagian header dokumen PDF Tanda Terima (TT), tepatnya pada baris "Tanggal Surat Terima". Sebelumnya hanya menampilkan tanggal `tt_date`, sekarang ditambahkan waktu saat PDF di-generate.

## Perubahan
- `resources/views/Backoffice/PDF/TandaTerima.blade.php`: menambahkan `now()->format('H:i:s')` di sebelah tanggal `tt_date` pada header, dengan format akhir `"<tt_date>, HH:mm:ss"`.
- Waktu diambil dari saat PDF di-render (`now()`), bukan kolom baru di database — tidak ada perubahan skema/migrasi.
- Sekalian merapikan guard null: kode lama `date(...)??null` tidak pernah bernilai null karena `strtotime()` sudah dieksekusi lebih dulu, sehingga null check tidak pernah tereksekusi. Sekarang dicek langsung dari `$tt["tt_date"]` sebelum diformat.

## Testing
- Perubahan hanya pada template Blade (tampilan PDF), tidak ada perubahan logika controller/model maupun kolom database.

Closes #50