### PR TITLE
feat: aturan change-status & cancel update (Dijadwalkan → Sudah terkirim)

### DIFF
--- a/app/ExternalApi/Docs/Endpoints/V1/ShipmentCancelDoc.php
+++ b/app/ExternalApi/Docs/Endpoints/V1/ShipmentCancelDoc.php
@@ -37,10 +37,11 @@ class ShipmentCancelDoc extends ApiEndpointDoc
     public function description(): string
     {
         return 'Membatalkan (pembatalan) satu shipment. Kalau shipment ini sebelumnya sudah '
-            .'"Berjalan" (stok sudah dipotong), stoknya DIKEMBALIKAN dulu sebelum status '
-            .'diubah menjadi "Dibatalkan" — proses pembatalan sungguhan, bukan sekadar menulis '
-            .'status seperti PATCH .../change-status. Idempoten: shipment yang sudah dibatalkan '
-            .'dijawab sukses apa adanya, tidak mengembalikan stok lagi.';
+            .'"Berjalan" atau "Sudah terkirim" (stok sudah dipotong), stoknya DIKEMBALIKAN dulu '
+            .'sebelum status diubah menjadi "Dibatalkan". Dari "Dijadwalkan" (stok belum pernah '
+            .'dipotong), cuma status yang berubah — proses pembatalan sungguhan, bukan sekadar '
+            .'menulis status seperti PATCH .../change-status. Idempoten: shipment yang sudah '
+            .'dibatalkan dijawab sukses apa adanya, tidak mengembalikan stok lagi.';
     }
 
     public function pathParameters(): array
@@ -91,7 +92,7 @@ class ShipmentCancelDoc extends ApiEndpointDoc
     public function notes(): array
     {
         return [
-            'Kalau shipment sebelumnya sudah ipm_status "Berjalan" (stok sudah dipotong — baik lewat POST /shipments/shipped maupun konfirmasi manual di halaman admin), stok DIKEMBALIKAN dulu sebelum status berubah — message-nya menyebutkan itu secara eksplisit ("...dan stok telah dikembalikan."). Kalau belum pernah "Berjalan" (mis. masih "Dijadwalkan"/"Belum terkirim"/"Sudah terkirim"), tidak ada stok yang perlu dikembalikan — message-nya cuma "Dokumen berhasil dibatalkan." tanpa menyebut stok.',
+            'Kalau shipment sebelumnya sudah ipm_status "Berjalan" (lewat POST /shipments/shipped atau konfirmasi manual di halaman admin) ATAU "Sudah terkirim" (lewat PATCH .../change-status) — dua-duanya berarti stok sudah dipotong — stok DIKEMBALIKAN dulu sebelum status berubah, message-nya menyebutkan itu secara eksplisit ("...dan stok telah dikembalikan."). Kalau masih "Dijadwalkan" (stok belum pernah dipotong), cuma status yang berubah — message-nya cuma "Dokumen berhasil dibatalkan." tanpa menyebut stok.',
             'Idempoten: shipment yang statusnya SUDAH "Dibatalkan" dijawab sukses apa adanya (meta.already_cancelled=true), TIDAK mengembalikan stok lagi — mencegah stok gudang tergelembung kalau permintaan yang sama dikirim ulang.',
             'ipm_status -1 "Dibatalkan" HANYA bisa dihasilkan lewat endpoint ini — PATCH .../change-status sengaja tidak menerima label ini (4 label lain saja: Dijadwalkan/Berjalan/Belum terkirim/Sudah terkirim).',
             'ref_shipment_id yang sama sekali belum pernah dipakai dijawab SHIPMENT_NOT_FOUND, sama seperti endpoint Shipment lain — existensi baris dan status "aktif" adalah dua hal berbeda.',

--- a/app/ExternalApi/Docs/Endpoints/V1/ShipmentChangeStatusDoc.php
+++ b/app/ExternalApi/Docs/Endpoints/V1/ShipmentChangeStatusDoc.php
@@ -37,10 +37,10 @@ class ShipmentChangeStatusDoc extends ApiEndpointDoc
 
     public function description(): string
     {
-        return 'FORCE mengubah status shipment ke salah satu dari 4 label yang disepakati kontrak. '
-            .'BELUM ada aturan transisi (status apa pun bisa dipaksa ke label apa pun yang sah) '
-            .'maupun efek samping per transisi (mis. memaksa ke "Berjalan" TIDAK memotong stok) — '
-            .'lihat catatan.';
+        return 'Mengubah status shipment ke salah satu dari 4 label yang disepakati kontrak. '
+            .'HANYA SATU transisi yang diizinkan saat ini: "Dijadwalkan" ke "Sudah terkirim" — '
+            .'kombinasi lain ditolak. Transisi ini memotong stok sungguhan, proses yang sama '
+            .'dengan POST /shipments/shipped — lihat catatan.';
     }
 
     public function pathParameters(): array
@@ -57,14 +57,14 @@ class ShipmentChangeStatusDoc extends ApiEndpointDoc
             ['name' => 'status', 'type' => 'string', 'required' => true,
                 'description' => 'Label status baru — SALAH SATU dari: '
                     .implode(', ', array_map(static fn ($l) => '"'.$l.'"', ShipmentStatusMap::validLabels()))
-                    .'. Bukan angka, bukan ipm_status — persis salah satu label itu.'],
+                    .'. Bukan angka, bukan ipm_status — persis salah satu label itu. Untuk saat ini hanya "Sudah terkirim" yang bisa berhasil, dan hanya kalau status shipment saat ini "Dijadwalkan".'],
         ];
     }
 
     public function requestExample(): ?array
     {
         return [
-            'status' => 'Berjalan',
+            'status' => 'Sudah terkirim',
         ];
     }
 
@@ -74,8 +74,8 @@ class ShipmentChangeStatusDoc extends ApiEndpointDoc
             'success' => true,
             'data' => [
                 'ref_shipment_id' => 'SHP-7788',
-                'status' => 'Berjalan',
-                'message' => 'Status Pengiriman dengan referensi SHP-7788 menjadi Berjalan',
+                'status' => 'Sudah terkirim',
+                'message' => 'Status Pengiriman dengan referensi SHP-7788 menjadi Sudah terkirim',
             ],
         ];
     }
@@ -87,16 +87,19 @@ class ShipmentChangeStatusDoc extends ApiEndpointDoc
                 'message' => 'Pengiriman dengan referensi SHP-7788 tidak ditemukan.'],
             ['code' => 'INVALID_STATUS', 'http_status' => 422,
                 'message' => 'Field status tidak valid. Hanya menerima [Dijadwalkan, Berjalan, Belum terkirim, Sudah terkirim]'],
+            ['code' => 'INVALID_STATUS_TRANSITION', 'http_status' => 409,
+                'message' => 'Perubahan status dari "Berjalan" ke "Dijadwalkan" belum diizinkan. Transisi yang didukung saat ini: Dijadwalkan -> Sudah terkirim.'],
+            ['code' => 'INSUFFICIENT_STOCK', 'http_status' => 409,
+                'message' => 'Stok tidak mencukupi untuk satu atau lebih item.'],
         ];
     }
 
     public function notes(): array
     {
         return [
-            'status pada body adalah LABEL (String, sama seperti ipm_status_label pada respons endpoint Shipment lain), BUKAN angka ipm_status maupun sales_orders.status internal.',
-            'BELUM ada aturan transisi — status shipment saat ini APA PUN bisa dipaksa ke label APA PUN yang sah, termasuk melompat atau mundur. PERLU DITINJAU ULANG pemilik produk (dicatat di KNOWN_ISSUES.md), belum dikonfirmasi untuk rilis ini.',
-            'HANYA mengubah status — TIDAK menjalankan efek samping apa pun yang menyertai perubahan status di endpoint lain. Contoh: memaksa ke "Berjalan" TIDAK memotong stok seperti yang dilakukan POST /shipments/shipped — kalau dipakai untuk shipment yang stoknya belum pernah dipotong, ipm_status akan tampak "Berjalan" padahal stok gudang belum tersentuh.',
-            '"Belum terkirim" dan "Sudah terkirim" hanya bisa dihasilkan lewat endpoint ini — POST /shipments/scheduled dan /shipments/shipped hanya menghasilkan "Dijadwalkan"/"Berjalan".',
+            'status pada body adalah LABEL (String, sama seperti ipm_status_label pada respons endpoint Shipment lain), BUKAN angka ipm_status maupun status internal sistem.',
+            'HANYA SATU transisi yang diizinkan untuk saat ini: dari "Dijadwalkan" ke "Sudah terkirim". Mengirim label yang valid tapi bukan bagian dari transisi ini (mis. shipment yang statusnya sudah "Sudah terkirim" dikirim ulang "Sudah terkirim", atau shipment "Dijadwalkan" diminta jadi "Berjalan"/"Belum terkirim") ditolak dengan galat INVALID_STATUS_TRANSITION — beda dengan INVALID_STATUS yang berarti labelnya sendiri tidak dikenali sama sekali.',
+            'Transisi "Dijadwalkan" ke "Sudah terkirim" MEMOTONG STOK sungguhan, proses yang sama dengan konfirmasi di POST /shipments/shipped. Kalau stok tidak mencukupi, permintaan gagal INSUFFICIENT_STOCK dan status shipment TETAP "Dijadwalkan".',
             'ref_shipment_id yang sama sekali belum pernah dipakai dijawab SHIPMENT_NOT_FOUND, sama seperti GET /shipments/{ref_shipment_id} — existensi baris dan status "aktif" adalah dua hal berbeda.',
         ];
     }

--- a/app/ExternalApi/Errors/ErrorCatalog.php
+++ b/app/ExternalApi/Errors/ErrorCatalog.php
@@ -79,6 +79,9 @@ final class ErrorCatalog
     /** PATCH /shipments/{ref_shipment_id}/change-status — label status yang dikirim bukan salah satu dari 4 label yang disepakati kontrak. */
     public const INVALID_STATUS = 'INVALID_STATUS';
 
+    /** PATCH /shipments/{ref_shipment_id}/change-status — label valid, tapi transisi dari status shipment saat ini ke label itu belum diizinkan. */
+    public const INVALID_STATUS_TRANSITION = 'INVALID_STATUS_TRANSITION';
+
     /**
      * Pesan baku bertemplate, placeholder `<nama>` diganti lewat $params.
      *
@@ -87,6 +90,7 @@ final class ErrorCatalog
     private const TEMPLATES = [
         self::SHIPMENT_NOT_FOUND => 'Pengiriman dengan referensi <ref_shipment_id> tidak ditemukan.',
         self::INVALID_STATUS => 'Field status tidak valid. Hanya menerima [<valid_statuses>]',
+        self::INVALID_STATUS_TRANSITION => 'Perubahan status dari "<current_status>" ke "<target_status>" belum diizinkan. Transisi yang didukung saat ini: <allowed_transitions>.',
     ];
 
     /**

--- a/app/Http/Controllers/ExternalApi/V1/ShipmentController.php
+++ b/app/Http/Controllers/ExternalApi/V1/ShipmentController.php
@@ -48,22 +48,26 @@ class ShipmentController extends Controller
 
     private const STATUS_SCHEDULED = 4;
 
-    /** sales_orders.status, lihat migrasi 2026_08_12_110000_* — hanya dihasilkan changeStatus(). */
+    /**
+     * sales_orders.status, lihat migrasi 2026_08_12_110000_*. Belum dihasilkan endpoint manapun
+     * saat ini — ALLOWED_TRANSITIONS di bawah belum membuka transisi apa pun menuju "Belum
+     * terkirim", dipertahankan untuk kalau pemilik produk membukanya nanti.
+     */
     private const STATUS_NOT_DELIVERED = 5;
 
+    /** sales_orders.status untuk ipm_status "Sudah Terkirim" — lihat ALLOWED_TRANSITIONS. */
     private const STATUS_DELIVERED = 6;
 
     /**
-     * ipm_status (ShipmentStatusMap::ipmForLabel()) -> target sales_orders.status dipaksa
-     * changeStatus(). BUKAN kebalikan sesungguhnya dari ShipmentStatusMap::fromInternal() — ipm
-     * 1 "Dijadwalkan" bisa dihasilkan internal 1 ATAU 4, tapi target paksa di sini SELALU 4
-     * (dijadwalkan lewat API), tidak pernah 1 (dibuat manual lewat admin, beda alur).
+     * Transisi ipm_status yang diizinkan changeStatus() saat ini — DIKONFIRMASI pemilik produk
+     * 2026-08-13: HANYA Dijadwalkan -> Sudah Terkirim, kombinasi lain (termasuk mundur, maupun
+     * target "Berjalan"/"Belum terkirim") ditolak INVALID_STATUS_TRANSITION. Bentuknya
+     * ipm_status_saat_ini => daftar ipm_status_tujuan yang boleh, supaya gampang ditambah kalau
+     * pemilik produk membuka transisi lain nanti — bukan berarti sengaja disiapkan buat itu
+     * sekarang, cuma bentuk yang paling gampang diperluas tanpa nulis ulang guard-nya.
      */
-    private const TARGET_INTERNAL_STATUS = [
-        ShipmentStatusMap::IPM_SCHEDULED => self::STATUS_SCHEDULED,
-        ShipmentStatusMap::IPM_RUNNING => self::STATUS_CONFIRMED,
-        ShipmentStatusMap::IPM_NOT_DELIVERED => self::STATUS_NOT_DELIVERED,
-        ShipmentStatusMap::IPM_DELIVERED => self::STATUS_DELIVERED,
+    private const ALLOWED_TRANSITIONS = [
+        ShipmentStatusMap::IPM_SCHEDULED => [ShipmentStatusMap::IPM_DELIVERED],
     ];
 
     /**
@@ -409,29 +413,22 @@ class ShipmentController extends Controller
     /**
      * PATCH /api/external/v1/shipments/{ref_shipment_id}/change-status
      *
-     * FORCE mengubah status shipment — body.status adalah LABEL (bukan angka), salah satu dari
-     * 4 label yang disepakati kontrak (App\ExternalApi\Support\ShipmentStatusMap::validLabels()):
-     * "Dijadwalkan", "Berjalan", "Belum terkirim", "Sudah terkirim". Label yang bukan salah satu
-     * dari situ dijawab galat INVALID_STATUS (422) berisi daftar label yang sah.
+     * body.status adalah LABEL (bukan angka), salah satu dari 4 label yang disepakati kontrak
+     * (App\ExternalApi\Support\ShipmentStatusMap::validLabels()): "Dijadwalkan", "Berjalan",
+     * "Belum terkirim", "Sudah terkirim". Label yang bukan salah satu dari situ dijawab galat
+     * INVALID_STATUS (422) berisi daftar label yang sah.
      *
-     * BELUM ada aturan transisi (mis. tidak boleh lompat dari "Dijadwalkan" langsung ke "Sudah
-     * terkirim", tidak boleh mundur) — status APA PUN pada baris saat ini bisa dipaksa ke label
-     * APA PUN yang sah, tanpa syarat. Ini SENGAJA untuk rilis pertama endpoint ini ("for now only
-     * force change the status") — PERLU DITINJAU ULANG pemilik produk, dicatat di
-     * cdocs/testing/KNOWN_ISSUES.md.
+     * HANYA SATU transisi yang diizinkan saat ini (DIKONFIRMASI pemilik produk 2026-08-13, lihat
+     * ALLOWED_TRANSITIONS di atas): Dijadwalkan -> Sudah Terkirim. Kombinasi status-saat-ini/
+     * label-tujuan lain (termasuk target "Berjalan"/"Belum terkirim", atau mundur dari status
+     * mana pun) ditolak INVALID_STATUS_TRANSITION (409) — beda dari INVALID_STATUS: labelnya
+     * SAH secara kontrak, cuma transisinya yang belum dibuka untuk status baris saat ini.
      *
-     * PENTING: perubahan ini HANYA menulis kolom status — TIDAK menjalankan efek samping apa pun
-     * yang biasanya menyertai perubahan status di alur lain. Contoh paling nyata: memaksa ke
-     * "Berjalan" TIDAK memotong stok lewat App\Support\SalesOrderApproval::confirm() seperti
-     * POST /shipments/shipped — kalau dipakai untuk shipment yang stoknya belum pernah dipotong,
-     * shipment akan tampak "Berjalan" padahal stok gudang belum tersentuh. Efek samping per
-     * transisi (kalau memang dibutuhkan) menyusul setelah dikonfirmasi pemilik produk, sama
-     * seperti aturan transisi di atas.
-     *
-     * "Belum terkirim" dan "Sudah terkirim" belum bisa dihasilkan endpoint Shipment manapun
-     * selain lewat sini (scheduled()/shipped() hanya menghasilkan "Dijadwalkan"/"Berjalan") —
-     * makanya sales_orders.status butuh dua nilai baru (5, 6) khusus endpoint ini, lihat migrasi
-     * 2026_08_12_110000_* dan TARGET_INTERNAL_STATUS di atas.
+     * Transisi Dijadwalkan -> Sudah Terkirim ini MEMOTONG STOK sungguhan — memakai ulang
+     * App\Support\SalesOrderApproval::confirm() PERSIS seperti POST /shipments/shipped, cuma
+     * target status akhirnya beda (6 "Sudah Terkirim (API)", bukan 2 "Confirmed/Berjalan").
+     * Kalau stok tidak cukup, permintaan gagal INSUFFICIENT_STOCK (409) dan baris TETAP di
+     * "Dijadwalkan" — sama seperti kegagalan konfirmasi di /shipments/shipped.
      */
     public function changeStatus(Request $request, string $refShipmentId): JsonResponse
     {
@@ -449,8 +446,8 @@ class ShipmentController extends Controller
             'status' => ['required', 'string'],
         ]);
 
-        $ipmStatus = ShipmentStatusMap::ipmForLabel($data['status']);
-        if ($ipmStatus === null) {
+        $targetIpm = ShipmentStatusMap::ipmForLabel($data['status']);
+        if ($targetIpm === null) {
             return ApiResponse::error(
                 ErrorCatalog::INVALID_STATUS,
                 ErrorCatalog::message(ErrorCatalog::INVALID_STATUS, [
@@ -460,23 +457,65 @@ class ShipmentController extends Controller
             );
         }
 
-        $so->status = self::TARGET_INTERNAL_STATUS[$ipmStatus];
-        $so->save();
+        $currentIpm = ShipmentStatusMap::fromInternal((int) $so->status);
+        $allowedTargets = self::ALLOWED_TRANSITIONS[$currentIpm] ?? [];
+        if (! in_array($targetIpm, $allowedTargets, true)) {
+            return $this->invalidTransitionError($currentIpm, $targetIpm);
+        }
+
+        // Satu-satunya transisi yang bisa lolos guard di atas saat ini: Dijadwalkan -> Sudah
+        // Terkirim — memotong stok sungguhan lewat proses yang sama dengan /shipments/shipped.
+        $result = SalesOrderApproval::confirm($so, null, self::STATUS_DELIVERED);
+        if (! ($result['ok'] ?? false)) {
+            return ApiResponse::error(
+                ErrorCatalog::INSUFFICIENT_STOCK,
+                $result['message'] ?? 'Stok tidak mencukupi.',
+                409,
+                [
+                    'products' => $result['products'] ?? [],
+                    'recommendations' => $result['recommendations'] ?? [],
+                ],
+            );
+        }
+
+        $label = ShipmentStatusMap::label($targetIpm);
 
         return ApiResponse::success([
             'ref_shipment_id' => (string) $so->ref_shipment_id,
-            'status' => ShipmentStatusMap::label($ipmStatus),
-            'message' => 'Status Pengiriman dengan referensi '.$so->ref_shipment_id.' menjadi '.ShipmentStatusMap::label($ipmStatus),
+            'status' => $label,
+            'message' => 'Status Pengiriman dengan referensi '.$so->ref_shipment_id.' menjadi '.$label,
         ]);
+    }
+
+    private function invalidTransitionError(?int $currentIpm, int $targetIpm): JsonResponse
+    {
+        $allowedDescriptions = [];
+        foreach (self::ALLOWED_TRANSITIONS as $fromIpm => $toIpmList) {
+            foreach ($toIpmList as $toIpm) {
+                $allowedDescriptions[] = ShipmentStatusMap::label($fromIpm).' -> '.ShipmentStatusMap::label($toIpm);
+            }
+        }
+
+        return ApiResponse::error(
+            ErrorCatalog::INVALID_STATUS_TRANSITION,
+            ErrorCatalog::message(ErrorCatalog::INVALID_STATUS_TRANSITION, [
+                'current_status' => $currentIpm !== null ? ShipmentStatusMap::label($currentIpm) : 'Tidak diketahui',
+                'target_status' => ShipmentStatusMap::label($targetIpm),
+                'allowed_transitions' => implode(', ', $allowedDescriptions),
+            ]),
+            409,
+        );
     }
 
     /**
      * PUT /api/external/v1/shipments/{ref_shipment_id}/cancel
      *
      * Batalkan (pembatalan) satu shipment — SELALU menjalankan proses pembatalan yang sama
-     * seperti alur normal, bukan sekadar menulis status seperti changeStatus(): kalau shipment
-     * ini sebelumnya sudah Confirmed (ipm_status "Berjalan", stok sudah dipotong lewat
-     * SalesOrderApproval::confirm()), stoknya DIKEMBALIKAN lebih dulu — lihat
+     * seperti alur normal, bukan sekadar menulis status seperti changeStatus(): kalau stok
+     * shipment ini sebelumnya sudah dipotong (ipm_status "Berjalan" lewat /shipments/shipped,
+     * ATAU "Sudah Terkirim" lewat transisi change-status Dijadwalkan -> Sudah Terkirim yang MEMANG
+     * memotong stok — DIKONFIRMASI pemilik produk 2026-08-13), stoknya DIKEMBALIKAN lebih dulu.
+     * Dari "Dijadwalkan" (stok belum pernah dipotong), cancel cuma mengubah status. Lihat
      * App\Support\SalesOrderCancellation::cancel() (BARU, diekstrak jadi reusable karena TIDAK
      * ADA alur admin yang setara untuk dicontek: CustomerController::declineSO()/
      * deleteSalesOrder() cuma berlaku sebelum Confirmed, jadi tidak pernah perlu mengembalikan

--- a/app/Support/SalesOrderApproval.php
+++ b/app/Support/SalesOrderApproval.php
@@ -8,13 +8,14 @@ use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Facades\DB;
 
 /**
- * Confirm/ACC satu Sales Order (Pengiriman): potong stok + set status Confirmed (2).
+ * Confirm/ACC satu Sales Order (Pengiriman): potong stok + set status Confirmed (2) — atau status
+ * lain yang juga berarti "stok sudah dipotong", lihat $targetStatus.
  *
  * Diekstrak dari CustomerController::accSO() supaya bisa dipakai ulang tanpa lewat HTTP layer -
- * dipakai juga oleh App\Http\Controllers\ExternalApi\V1\ShipmentController::shipped(). Isinya
- * PERSIS logika yang sama (buildPlan -> executeDeduct -> set status 2), bukan tulis ulang.
- * CustomerController::accSO() sendiri sekarang memanggil confirm() ini juga, jadi hanya ada SATU
- * tempat yang perlu diubah kalau alur konfirmasi berubah.
+ * dipakai juga oleh App\Http\Controllers\ExternalApi\V1\ShipmentController::shipped() dan
+ * ::changeStatus(). Isinya PERSIS logika yang sama (buildPlan -> executeDeduct -> set status),
+ * bukan tulis ulang. CustomerController::accSO() sendiri sekarang memanggil confirm() ini juga,
+ * jadi hanya ada SATU tempat yang perlu diubah kalau alur potong-stok berubah.
  *
  * Beda dengan accSO() controller aslinya:
  * - Precondition status "boleh dikonfirmasi" diperluas: 1 (Created, dibuat manual lewat halaman
@@ -26,6 +27,11 @@ use Illuminate\Support\Facades\DB;
  * - $staffId eksplisit sebagai parameter, bukan membaca Session::get('user') sendiri - supaya
  *   jelas nilainya dari mana (null utuh untuk panggilan dari External API, sama seperti
  *   created_by pada insertSalesOrder/insertProduct dst.).
+ * - $targetStatus eksplisit (bawaan 2 = Confirmed/"Berjalan"): dipakai apa adanya oleh
+ *   accSO()/shipped(). ShipmentController::changeStatus() memakai fungsi yang SAMA PERSIS ini
+ *   untuk transisi Dijadwalkan -> Sudah Terkirim (status 6) - potong stok terjadi, cuma status
+ *   akhirnya beda (DIKONFIRMASI pemilik produk 2026-08-13: transisi itu MEMANG memotong stok,
+ *   bukan cuma tulis status).
  * - Seluruh kegagalan (status tidak valid, stok tidak cukup, potong stok gagal) selalu
  *   dikembalikan sebagai array terstruktur, tidak pernah melempar exception ke pemanggil -
  *   supaya baik controller admin maupun External API bisa memakai bentuk yang sama tanpa
@@ -42,7 +48,7 @@ class SalesOrderApproval
      *     products?: array<int, string>, recommendations?: array<int, array>,
      * }
      */
-    public static function confirm(SalesOrder $so, ?int $staffId): array
+    public static function confirm(SalesOrder $so, ?int $staffId, int $targetStatus = 2): array
     {
         if (! in_array((int) $so->status, self::CONFIRMABLE_STATUSES, true)) {
             return [
@@ -68,7 +74,7 @@ class SalesOrderApproval
         }
 
         try {
-            DB::transaction(function () use ($plan, $so, $staffId) {
+            DB::transaction(function () use ($plan, $so, $staffId, $targetStatus) {
                 $deduct = SalesOrderStock::executeDeduct(
                     $plan['plan'],
                     $so->so_invoice_no ?: $so->so_number,
@@ -78,7 +84,7 @@ class SalesOrderApproval
                     throw new \RuntimeException($deduct['message'] ?? 'Gagal potong stok');
                 }
 
-                $so->status = 2;
+                $so->status = $targetStatus;
                 if (Schema::hasColumn($so->getTable(), 'acc_by')) {
                     $so->acc_by = $staffId;
                 }

--- a/app/Support/SalesOrderCancellation.php
+++ b/app/Support/SalesOrderCancellation.php
@@ -8,8 +8,10 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 /**
- * Batalkan satu Sales Order (Pengiriman): kembalikan stok KALAU sebelumnya sudah Confirmed
- * (stoknya sudah dipotong lewat SalesOrderApproval::confirm()), lalu set status Dibatalkan (7).
+ * Batalkan satu Sales Order (Pengiriman): kembalikan stok KALAU stoknya sebelumnya sudah pernah
+ * dipotong (lewat SalesOrderApproval::confirm(), baik dari /shipments/shipped ATAU dari transisi
+ * change-status Dijadwalkan -> Sudah Terkirim — lihat STOCK_DEDUCTED_STATUSES), lalu set status
+ * Dibatalkan (7).
  *
  * Tidak ada alur admin yang setara untuk dicontek/diekstrak (BEDA dengan SalesOrderApproval yang
  * diekstrak dari accSO() yang sudah ada) - CustomerController::declineSO()/deleteSalesOrder()
@@ -31,11 +33,14 @@ class SalesOrderCancellation
     public const STATUS_CANCELLED = 7;
 
     /**
-     * Status internal yang berarti "stok sudah dipotong dan perlu dikembalikan" kalau dibatalkan.
-     * Cuma 2 (Confirmed) - status lain (1/4/5/6) tidak pernah lewat SalesOrderApproval::confirm(),
-     * jadi stoknya tidak pernah dipotong untuk baris itu.
+     * Status internal yang berarti "stok sudah dipotong dan perlu dikembalikan" kalau dibatalkan:
+     *   - 2 (Confirmed/"Berjalan") - lewat POST /shipments/shipped atau ACC manual admin.
+     *   - 6 (Sudah Terkirim (API)) - lewat PATCH .../change-status, transisi Dijadwalkan -> Sudah
+     *     Terkirim (DIKONFIRMASI pemilik produk 2026-08-13 MEMOTONG STOK, sama seperti /shipped).
+     * Status lain (1/4/5, "Dijadwalkan"/"Belum terkirim") tidak pernah dipotong untuk baris itu -
+     * dikonfirmasi pemilik produk: dari "Dijadwalkan", cancel cuma mengubah status.
      */
-    private const STOCK_DEDUCTED_STATUSES = [2];
+    private const STOCK_DEDUCTED_STATUSES = [2, 6];
 
     /**
      * @return array{ok: bool, message?: string, already_cancelled?: bool, stock_restored?: bool}

--- a/database/migrations/2026_08_13_090000_update_sales_orders_status_comment_for_delivered_deduction.php
+++ b/database/migrations/2026_08_13_090000_update_sales_orders_status_comment_for_delivered_deduction.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Perubahan komentar kolom saja — DIKONFIRMASI pemilik produk 2026-08-13: transisi
+     * PATCH /shipments/{ref}/change-status (status = 6 "Sudah Terkirim") sekarang MEMOTONG STOK
+     * sungguhan (lewat App\Support\SalesOrderApproval::confirm(), sama seperti /shipments/shipped),
+     * bukan cuma tulis status seperti sebelumnya. Aturan lengkap: satu-satunya transisi yang
+     * diizinkan saat ini adalah Dijadwalkan (1/4) -> Sudah Terkirim (6); target lain (5 "Belum
+     * Terkirim") belum bisa dihasilkan endpoint manapun, dipertahankan untuk kalau dibuka nanti.
+     *
+     * Tidak ada doctrine/dbal di proyek ini, jadi comment kolom diubah lewat SQL mentah (MODIFY).
+     */
+    public function up(): void
+    {
+        DB::statement(
+            "ALTER TABLE sales_orders MODIFY status TINYINT NOT NULL DEFAULT 1 COMMENT "
+            ."'1 = Created, 2 = Confirmed, 3 = Completed, 4 = Dijadwalkan (dibuat lewat External API /shipments/scheduled, stok belum dipotong), "
+            ."5 = Belum Terkirim (API, belum ada endpoint yang menghasilkan ini), "
+            ."6 = Sudah Terkirim (API, lewat PATCH /shipments/{ref}/change-status dari status 4 — MEMOTONG STOK sungguhan), "
+            ."7 = Dibatalkan (API, lewat PUT /shipments/{ref}/cancel, stok dikembalikan kalau sebelumnya Confirmed atau Sudah Terkirim)'"
+        );
+    }
+
+    public function down(): void
+    {
+        DB::statement(
+            "ALTER TABLE sales_orders MODIFY status TINYINT NOT NULL DEFAULT 1 COMMENT "
+            ."'1 = Created, 2 = Confirmed, 3 = Completed, 4 = Dijadwalkan (dibuat lewat External API /shipments/scheduled, stok belum dipotong), "
+            ."5 = Belum Terkirim (API, dipaksa lewat PATCH /shipments/{ref}/change-status), "
+            ."6 = Sudah Terkirim (API, dipaksa lewat PATCH /shipments/{ref}/change-status), "
+            ."7 = Dibatalkan (API, lewat PUT /shipments/{ref}/cancel, stok dikembalikan kalau sebelumnya Confirmed)'"
+        );
+    }
+};

--- a/routes/external-api/v1.php
+++ b/routes/external-api/v1.php
@@ -156,12 +156,14 @@ Route::prefix('stock')->name('stock.')->group(function () {
  * ref_shipment_id (beda dengan scheduled() yang menolak duplikat) dan memakai ulang
  * App\Support\SalesOrderApproval::confirm() — logika accSO() yang sama dipakai halaman admin
  * Pengiriman, diekstrak supaya bisa dipakai di sini juga. show() (GET) menemukan baris apa pun
- * dengan ref_shipment_id itu tanpa syarat status. changeStatus() (PATCH) FORCE mengubah status
- * berdasarkan label — BELUM ada aturan transisi maupun efek samping per transisi, lihat docblock
- * method-nya (butuh konfirmasi pemilik produk, dicatat KNOWN_ISSUES.md). cancel() (PUT)
- * membatalkan shipment SUNGGUHAN (bukan sekadar tulis status) — mengembalikan stok kalau
- * sebelumnya Confirmed, lewat App\Support\SalesOrderCancellation::cancel() (BARU, karena tidak
- * ada alur admin setara untuk diekstrak), idempoten lewat status.
+ * dengan ref_shipment_id itu tanpa syarat status. changeStatus() (PATCH) mengubah status
+ * berdasarkan label — HANYA satu transisi diizinkan saat ini (DIKONFIRMASI pemilik produk
+ * 2026-08-13): Dijadwalkan -> Sudah Terkirim, dan transisi itu MEMOTONG STOK sungguhan lewat
+ * SalesOrderApproval::confirm() yang sama, lihat docblock method-nya. cancel() (PUT) membatalkan
+ * shipment SUNGGUHAN (bukan sekadar tulis status) — mengembalikan stok kalau sebelumnya
+ * Confirmed/"Berjalan" ATAU "Sudah Terkirim" (dua-duanya berarti stok sudah dipotong), lewat
+ * App\Support\SalesOrderCancellation::cancel() (BARU, karena tidak ada alur admin setara untuk
+ * diekstrak), idempoten lewat status.
  */
 Route::prefix('shipments')->name('shipments.')->group(function () {
     Route::post('/scheduled', [ShipmentController::class, 'scheduled'])->name('scheduled');

--- a/tests/Workflow/ExternalApiShipmentCancelFlowTest.php
+++ b/tests/Workflow/ExternalApiShipmentCancelFlowTest.php
@@ -227,6 +227,41 @@ class ExternalApiShipmentCancelFlowTest extends TestCase
         $this->assertSame(100, $stock->fresh()->ps_stock); // fully restored back to pre-shipment level
     }
 
+    public function test_cancel_a_sudah_terkirim_shipment_restores_stock(): void
+    {
+        $headers = $this->externalApiHeaders();
+        $fixture = $this->createScheduledShipment($headers);
+
+        // Dijadwalkan -> Sudah terkirim, per App\Support\SalesOrderApproval::confirm() deducting
+        // stock the same way /shipments/shipped does (DIKONFIRMASI pemilik produk 2026-08-13).
+        $this->patchJson('/api/external/v1/shipments/'.$fixture['ref'].'/change-status', ['status' => 'Sudah terkirim'], $headers)
+            ->assertStatus(200);
+
+        $stock = ProductStock::withoutGlobalScope('active_warehouse')
+            ->where('product_variant_id', $fixture['variant']->product_variant_id)
+            ->where('warehouse_id', self::MAIN_WAREHOUSE_ID)->first();
+        $this->assertSame(76, $stock->fresh()->ps_stock); // 100 - 24, sanity check change-status deducted
+
+        $response = $this->putJson(
+            '/api/external/v1/shipments/'.$fixture['ref'].'/cancel',
+            ['reason' => 'Dibatalkan setelah Sudah terkirim'],
+            $headers,
+        );
+
+        $response->assertStatus(200)->assertJson([
+            'success' => true,
+            'data' => [
+                'ref_shipment_id' => $fixture['ref'],
+                'ipm_status' => -1,
+                'ipm_status_label' => 'Dibatalkan',
+                'message' => 'Dokumen berhasil dibatalkan dan stok telah dikembalikan.',
+            ],
+        ]);
+
+        $this->assertSame(7, SalesOrder::where('ref_shipment_id', $fixture['ref'])->value('status'));
+        $this->assertSame(100, $stock->fresh()->ps_stock); // fully restored back to pre-shipment level
+    }
+
     public function test_cancel_is_idempotent_and_does_not_double_restore_stock(): void
     {
         $headers = $this->externalApiHeaders();

--- a/tests/Workflow/ExternalApiShipmentChangeStatusFlowTest.php
+++ b/tests/Workflow/ExternalApiShipmentChangeStatusFlowTest.php
@@ -9,7 +9,6 @@ use App\Models\ProductStock;
 use App\Models\ProductVariant;
 use App\Models\SalesOrder;
 use App\Models\Unit;
-use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\Support\ActingAsExternalApiClient;
 use Tests\TestCase;
 
@@ -18,11 +17,10 @@ use Tests\TestCase;
  * changeStatus(). Real warehouse id from the committed seed snapshot: 1 = Gudang Pusat (main), see
  * SalesOrderRetailAndUnitConversionFlowTest's docblock.
  *
- * changeStatus() FORCE-writes sales_orders.status with no transition guard and no side effects
- * (no stock deduction even when targeting "Berjalan") — see the controller's docblock. These tests
- * cover exactly that: any status -> any valid label succeeds, no stock is touched, and the round
- * trip through GET /shipments/{ref} shows the correct ipm_status/label back, including for the two
- * new internal codes (5, 6) that only this endpoint can produce.
+ * DIKONFIRMASI pemilik produk 2026-08-13: hanya SATU transisi diizinkan saat ini — "Dijadwalkan"
+ * ke "Sudah terkirim" — dan transisi itu MEMOTONG STOK sungguhan (proses yang sama dengan
+ * POST /shipments/shipped). Segala kombinasi lain (label lain, atau status shipment saat ini
+ * bukan "Dijadwalkan") ditolak INVALID_STATUS_TRANSITION.
  */
 class ExternalApiShipmentChangeStatusFlowTest extends TestCase
 {
@@ -94,14 +92,14 @@ class ExternalApiShipmentChangeStatusFlowTest extends TestCase
         ]);
     }
 
-    /** Creates a "Dijadwalkan" (status=4) shipment via the real endpoint, returns its ref. */
-    private function createScheduledShipment(array $headers): string
+    /** @return array{ref: string, variant: ProductVariant} "Dijadwalkan" (status=4, stock untouched) shipment. */
+    private function createScheduledShipment(array $headers, int $stockQty = 100): array
     {
         $armada = $this->createArmada();
         $refUnitId = random_int(900000, 999999);
         $unit = $this->createUnit($refUnitId);
         $fx = $this->createProductFixture($unit);
-        $this->createStock($fx['variant'], $unit->unit_id, 100);
+        $this->createStock($fx['variant'], $unit->unit_id, $stockQty);
         $refShipmentId = 'SHP-'.uniqid();
 
         $this->postJson('/api/external/v1/shipments/scheduled', [
@@ -113,12 +111,12 @@ class ExternalApiShipmentChangeStatusFlowTest extends TestCase
             ],
         ], $headers)->assertStatus(201);
 
-        return $refShipmentId;
+        return ['ref' => $refShipmentId, 'variant' => $fx['variant']];
     }
 
     public function test_a_request_without_an_api_key_is_rejected(): void
     {
-        $this->patchJson('/api/external/v1/shipments/SHP-1/change-status', ['status' => 'Berjalan'])
+        $this->patchJson('/api/external/v1/shipments/SHP-1/change-status', ['status' => 'Sudah terkirim'])
             ->assertStatus(401)->assertJson(['success' => false, 'error' => ['code' => 'UNAUTHENTICATED']]);
     }
 
@@ -128,7 +126,7 @@ class ExternalApiShipmentChangeStatusFlowTest extends TestCase
 
         $response = $this->patchJson(
             '/api/external/v1/shipments/DOES-NOT-EXIST-'.uniqid().'/change-status',
-            ['status' => 'Berjalan'],
+            ['status' => 'Sudah terkirim'],
             $headers,
         );
 
@@ -142,10 +140,10 @@ class ExternalApiShipmentChangeStatusFlowTest extends TestCase
     public function test_change_status_rejects_a_label_outside_the_agreed_four(): void
     {
         $headers = $this->externalApiHeaders();
-        $refShipmentId = $this->createScheduledShipment($headers);
+        $fixture = $this->createScheduledShipment($headers);
 
         $response = $this->patchJson(
-            '/api/external/v1/shipments/'.$refShipmentId.'/change-status',
+            '/api/external/v1/shipments/'.$fixture['ref'].'/change-status',
             ['status' => 'Diterima'],
             $headers,
         );
@@ -158,130 +156,119 @@ class ExternalApiShipmentChangeStatusFlowTest extends TestCase
         $this->assertStringContainsString('Dijadwalkan', $message);
         $this->assertStringContainsString('Sudah terkirim', $message);
 
-        $this->assertSame(4, SalesOrder::where('ref_shipment_id', $refShipmentId)->value('status'));
+        $this->assertSame(4, SalesOrder::where('ref_shipment_id', $fixture['ref'])->value('status'));
     }
 
     public function test_change_status_requires_the_status_field(): void
     {
         $headers = $this->externalApiHeaders();
-        $refShipmentId = $this->createScheduledShipment($headers);
+        $fixture = $this->createScheduledShipment($headers);
 
-        $this->patchJson('/api/external/v1/shipments/'.$refShipmentId.'/change-status', [], $headers)
+        $this->patchJson('/api/external/v1/shipments/'.$fixture['ref'].'/change-status', [], $headers)
             ->assertStatus(422)->assertJson(['success' => false, 'error' => ['code' => 'VALIDATION_FAILED']]);
     }
 
-    /**
-     * @return array<int, array{0: string, 1: int}>
-     */
-    public static function labelToInternalStatusProvider(): array
-    {
-        return [
-            'Dijadwalkan' => ['Dijadwalkan', 4],
-            'Berjalan' => ['Berjalan', 2],
-            'Belum terkirim' => ['Belum terkirim', 5],
-            'Sudah terkirim' => ['Sudah terkirim', 6],
-        ];
-    }
-
-    #[DataProvider('labelToInternalStatusProvider')]
-    public function test_change_status_force_writes_the_target_internal_status(string $label, int $expectedInternalStatus): void
+    public function test_change_status_from_dijadwalkan_to_sudah_terkirim_deducts_stock(): void
     {
         $headers = $this->externalApiHeaders();
-        $refShipmentId = $this->createScheduledShipment($headers);
+        $fixture = $this->createScheduledShipment($headers, 100);
+
+        $stock = ProductStock::withoutGlobalScope('active_warehouse')
+            ->where('product_variant_id', $fixture['variant']->product_variant_id)
+            ->where('warehouse_id', self::MAIN_WAREHOUSE_ID)->first();
 
         $response = $this->patchJson(
-            '/api/external/v1/shipments/'.$refShipmentId.'/change-status',
-            ['status' => $label],
+            '/api/external/v1/shipments/'.$fixture['ref'].'/change-status',
+            ['status' => 'Sudah terkirim'],
             $headers,
         );
 
         $response->assertStatus(200)->assertJson([
             'success' => true,
             'data' => [
-                'ref_shipment_id' => $refShipmentId,
-                'status' => $label,
-                'message' => 'Status Pengiriman dengan referensi '.$refShipmentId.' menjadi '.$label,
+                'ref_shipment_id' => $fixture['ref'],
+                'status' => 'Sudah terkirim',
+                'message' => 'Status Pengiriman dengan referensi '.$fixture['ref'].' menjadi Sudah terkirim',
             ],
         ]);
 
-        $this->assertSame($expectedInternalStatus, SalesOrder::where('ref_shipment_id', $refShipmentId)->value('status'));
+        $this->assertSame(6, SalesOrder::where('ref_shipment_id', $fixture['ref'])->value('status'));
+        // 100 - 24 = 76, the same real deduction /shipments/shipped would have done.
+        $this->assertSame(76, $stock->fresh()->ps_stock);
     }
 
-    public function test_change_status_to_berjalan_does_not_deduct_stock(): void
+    public function test_change_status_rejects_any_other_transition(): void
     {
         $headers = $this->externalApiHeaders();
-        $armada = $this->createArmada();
-        $refUnitId = random_int(900000, 999999);
-        $unit = $this->createUnit($refUnitId);
-        $fx = $this->createProductFixture($unit);
-        $this->createStock($fx['variant'], $unit->unit_id, 100);
-        $refShipmentId = 'SHP-'.uniqid();
+        $fixture = $this->createScheduledShipment($headers);
 
-        $this->postJson('/api/external/v1/shipments/scheduled', [
-            'ref_shipment_id' => $refShipmentId,
-            'scheduled_date' => '2026-07-25',
-            'armada_code' => $armada->customer_code,
-            'items' => [
-                ['sku' => $fx['sku'], 'qty' => 24, 'unit_id' => $refUnitId],
-            ],
-        ], $headers)->assertStatus(201);
-
-        $stock = ProductStock::withoutGlobalScope('active_warehouse')
-            ->where('product_variant_id', $fx['variant']->product_variant_id)
-            ->where('warehouse_id', self::MAIN_WAREHOUSE_ID)->first();
-        $stockBefore = $stock->ps_stock;
-
-        $this->patchJson(
-            '/api/external/v1/shipments/'.$refShipmentId.'/change-status',
+        // Dijadwalkan -> Berjalan is not the one allowed transition.
+        $response = $this->patchJson(
+            '/api/external/v1/shipments/'.$fixture['ref'].'/change-status',
             ['status' => 'Berjalan'],
             $headers,
-        )->assertStatus(200);
+        );
 
-        // changeStatus() force-writes the status column only — no SalesOrderApproval::confirm()
-        // call, so the stock row must be untouched (this is the documented, needs-confirmation
-        // gap, not a bug — see the controller/doc-class docblocks).
-        $this->assertSame($stockBefore, $stock->fresh()->ps_stock);
+        $response->assertStatus(409)->assertJson([
+            'success' => false,
+            'error' => ['code' => 'INVALID_STATUS_TRANSITION'],
+        ]);
+        $this->assertSame(4, SalesOrder::where('ref_shipment_id', $fixture['ref'])->value('status'));
     }
 
-    public function test_change_status_has_no_transition_guard_any_status_to_any_label(): void
+    public function test_change_status_rejects_repeating_sudah_terkirim_once_already_there(): void
     {
         $headers = $this->externalApiHeaders();
-        $refShipmentId = $this->createScheduledShipment($headers);
+        $fixture = $this->createScheduledShipment($headers);
 
-        // Dijadwalkan (4) -> Sudah terkirim (6), skipping Berjalan/Belum terkirim entirely.
-        $this->patchJson(
-            '/api/external/v1/shipments/'.$refShipmentId.'/change-status',
+        $this->patchJson('/api/external/v1/shipments/'.$fixture['ref'].'/change-status', ['status' => 'Sudah terkirim'], $headers)
+            ->assertStatus(200);
+
+        $stock = ProductStock::withoutGlobalScope('active_warehouse')
+            ->where('product_variant_id', $fixture['variant']->product_variant_id)
+            ->where('warehouse_id', self::MAIN_WAREHOUSE_ID)->first();
+        $stockAfterFirstCall = $stock->fresh()->ps_stock;
+
+        // Sending "Sudah terkirim" again once already there is not the allowed transition either
+        // (Sudah Terkirim -> Sudah Terkirim isn't in ALLOWED_TRANSITIONS) — must not deduct twice.
+        $response = $this->patchJson(
+            '/api/external/v1/shipments/'.$fixture['ref'].'/change-status',
             ['status' => 'Sudah terkirim'],
             $headers,
-        )->assertStatus(200)->assertJson(['data' => ['status' => 'Sudah terkirim']]);
+        );
 
-        // ...then straight back to Dijadwalkan, going "backwards".
-        $this->patchJson(
-            '/api/external/v1/shipments/'.$refShipmentId.'/change-status',
-            ['status' => 'Dijadwalkan'],
-            $headers,
-        )->assertStatus(200)->assertJson(['data' => ['status' => 'Dijadwalkan']]);
-
-        $this->assertSame(4, SalesOrder::where('ref_shipment_id', $refShipmentId)->value('status'));
+        $response->assertStatus(409)->assertJson(['success' => false, 'error' => ['code' => 'INVALID_STATUS_TRANSITION']]);
+        $this->assertSame($stockAfterFirstCall, $stock->fresh()->ps_stock);
     }
 
-    #[DataProvider('labelToInternalStatusProvider')]
-    public function test_get_shipment_reflects_the_changed_status_afterwards(string $label): void
+    public function test_change_status_insufficient_stock_leaves_shipment_scheduled(): void
     {
         $headers = $this->externalApiHeaders();
-        $refShipmentId = $this->createScheduledShipment($headers);
+        $fixture = $this->createScheduledShipment($headers, 5); // less than the 24 requested
 
-        $this->patchJson(
-            '/api/external/v1/shipments/'.$refShipmentId.'/change-status',
-            ['status' => $label],
+        $response = $this->patchJson(
+            '/api/external/v1/shipments/'.$fixture['ref'].'/change-status',
+            ['status' => 'Sudah terkirim'],
             $headers,
-        )->assertStatus(200);
+        );
 
-        $response = $this->getJson('/api/external/v1/shipments/'.$refShipmentId, $headers);
+        $response->assertStatus(409)->assertJson(['success' => false, 'error' => ['code' => 'INSUFFICIENT_STOCK']]);
+        $this->assertSame(4, SalesOrder::where('ref_shipment_id', $fixture['ref'])->value('status'));
+    }
+
+    public function test_get_shipment_reflects_sudah_terkirim_after_change_status(): void
+    {
+        $headers = $this->externalApiHeaders();
+        $fixture = $this->createScheduledShipment($headers);
+
+        $this->patchJson('/api/external/v1/shipments/'.$fixture['ref'].'/change-status', ['status' => 'Sudah terkirim'], $headers)
+            ->assertStatus(200);
+
+        $response = $this->getJson('/api/external/v1/shipments/'.$fixture['ref'], $headers);
 
         $response->assertStatus(200)->assertJson([
             'success' => true,
-            'data' => ['ref_shipment_id' => $refShipmentId, 'ipm_status_label' => $label],
+            'data' => ['ref_shipment_id' => $fixture['ref'], 'ipm_status' => 4, 'ipm_status_label' => 'Sudah terkirim'],
         ]);
     }
 }


### PR DESCRIPTION
## Ringkasan

Tindak lanjut PR #49: pemilik produk menjawab 4 pertanyaan terbuka yang dicatat di `KNOWN_ISSUES.md` soal `PATCH /shipments/{ref}/change-status` dan `PUT /shipments/{ref}/cancel`. PR ini mengimplementasikan jawaban-jawaban itu.

### Jawaban pemilik produk & implementasinya

1. **Aturan transisi**: untuk saat ini, HANYA SATU transisi yang diizinkan — "Dijadwalkan" ke "Sudah terkirim". Kombinasi lain (label lain, status saat ini bukan "Dijadwalkan", mengulang transisi yang sama, atau mundur) ditolak galat baru `INVALID_STATUS_TRANSITION` (409) — beda dari `INVALID_STATUS` yang berarti labelnya sendiri tidak dikenali.
2. **Potong stok?** Transisi yang diizinkan itu MEMOTONG STOK sungguhan — proses yang sama dengan `POST /shipments/shipped`. `SalesOrderApproval::confirm()` sekarang menerima parameter `$targetStatus` opsional (bawaan `2`, tidak mengubah perilaku `accSO()`/`shipped()` yang sudah ada) supaya `change-status` bisa mendarat di status `6` ("Sudah Terkirim").
3. **Efek samping "Sudah terkirim"?** Dikonfirmasi tidak perlu — tidak ada perubahan lain.
4. **Aturan cancel**: dari "Sudah terkirim" → stok dikembalikan; dari "Dijadwalkan" → hanya status yang berubah. `SalesOrderCancellation::STOCK_DEDUCTED_STATUSES` sekarang mencakup status `6` juga (sebelumnya cuma `2`) — masuk akal sekarang karena status `6` memang berarti stok sudah dipotong sungguhan (poin 2 di atas).

### Catatan proses

Ditemukan kontradiksi nyata antara jawaban poin 2 dan 4 sebelum implementasi dimulai: kalau transisi "Sudah terkirim" tidak memotong stok (jawaban awal poin 2), maka aturan cancel poin 4 (kembalikan stok dari "Sudah terkirim") tidak mungkin benar — tidak ada yang bisa dikembalikan. Pertanyaan klarifikasi diajukan sebelum menulis kode; jawabannya: transisi itu MEMANG memotong stok. Seluruh riwayat tanya-jawab dicatat di `KNOWN_ISSUES.md` untuk jejak audit.

## Pengujian

- Suite `change-status` ditulis ulang (9 test): transisi yang diizinkan memotong stok dan tidak bisa diulang; semua transisi lain ditolak; stok tidak cukup meninggalkan status apa adanya.
- Suite `cancel` bertambah 1 test: pembatalan dari "Sudah terkirim" mengembalikan stok penuh.
- Regresi penuh `ExternalApi` + `SalesOrder`: 92 test, hanya 1 kegagalan yang sudah diketahui sebelumnya dan tidak terkait (`SalesOrderDeliveryFlowTest`, modul deprecated).
- Smoke test registry dokumentasi: 33 kelas ter-render tanpa galat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)