### PR TITLE
fix: Stock Opname PDF highlight + live system-stock, dashboard Changelog traceability (#53)

### DIFF
--- a/app/Http/Controllers/ReportController.php
+++ b/app/Http/Controllers/ReportController.php
@@ -2399,7 +2399,11 @@ class ReportController extends Controller
             ->where('status', 1)
             ->whereRaw('DATE(COALESCE(pi_date, created_at)) BETWEEN ? AND ?', [$s, $e])
             ->count();
+        // GitHub #53: dashboard_change_logs sekarang juga menyimpan baris activity_type='open'
+        // ("staf membuka menu X", lihat LogDashboardActivity) -- itu bukan sesuatu yang
+        // "menunggu ACC Direktur", jadi tidak ikut dihitung di KPI ini.
         $changelogPending += (int) DB::table('dashboard_change_logs')
+            ->where('activity_type', 'change')
             ->whereRaw('DATE(created_at) BETWEEN ? AND ?', [$s, $e])
             ->count();
 
@@ -2471,6 +2475,31 @@ class ReportController extends Controller
             return 'INV '.$so;
         };
 
+        // GitHub #53: format durasi pasif dari LogDashboardActivity::logOpen() jadi teks ringkas.
+        $fmtDuration = static function ($seconds) {
+            $seconds = (int) $seconds;
+            if ($seconds < 60) {
+                return $seconds.' detik';
+            }
+            $minutes = intdiv($seconds, 60);
+            if ($minutes < 60) {
+                return $minutes.' menit';
+            }
+            $hours = intdiv($minutes, 60);
+            $restMinutes = $minutes % 60;
+            return $restMinutes > 0 ? ($hours.' jam '.$restMinutes.' menit') : ($hours.' jam');
+        };
+        $fmtOpenedAt = static function ($createdAt) {
+            if (!$createdAt) {
+                return '-';
+            }
+            try {
+                return \Carbon\Carbon::parse($createdAt)->format('d M Y H:i');
+            } catch (\Throwable $e) {
+                return (string) $createdAt;
+            }
+        };
+
         $changelog = [];
 
         $piRows = DB::table('product_issues as pi')
@@ -2478,7 +2507,36 @@ class ReportController extends Controller
             ->whereRaw('DATE(COALESCE(pi.pi_date, pi.created_at)) BETWEEN ? AND ?', [$s, $e])
             ->orderByDesc('pi.created_at')
             ->limit($limit)
-            ->get(['pi.pi_id', 'pi.pi_code', 'pi.pi_type', 'pi.tipe_return', 'pi.pi_notes', 'pi.pi_date']);
+            ->get(['pi.pi_id', 'pi.pi_code', 'pi.pi_type', 'pi.tipe_return', 'pi.pi_notes', 'pi.pi_date', 'pi.created_at', 'pi.created_by']);
+
+        $masterChangeRows = DB::table('dashboard_change_logs as dcl')
+            ->whereRaw('DATE(dcl.created_at) BETWEEN ? AND ?', [$s, $e])
+            ->orderByDesc('dcl.created_at')
+            ->limit($limit)
+            ->get([
+                'dcl.id',
+                'dcl.module_key',
+                'dcl.activity_type',
+                'dcl.module_label',
+                'dcl.reference',
+                'dcl.what_changed',
+                'dcl.summary',
+                'dcl.url',
+                'dcl.url_label',
+                'dcl.created_at',
+                'dcl.created_by',
+                'dcl.duration_seconds',
+            ]);
+
+        // Satu query untuk semua nama staf (retur + changelog), hindari N+1.
+        $staffIds = $piRows->pluck('created_by')
+            ->concat($masterChangeRows->pluck('created_by'))
+            ->filter()
+            ->unique()
+            ->values();
+        $staffNames = $staffIds->isEmpty()
+            ? collect()
+            : DB::table('staffs')->whereIn('staff_id', $staffIds)->pluck('staff_name', 'staff_id');
 
         foreach ($piRows as $pi) {
             $tipe = (int) ($pi->tipe_return ?? 0);
@@ -2493,28 +2551,23 @@ class ReportController extends Controller
                 'summary' => trim($tipeLabel.(($pi->pi_notes ?? '') !== '' ? ' — '.(string) $pi->pi_notes : '')),
                 'url' => url('productIssue').'?pi_id='.(int) $pi->pi_id,
                 'url_label' => 'Buka baris ini',
+                'staff_name' => $staffNames[$pi->created_by ?? 0] ?? '-',
+                'opened_at' => $fmtOpenedAt($pi->created_at ?? $pi->pi_date),
+                'duration_label' => '-',
             ];
         }
 
-        $masterChangeRows = DB::table('dashboard_change_logs as dcl')
-            ->whereRaw('DATE(dcl.created_at) BETWEEN ? AND ?', [$s, $e])
-            ->orderByDesc('dcl.created_at')
-            ->limit($limit)
-            ->get([
-                'dcl.id',
-                'dcl.module_key',
-                'dcl.module_label',
-                'dcl.reference',
-                'dcl.what_changed',
-                'dcl.summary',
-                'dcl.url',
-                'dcl.url_label',
-                'dcl.created_at',
-            ]);
         foreach ($masterChangeRows as $log) {
             $safeUrl = $this->normalizeDashboardLogUrl((string) ($log->url ?? ''));
             if ($safeUrl === url('admin')) {
                 $safeUrl = $this->fallbackDashboardLogUrlByModule((string) ($log->module_key ?? ''));
+            }
+            $isOpen = ($log->activity_type ?? 'change') === 'open';
+            $durationLabel = '-';
+            if ($isOpen) {
+                $durationLabel = $log->duration_seconds !== null
+                    ? $fmtDuration($log->duration_seconds)
+                    : 'Sedang dibuka';
             }
             $changelog[] = [
                 'kind' => (string) ($log->module_key ?? 'master_change'),
@@ -2526,6 +2579,9 @@ class ReportController extends Controller
                 'summary' => (string) ($log->summary ?? ''),
                 'url' => $safeUrl,
                 'url_label' => (string) ($log->url_label ?? 'Buka'),
+                'staff_name' => $staffNames[$log->created_by ?? 0] ?? '-',
+                'opened_at' => $fmtOpenedAt($log->created_at),
+                'duration_label' => $durationLabel,
             ];
         }
 

--- a/app/Http/Controllers/StockController.php
+++ b/app/Http/Controllers/StockController.php
@@ -27,6 +27,7 @@ use App\Models\Supplier;
 use App\Models\Supplies;
 use App\Models\SuppliesStock;
 use App\Models\SuppliesVariant;
+use App\Models\Unit;
 use Barryvdh\DomPDF\Facade\Pdf;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
@@ -173,6 +174,52 @@ class StockController extends Controller
         return 0;
     }
 
+    // Kebalikan dari getQty() -- rakit ['DOS' => 10, 'pcs' => 2] jadi "10 DOS, 2 pcs".
+    private function buildQtyString(array $qtyByUnit): string
+    {
+        $parts = [];
+        foreach ($qtyByUnit as $unit => $qty) {
+            $parts[] = $qty . ' ' . $unit;
+        }
+        return implode(', ', $parts);
+    }
+
+    /**
+     * stod_system/stod_selisih (stobd_* untuk Bahan) dibekukan sekali saat dokumen dibuat/diedit
+     * dan tidak pernah di-refresh -- begitu ada peristiwa stok LAIN APAPUN sebelum dokumen ini
+     * diputuskan (stock opname lain di-ACC, SO dikirim, dst.), PDF-nya diam-diam membandingkan
+     * dengan angka sistem yang sudah basi. getDetail()/getDetailBulk() sudah menempelkan koleksi
+     * stok LIVE per unit (`->stock`, lihat ProductVariant::getProductVariantBulk()/
+     * Supplies::getSuppliesBulk()) -- pakai itu, bukan string yang tersimpan, TAPI HANYA untuk
+     * dokumen yang belum diputuskan (status masih 1/menunggu). Snapshot dokumen yang sudah
+     * disetujui/ditolak adalah catatan historis yang sengaja dibekukan (lihat accStockOpname() --
+     * dibekukan ke nilai sebenarnya saat itu terjadi) dan TIDAK BOLEH dihitung ulang live, atau
+     * dokumen yang sudah disetujui akan selalu terlihat "tidak ada selisih" selamanya setelahnya.
+     */
+    private function refreshLiveSystemQty($detail, string $realKey, string $systemKey, string $selisihKey, string $stockQtyKey)
+    {
+        foreach ($detail as $item) {
+            $liveByUnit = [];
+            foreach ($item->stock ?? [] as $s) {
+                $liveByUnit[$s->unit_short_name] = (int) $s->{$stockQtyKey};
+            }
+            if (empty($liveByUnit)) {
+                continue;
+            }
+
+            $selisihByUnit = [];
+            foreach ($liveByUnit as $unitName => $systemQty) {
+                $realQty = $this->getQty($item->{$realKey} ?? '', $unitName);
+                $selisihByUnit[$unitName] = $realQty - $systemQty;
+            }
+
+            $item->{$systemKey} = $this->buildQtyString($liveByUnit);
+            $item->{$selisihKey} = $this->buildQtyString($selisihByUnit);
+        }
+
+        return $detail;
+    }
+
     function getDetailStockOpname(Request $req)
     {
         $data = StockOpnameDetail::getDetail($req->all());
@@ -228,10 +275,30 @@ class StockController extends Controller
             ]);
         }
 
+        // GitHub #53 follow-up: bekukan stod_system/stod_selisih ke nilai SEBENARNYA yang dipakai
+        // approval ini (bukan lagi nilai basi dari saat dokumen dibuat/diedit) -- ini jadi catatan
+        // historis permanen dokumen, mirror persis "before" yang sudah ditulis ke log_stocks di
+        // bawah, cuma sekarang juga disimpan balik ke stock_opname_details.
+        $detailRows = StockOpnameDetail::where('sto_id', $sto->sto_id)
+            ->where('status', 1)
+            ->get()
+            ->keyBy('product_variant_id');
+        $allUnitIds = collect($stod)
+            ->flatMap(fn ($v) => collect($v['units'] ?? [])->pluck('unit_id'))
+            ->filter()
+            ->unique()
+            ->values()
+            ->all();
+        $unitNames = $allUnitIds !== []
+            ? Unit::whereIn('unit_id', $allUnitIds)->pluck('unit_short_name', 'unit_id')
+            : collect();
+
         DB::beginTransaction();
         try {
         $produk_gagal = [];
         foreach ($stod as $key => $value) {
+            $liveSystemByUnit = [];
+            $realByUnit = [];
             foreach ($value['units'] as $u) {
                 $s = ProductStock::where('product_variant_id', $value['product_variant_id'])
                     ->where('unit_id', $u['unit_id'])
@@ -252,6 +319,8 @@ class StockController extends Controller
                     continue;
                 }
 
+                $beforeStock = $s->ps_stock;
+
                 // Catat log
                 (new LogStock())->insertLog([
                     'log_date' => now(),
@@ -260,7 +329,7 @@ class StockController extends Controller
                     'log_category' => 2,
                     'log_item_id' => $value['product_variant_id'],
                     'log_notes'  => "Stock Opname Produk",
-                    'log_jumlah' => $s->ps_stock,
+                    'log_jumlah' => $beforeStock,
                     'unit_id'    => $u['unit_id'],
                 ]);
 
@@ -278,6 +347,21 @@ class StockController extends Controller
                     'log_jumlah' => $s->ps_stock,
                     'unit_id'    => $u['unit_id'],
                 ]);
+
+                $unitName = $unitNames[$u['unit_id']] ?? ('unit#'.$u['unit_id']);
+                $liveSystemByUnit[$unitName] = (int) $beforeStock;
+                $realByUnit[$unitName] = (int) $u['real_qty'];
+            }
+
+            $detailRow = $detailRows->get($value['product_variant_id']);
+            if ($detailRow && !empty($liveSystemByUnit)) {
+                $selisihByUnit = [];
+                foreach ($liveSystemByUnit as $unitName => $systemQty) {
+                    $selisihByUnit[$unitName] = ($realByUnit[$unitName] ?? 0) - $systemQty;
+                }
+                $detailRow->stod_system = $this->buildQtyString($liveSystemByUnit);
+                $detailRow->stod_selisih = $this->buildQtyString($selisihByUnit);
+                $detailRow->save();
             }
         }
 
@@ -314,6 +398,10 @@ class StockController extends Controller
         $param['stockOpname'] = StockOpname::find($id);
         $param['staff_name'] = Staff::find($param['stockOpname']['staff_id']);
         $param["detail"] = (new StockOpnameDetail())->getDetail(['sto_id' => $id]);
+
+        if ((int) $param['stockOpname']['status'] === 1) {
+            $this->refreshLiveSystemQty($param['detail'], 'stod_real', 'stod_system', 'stod_selisih', 'ps_stock');
+        }
 
         if ($param['stockOpname']['status'] == 1) $param['status'] = "Menunggu";
         else if ($param['stockOpname']['status'] == 2) $param['status'] = "Disetujui";
@@ -450,10 +538,28 @@ class StockController extends Controller
             ]);
         }
 
+        // GitHub #53 follow-up: mirrors accStockOpname() above -- bekukan stobd_system/
+        // stobd_selisih ke nilai sebenarnya yang dipakai approval ini.
+        $detailRows = StockOpnameDetailBahan::where('stob_id', $stob->stob_id)
+            ->where('status', 1)
+            ->get()
+            ->keyBy('supplies_id');
+        $allUnitIds = collect($stod)
+            ->flatMap(fn ($v) => collect($v['sp_units'] ?? [])->pluck('unit_id'))
+            ->filter()
+            ->unique()
+            ->values()
+            ->all();
+        $unitNames = $allUnitIds !== []
+            ? Unit::whereIn('unit_id', $allUnitIds)->pluck('unit_short_name', 'unit_id')
+            : collect();
+
         DB::beginTransaction();
         try {
         $bahan_gagal = [];
         foreach ($stod as $key => $value) {
+            $liveSystemByUnit = [];
+            $realByUnit = [];
             foreach ($value['sp_units'] as $u) {
                 $s = SuppliesStock::where('supplies_id', $value['supplies_id'])
                     ->where('unit_id', $u['unit_id'])
@@ -467,6 +573,8 @@ class StockController extends Controller
                     continue;
                 }
 
+                $beforeStock = $s->ss_stock;
+
                 // Catat log
                 (new LogStock())->insertLog([
                     'log_date' => now(),
@@ -475,7 +583,7 @@ class StockController extends Controller
                     'log_category' => 2,
                     'log_item_id' => $value['supplies_id'],
                     'log_notes'  => "Stock Opname Bahan Mentah",
-                    'log_jumlah' => $s->ss_stock,
+                    'log_jumlah' => $beforeStock,
                     'unit_id'    => $u['unit_id'],
                 ]);
 
@@ -493,6 +601,21 @@ class StockController extends Controller
                     'log_jumlah' => $s->ss_stock,
                     'unit_id'    => $u['unit_id'],
                 ]);
+
+                $unitName = $unitNames[$u['unit_id']] ?? ('unit#'.$u['unit_id']);
+                $liveSystemByUnit[$unitName] = (int) $beforeStock;
+                $realByUnit[$unitName] = (int) $u['real_qty'];
+            }
+
+            $detailRow = $detailRows->get($value['supplies_id']);
+            if ($detailRow && !empty($liveSystemByUnit)) {
+                $selisihByUnit = [];
+                foreach ($liveSystemByUnit as $unitName => $systemQty) {
+                    $selisihByUnit[$unitName] = ($realByUnit[$unitName] ?? 0) - $systemQty;
+                }
+                $detailRow->stobd_system = $this->buildQtyString($liveSystemByUnit);
+                $detailRow->stobd_selisih = $this->buildQtyString($selisihByUnit);
+                $detailRow->save();
             }
         }
 
@@ -529,6 +652,10 @@ class StockController extends Controller
         $param['stockOpname'] = StockOpnameBahan::find($id);
         $param['staff_name'] = Staff::find($param['stockOpname']['staff_id']);
         $param["detail"] = (new StockOpnameDetailBahan())->getDetail(['stob_id' => $id]);
+
+        if ((int) $param['stockOpname']['status'] === 1) {
+            $this->refreshLiveSystemQty($param['detail'], 'stobd_real', 'stobd_system', 'stobd_selisih', 'ss_stock');
+        }
 
         if ($param['stockOpname']['status'] == 1) $param['status'] = "Menunggu";
         else if ($param['stockOpname']['status'] == 2) $param['status'] = "Disetujui";

--- a/app/Http/Middleware/LogDashboardActivity.php
+++ b/app/Http/Middleware/LogDashboardActivity.php
@@ -5,7 +5,9 @@ namespace App\Http\Middleware;
 use App\Models\DashboardChangeLog;
 use Closure;
 use Illuminate\Http\Request;
+use Illuminate\Http\Response as HttpResponse;
 use Illuminate\Support\Str;
+use Illuminate\View\View;
 use Symfony\Component\HttpFoundation\Response;
 
 class LogDashboardActivity
@@ -14,13 +16,24 @@ class LogDashboardActivity
     {
         $response = $next($request);
 
-        if (!$this->shouldLog($request, $response)) {
-            return $response;
+        if ($this->shouldLogChange($request, $response)) {
+            $this->logChange($request);
+        } elseif ($this->shouldLogOpen($request, $response)) {
+            // GitHub #53: "jam dia buka modul atau menu apapun" — traceability tambahan di
+            // samping log mutasi di atas. Baris 'open' dicatat dengan activity_type terpisah
+            // supaya ReportController::dashboardChangeLogCounts() (KPI "Changelog" = antrean
+            // butuh ACC Direktur) tidak ikut menghitung page-view biasa sebagai item pending.
+            $this->logOpen($request);
         }
 
+        return $response;
+    }
+
+    private function logChange(Request $request): void
+    {
         $action = $this->detectAction($request);
         if ($action === null) {
-            return $response;
+            return;
         }
 
         $moduleKey = $this->detectModuleKey($request);
@@ -30,6 +43,7 @@ class LogDashboardActivity
 
         DashboardChangeLog::create([
             'module_key' => $moduleKey,
+            'activity_type' => 'change',
             'module_label' => $moduleLabel,
             'reference' => $reference,
             'what_changed' => ucfirst($action).' pada '.$moduleLabel,
@@ -43,11 +57,78 @@ class LogDashboardActivity
                 'action' => $action,
             ],
         ]);
-
-        return $response;
     }
 
-    private function shouldLog(Request $request, Response $response): bool
+    /**
+     * Catat "staf X membuka menu Y" + isi durasi baris 'open' sebelumnya milik staf yang sama.
+     * Ini estimasi pasif (jarak waktu ke request berikutnya), bukan sinyal tab-ditutup yang
+     * sesungguhnya — lihat catatan cap 4 jam di bawah.
+     */
+    private function logOpen(Request $request): void
+    {
+        $staffId = (int) (session('user')->staff_id ?? 0);
+        if ($staffId <= 0) {
+            return;
+        }
+
+        $moduleKey = $this->detectModuleKey($request);
+        $moduleLabel = $this->formatModuleLabel($moduleKey);
+        $now = now();
+
+        // Debounce: staf yang sama membuka modul yang sama berkali-kali (klik-klik/refresh)
+        // dalam jendela singkat tidak perlu jadi baris baru tiap kali.
+        $recentlyOpened = DashboardChangeLog::where('created_by', $staffId)
+            ->where('module_key', $moduleKey)
+            ->where('activity_type', 'open')
+            ->where('created_at', '>=', $now->copy()->subMinutes(15))
+            ->exists();
+        if ($recentlyOpened) {
+            return;
+        }
+
+        // Tutup baris 'open' terakhir milik staf ini (modul manapun) yang belum punya durasi —
+        // durasinya = jarak ke pembukaan menu berikutnya ini. Kalau jaraknya lebih dari 4 jam,
+        // anggap tab lama itu cuma ditinggal (idle/browser ditutup tanpa navigasi lagi) dan
+        // jangan diisi durasi yang menyesatkan.
+        $previous = DashboardChangeLog::where('created_by', $staffId)
+            ->where('activity_type', 'open')
+            ->whereNull('duration_seconds')
+            ->orderByDesc('created_at')
+            ->first();
+        if ($previous) {
+            // Explicit $absolute=true + cast to int: Carbon 3's diffInSeconds() defaults to a
+            // signed, sub-second-precision float (negative here since $previous is in the past).
+            $seconds = (int) $now->diffInSeconds($previous->created_at, true);
+            if ($seconds <= 4 * 3600) {
+                $previous->duration_seconds = $seconds;
+                $previous->save();
+            }
+        }
+
+        $staffName = session('user')->staff_name ?? '-';
+
+        DashboardChangeLog::create([
+            'module_key' => $moduleKey,
+            'activity_type' => 'open',
+            'module_label' => $moduleLabel,
+            'reference' => null,
+            'what_changed' => 'Membuka menu '.$moduleLabel,
+            'summary' => $staffName.' membuka '.$moduleLabel,
+            // Beda dari logChange(): request GET ini SENDIRI adalah halaman yang dibuka, jadi
+            // link-nya ke path saat ini -- bukan detectSafeUrl() (referer) yang dipakai untuk
+            // baris mutasi karena POST tidak punya halaman sendiri untuk dituju.
+            'url' => url(trim($request->path(), '/')),
+            'url_label' => 'Buka menu',
+            'created_by' => $staffId,
+            'meta' => [
+                'method' => $request->method(),
+                'path' => $request->path(),
+            ],
+            'duration_seconds' => null,
+        ]);
+    }
+
+    private function shouldLogChange(Request $request, Response $response): bool
     {
         if (!in_array(strtoupper($request->method()), ['POST', 'PUT', 'PATCH', 'DELETE'], true)) {
             return false;
@@ -64,6 +145,34 @@ class LogDashboardActivity
             return false;
         }
         if (in_array($path, ['dismissdashboardqueueitem', 'updatedashboardwidgets', 'updatepermission'], true)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Hanya GET yang benar-benar me-render sebuah halaman (bukan endpoint AJAX/data) yang
+     * dihitung sebagai "buka menu" — dibedakan lewat $response->original instanceof View,
+     * karena response()->json(...)/JsonResponse tidak punya properti itu sama sekali.
+     */
+    private function shouldLogOpen(Request $request, Response $response): bool
+    {
+        if (strtoupper($request->method()) !== 'GET') {
+            return false;
+        }
+        if ($response->getStatusCode() >= 400) {
+            return false;
+        }
+        if (!session()->has('user')) {
+            return false;
+        }
+        if (!($response instanceof HttpResponse) || !(($response->original ?? null) instanceof View)) {
+            return false;
+        }
+
+        $path = strtolower(trim($request->path(), '/'));
+        if (in_array($path, ['', 'up', 'login', 'logout'], true)) {
             return false;
         }
 
@@ -153,4 +262,3 @@ class LogDashboardActivity
         return url('admin');
     }
 }
-

--- a/app/Models/DashboardChangeLog.php
+++ b/app/Models/DashboardChangeLog.php
@@ -10,6 +10,7 @@ class DashboardChangeLog extends Model
 
     protected $fillable = [
         'module_key',
+        'activity_type',
         'module_label',
         'reference',
         'what_changed',
@@ -18,6 +19,7 @@ class DashboardChangeLog extends Model
         'url_label',
         'created_by',
         'meta',
+        'duration_seconds',
     ];
 
     protected $casts = [

--- a/app/Models/StockOpnameDetail.php
+++ b/app/Models/StockOpnameDetail.php
@@ -50,6 +50,7 @@ class StockOpnameDetail extends Model
             $temp->stod_real = $value->stod_real;
             $temp->stod_selisih = $value->stod_selisih;
             $temp->stod_notes = $value->stod_notes;
+            $temp->stod_touched = $value->stod_touched;
             $temp->stod_id = $value->stod_id;
             $temp->sto_id = $value->sto_id;
             $result[$key] = $temp;
@@ -91,6 +92,7 @@ class StockOpnameDetail extends Model
             $temp->stod_real = $value->stod_real;
             $temp->stod_selisih = $value->stod_selisih;
             $temp->stod_notes = $value->stod_notes;
+            $temp->stod_touched = $value->stod_touched;
             $temp->stod_id = $value->stod_id;
             $temp->sto_id = $value->sto_id;
 
@@ -116,6 +118,7 @@ class StockOpnameDetail extends Model
         $t->stod_real = $data['stod_real'] ?? null;
         $t->stod_selisih = $data['stod_selisih'] ?? null;
         $t->stod_notes = $data['stod_notes'] ?? null;
+        $t->stod_touched = !empty($data['stod_touched']);
         $t->save();
 
         return $t->stod_id;
@@ -136,6 +139,7 @@ class StockOpnameDetail extends Model
         $t->stod_real = $data['stod_real'] ?? null;
         $t->stod_selisih = $data['stod_selisih'] ?? null;
         $t->stod_notes = $data['stod_notes'] ?? null;
+        $t->stod_touched = !empty($data['stod_touched']);
         $t->save();
 
         return $t->stod_id;

--- a/app/Models/StockOpnameDetailBahan.php
+++ b/app/Models/StockOpnameDetailBahan.php
@@ -49,6 +49,7 @@ class StockOpnameDetailBahan extends Model
             $temp->stobd_real = $value->stobd_real;
             $temp->stobd_selisih = $value->stobd_selisih;
             $temp->stobd_notes = $value->stobd_notes;
+            $temp->stobd_touched = $value->stobd_touched;
             $temp->stobd_id = $value->stobd_id;
             $temp->stob_id = $value->stob_id;
             $result[$key] = $temp;
@@ -83,6 +84,7 @@ class StockOpnameDetailBahan extends Model
             $temp->stobd_real    = $value->stobd_real;
             $temp->stobd_selisih = $value->stobd_selisih;
             $temp->stobd_notes   = $value->stobd_notes;
+            $temp->stobd_touched = $value->stobd_touched;
             $temp->stobd_id      = $value->stobd_id;
             $temp->stob_id       = $value->stob_id;
 
@@ -107,6 +109,7 @@ class StockOpnameDetailBahan extends Model
         $t->stobd_real = $data['stobd_real'] ?? null;
         $t->stobd_selisih = $data['stobd_selisih'] ?? null;
         $t->stobd_notes = $data['stobd_notes'] ?? null;
+        $t->stobd_touched = !empty($data['stobd_touched']);
         $t->save();
 
         return $t->stobd_id;
@@ -126,6 +129,7 @@ class StockOpnameDetailBahan extends Model
         $t->stobd_real = $data['stobd_real'] ?? null;
         $t->stobd_selisih = $data['stobd_selisih'] ?? null;
         $t->stobd_notes = $data['stobd_notes'] ?? null;
+        $t->stobd_touched = !empty($data['stobd_touched']);
         $t->save();
 
         return $t->stobd_id;

--- a/database/migrations/2026_08_14_010000_add_touched_to_stock_opname_details_tables.php
+++ b/database/migrations/2026_08_14_010000_add_touched_to_stock_opname_details_tables.php
@@ -1,0 +1,47 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * GitHub #53: PDF Stock Opname perlu membedakan baris yang benar-benar diisi staf (real-stock
+ * di-input manual) dari baris yang cuma ikut tersimpan dengan real qty auto = stok sistem karena
+ * dibiarkan kosong (lihat CreateStockOpname.js/CreateStockOpnameSupplies.js insertData()) --
+ * tanpa kolom ini keduanya sama-sama terlihat "cocok, tidak ada selisih" di PDF.
+ *
+ * Kolom ini murni tampilan/PDF -- accStockOpname(Bahan) tidak membaca stock_opname_details sama
+ * sekali (lihat cdocs/docs/flows/stock-opname/FLOW.md), jadi tidak menyentuh logika approval/stok.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasColumn('stock_opname_details', 'stod_touched')) {
+            Schema::table('stock_opname_details', function (Blueprint $table) {
+                $table->boolean('stod_touched')->default(false)->after('stod_notes');
+            });
+        }
+
+        if (! Schema::hasColumn('stock_opname_detail_bahans', 'stobd_touched')) {
+            Schema::table('stock_opname_detail_bahans', function (Blueprint $table) {
+                $table->boolean('stobd_touched')->default(false)->after('stobd_notes');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        if (Schema::hasColumn('stock_opname_details', 'stod_touched')) {
+            Schema::table('stock_opname_details', function (Blueprint $table) {
+                $table->dropColumn('stod_touched');
+            });
+        }
+
+        if (Schema::hasColumn('stock_opname_detail_bahans', 'stobd_touched')) {
+            Schema::table('stock_opname_detail_bahans', function (Blueprint $table) {
+                $table->dropColumn('stobd_touched');
+            });
+        }
+    }
+};

--- a/database/migrations/2026_08_14_010100_add_activity_tracking_to_dashboard_change_logs_table.php
+++ b/database/migrations/2026_08_14_010100_add_activity_tracking_to_dashboard_change_logs_table.php
@@ -1,0 +1,47 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * GitHub #53: dashboard Changelog perlu mencatat kapan staf membuka sebuah menu dan berapa lama,
+ * bukan cuma mutasi data (lihat LogDashboardActivity). `activity_type` membedakan baris "open"
+ * (menu dibuka) dari baris "change" (mutasi data, perilaku lama) SUPAYA
+ * ReportController::dashboardChangeLogCounts() -- yang menghitung SEMUA baris dashboard_change_logs
+ * di periode sebagai "menunggu ACC Direktur" -- tidak ikut menghitung page-view biasa.
+ * `duration_seconds` diisi belakangan (saat request berikutnya dari staf yang sama terdeteksi),
+ * jadi harus nullable.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasColumn('dashboard_change_logs', 'activity_type')) {
+            Schema::table('dashboard_change_logs', function (Blueprint $table) {
+                $table->string('activity_type', 20)->default('change')->after('module_key');
+            });
+        }
+
+        if (! Schema::hasColumn('dashboard_change_logs', 'duration_seconds')) {
+            Schema::table('dashboard_change_logs', function (Blueprint $table) {
+                $table->unsignedInteger('duration_seconds')->nullable()->after('meta');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        if (Schema::hasColumn('dashboard_change_logs', 'duration_seconds')) {
+            Schema::table('dashboard_change_logs', function (Blueprint $table) {
+                $table->dropColumn('duration_seconds');
+            });
+        }
+
+        if (Schema::hasColumn('dashboard_change_logs', 'activity_type')) {
+            Schema::table('dashboard_change_logs', function (Blueprint $table) {
+                $table->dropColumn('activity_type');
+            });
+        }
+    }
+};

--- a/public/Custom_js/Backoffice/Dashboard/Dashboard-Admin.js
+++ b/public/Custom_js/Backoffice/Dashboard/Dashboard-Admin.js
@@ -203,10 +203,16 @@
     function renderApprovalTable(tbodySelector, rows, emptyMsg) {
         var $tb = $(tbodySelector);
         if (!$tb.length) return;
+        // GitHub #53: hanya panel Changelog yang dapat kolom User + Jam/Durasi -- Confirmation
+        // dan Revision tetap 4 kolom seperti sebelumnya.
+        var isChangelog = tbodySelector === "#dash_changelog_body";
+        var colspan = isChangelog ? 6 : 4;
         $tb.empty();
         if (!rows || !rows.length) {
             $tb.append(
-                '<tr><td colspan="4" class="text-center text-muted">' +
+                '<tr><td colspan="' +
+                    colspan +
+                    '" class="text-center text-muted">' +
                     escHtml(emptyMsg) +
                     "</td></tr>"
             );
@@ -222,6 +228,16 @@
                       ? "revision"
                       : "changelog";
             var queueKey = String(r.queue_key || "");
+            var extraCols = isChangelog
+                ? "<td>" +
+                  escHtml(r.staff_name || "-") +
+                  "</td><td>" +
+                  escHtml(r.opened_at || "-") +
+                  (r.duration_label
+                      ? " · " + escHtml(r.duration_label)
+                      : "") +
+                  "</td>"
+                : "";
             $tb.append(
                 "<tr><td>" +
                     escHtml(r.module_label || "-") +
@@ -231,7 +247,9 @@
                     escHtml(r.what_changed || r.summary || "") +
                     '">' +
                     escHtml(r.what_changed || r.summary || "-") +
-                    '</span></td><td class="dash-col-actions">' +
+                    "</span></td>" +
+                    extraCols +
+                    '<td class="dash-col-actions">' +
                     '<div class="d-inline-flex gap-1 align-items-center">' +
                     '<a class="btn btn-sm dash-log-btn px-2" title="Buka" href="' +
                     url.replace(/"/g, "&quot;") +

--- a/public/Custom_js/Backoffice/Inventory/CreateStockOpname.js
+++ b/public/Custom_js/Backoffice/Inventory/CreateStockOpname.js
@@ -537,6 +537,10 @@ function insertData(options) {
         item.stod_system = systemArr.join(", ");
         item.stod_real = realArr.join(", ");
         item.stod_selisih = selisihArr.join(", ");
+        // GitHub #53: baris ini pernah benar-benar diisi user, dibedakan dari yang cuma
+        // ikut tersimpan dengan real qty auto = stok sistem karena dibiarkan kosong --
+        // dipakai PDF (Backoffice/PDF/Opname.blade.php) untuk highlight.
+        item.stod_touched = hasValue ? 1 : 0;
 
         productSubmit.push(item);
     });

--- a/public/Custom_js/Backoffice/Inventory/CreateStockOpnameSupplies.js
+++ b/public/Custom_js/Backoffice/Inventory/CreateStockOpnameSupplies.js
@@ -600,6 +600,10 @@ function insertData(options) {
         item.stobd_system = systemArr.join(", ");
         item.stobd_real = realArr.join(", ");
         item.stobd_selisih = selisihArr.join(", ");
+        // GitHub #53: baris ini pernah benar-benar diisi user, dibedakan dari yang cuma
+        // ikut tersimpan dengan real qty auto = stok sistem karena dibiarkan kosong --
+        // dipakai PDF (Backoffice/PDF/OpnameBahan.blade.php) untuk highlight.
+        item.stobd_touched = hasValue ? 1 : 0;
 
         suppliesSubmit.push(item);
     });

--- a/resources/views/Backoffice/Dashboard/partials/home-dashboard-widgets.blade.php
+++ b/resources/views/Backoffice/Dashboard/partials/home-dashboard-widgets.blade.php
@@ -687,11 +687,13 @@
                                 <th class="text-nowrap">Modul</th>
                                 <th class="text-nowrap">Ref</th>
                                 <th>Perubahan / status</th>
+                                <th class="text-nowrap">User</th>
+                                <th class="text-nowrap">Jam / Durasi</th>
                                 <th class="text-end text-nowrap">Aksi</th>
                             </tr>
                         </thead>
                         <tbody id="dash_changelog_body">
-                            <tr><td colspan="4" class="text-center text-muted">Memuat…</td></tr>
+                            <tr><td colspan="6" class="text-center text-muted">Memuat…</td></tr>
                         </tbody>
                     </table>
                     </div>

--- a/resources/views/Backoffice/PDF/Opname.blade.php
+++ b/resources/views/Backoffice/PDF/Opname.blade.php
@@ -122,7 +122,13 @@
                                 }
                             }
                         }
-                        $highlight = $hasSelisih ? 'background-color: #FFF9C4;' : '';
+                        // GitHub #53: kuning kalau diisi dan ada selisih, hijau kalau diisi dan
+                        // stok real cocok dengan sistem, tanpa highlight kalau memang tidak
+                        // pernah diisi stok real-nya (bukan sekadar default = stok sistem).
+                        $highlight = '';
+                        if (!empty($item['stod_touched'])) {
+                            $highlight = $hasSelisih ? 'background-color: #FFF9C4;' : 'background-color: #C8E6C9;';
+                        }
                     @endphp
                     <tr>
                         <td>{{ empty($item['product_variant_sku']) ? '-' : $item['product_variant_sku'] }}</td>

--- a/resources/views/Backoffice/PDF/OpnameBahan.blade.php
+++ b/resources/views/Backoffice/PDF/OpnameBahan.blade.php
@@ -120,7 +120,13 @@
                                 }
                             }
                         }
-                        $highlight = $hasSelisih ? 'background-color: #FFF9C4;' : '';
+                        // GitHub #53: kuning kalau diisi dan ada selisih, hijau kalau diisi dan
+                        // stok real cocok dengan sistem, tanpa highlight kalau memang tidak
+                        // pernah diisi stok real-nya (bukan sekadar default = stok sistem).
+                        $highlight = '';
+                        if (!empty($item['stobd_touched'])) {
+                            $highlight = $hasSelisih ? 'background-color: #FFF9C4;' : 'background-color: #C8E6C9;';
+                        }
                     @endphp
                     <tr>
                         <td>{{ $item['supplies_name'] ?? '-' }}</td>

--- a/tests/Workflow/DashboardChangelogMenuOpenTrackingTest.php
+++ b/tests/Workflow/DashboardChangelogMenuOpenTrackingTest.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace Tests\Workflow;
+
+use App\Models\DashboardChangeLog;
+use Tests\Support\ActingAsStaff;
+use Tests\TestCase;
+
+/**
+ * GitHub #53: "jam dia buka modul atau menu apapun" — App\Http\Middleware\LogDashboardActivity
+ * now also logs activity_type='open' rows for real page views (GET requests that render a Blade
+ * view), separate from the pre-existing activity_type='change' rows for POST/PUT/PATCH/DELETE
+ * mutations. Duration is a passive estimate: the gap between one 'open' row and that same staff's
+ * next tracked request, filled in retroactively — see LogDashboardActivity::logOpen().
+ */
+class DashboardChangelogMenuOpenTrackingTest extends TestCase
+{
+    use ActingAsStaff;
+
+    public function test_opening_a_page_logs_an_open_row_with_staff_and_null_duration(): void
+    {
+        $staff = $this->actingAsSuperAdminStaff();
+
+        $this->get('/stockOpname')->assertStatus(200);
+
+        $this->assertDatabaseHas('dashboard_change_logs', [
+            'module_key' => 'stockopname',
+            'activity_type' => 'open',
+            'created_by' => $staff->staff_id,
+            'duration_seconds' => null,
+        ]);
+    }
+
+    public function test_reopening_the_same_module_within_the_debounce_window_does_not_duplicate(): void
+    {
+        $staff = $this->actingAsSuperAdminStaff();
+
+        $this->get('/stockOpname')->assertStatus(200);
+        $this->get('/stockOpname')->assertStatus(200);
+        $this->get('/stockOpname')->assertStatus(200);
+
+        $count = DashboardChangeLog::where('created_by', $staff->staff_id)
+            ->where('module_key', 'stockopname')
+            ->where('activity_type', 'open')
+            ->count();
+        $this->assertSame(1, $count, 'opening the same module repeatedly within 15 minutes must debounce to a single row');
+    }
+
+    public function test_opening_a_different_module_closes_the_previous_open_row_with_a_duration(): void
+    {
+        $staff = $this->actingAsSuperAdminStaff();
+
+        $this->get('/stockOpname')->assertStatus(200);
+        $firstOpen = DashboardChangeLog::where('created_by', $staff->staff_id)
+            ->where('module_key', 'stockopname')
+            ->where('activity_type', 'open')
+            ->firstOrFail();
+        $this->assertNull($firstOpen->duration_seconds);
+
+        // Back-date it so the diff is deterministic and clearly under the 4h cap.
+        $firstOpen->created_at = now()->subMinutes(5);
+        $firstOpen->save();
+
+        $this->get('/purchaseOrder')->assertStatus(200);
+
+        $firstOpen->refresh();
+        $this->assertNotNull($firstOpen->duration_seconds, 'navigating away must retroactively fill the previous open row\'s duration');
+        $this->assertGreaterThanOrEqual(290, $firstOpen->duration_seconds); // ~5 minutes, allow test-runtime slack
+
+        $secondOpen = DashboardChangeLog::where('created_by', $staff->staff_id)
+            ->where('module_key', 'purchaseorder')
+            ->where('activity_type', 'open')
+            ->firstOrFail();
+        $this->assertNull($secondOpen->duration_seconds, 'the newly opened module is still an open session');
+    }
+
+    public function test_a_gap_longer_than_the_cap_is_left_without_a_duration(): void
+    {
+        $staff = $this->actingAsSuperAdminStaff();
+
+        $this->get('/stockOpname')->assertStatus(200);
+        $firstOpen = DashboardChangeLog::where('created_by', $staff->staff_id)
+            ->where('module_key', 'stockopname')
+            ->where('activity_type', 'open')
+            ->firstOrFail();
+
+        // Simulate a tab left open overnight: gap far beyond the 4h sanity cap.
+        $firstOpen->created_at = now()->subHours(10);
+        $firstOpen->save();
+
+        $this->get('/purchaseOrder')->assertStatus(200);
+
+        $firstOpen->refresh();
+        $this->assertNull($firstOpen->duration_seconds, 'a gap beyond the cap must not be recorded as a real duration');
+    }
+
+    public function test_menu_open_rows_are_excluded_from_the_changelog_pending_kpi(): void
+    {
+        $staff = $this->actingAsSuperAdminStaff();
+
+        // Baseline via the real endpoint (not a raw table count) so it goes through the same
+        // "current period" date filter as the KPI itself — seeded rows outside that window would
+        // otherwise make a raw count diverge from what the endpoint actually reports.
+        $before = (int) $this->get('/getDashboardOverview')->json('changelog.changelog_pending');
+
+        // A real mutation -> activity_type='change', counted by the KPI.
+        DashboardChangeLog::create([
+            'module_key' => 'master_bahan',
+            'activity_type' => 'change',
+            'module_label' => 'Master Bahan',
+            'reference' => 'BHN #1',
+            'what_changed' => 'Master bahan diperbarui.',
+            'summary' => 'Test',
+            'created_by' => $staff->staff_id,
+        ]);
+
+        // A page view -> activity_type='open', must NOT be counted.
+        $this->get('/stockOpname')->assertStatus(200);
+
+        $response = $this->get('/getDashboardOverview');
+        $response->assertStatus(200);
+        $pending = (int) $response->json('changelog.changelog_pending');
+
+        $this->assertSame($before + 1, $pending, 'the Changelog KPI must count the mutation row but not the menu-open row');
+    }
+}

--- a/tests/Workflow/StockOpnamePdfHighlightTest.php
+++ b/tests/Workflow/StockOpnamePdfHighlightTest.php
@@ -1,0 +1,167 @@
+<?php
+
+namespace Tests\Workflow;
+
+use App\Models\ProductStock;
+use App\Models\StockOpnameDetail;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\View;
+use Tests\Support\ActingAsStaff;
+use Tests\TestCase;
+
+/**
+ * GitHub #53: the Stock Opname PDF (Backoffice/PDF/Opname.blade.php) must show three highlight
+ * states per row, not the old binary yellow/none:
+ *   - untouched (real-stock input left blank client-side, real qty just defaulted to system qty)
+ *     -> no highlight
+ *   - touched, no selisih (staff typed a value and it matches the system) -> green
+ *   - touched, has selisih -> yellow (unchanged behaviour)
+ *
+ * See cdocs/testing/workflows/STOCK_OPNAME_FLOW.md — stod_system/stod_real/stod_selisih are pure
+ * display strings never read by accStockOpname(), so stod_touched is purely a display flag too.
+ */
+class StockOpnamePdfHighlightTest extends TestCase
+{
+    use ActingAsStaff;
+
+    private const YELLOW = 'background-color: #FFF9C4;';
+    private const GREEN = 'background-color: #C8E6C9;';
+
+    private function pickFixtureStocks(int $count): \Illuminate\Support\Collection
+    {
+        return ProductStock::withoutGlobalScope('active_warehouse')
+            ->where('status', 1)
+            ->where('warehouse_id', 1) // Gudang Pusat (main), seeded 2026-08-01
+            ->where('ps_stock', '>', 10)
+            ->limit($count)
+            ->get();
+    }
+
+    private function categoryId(): int
+    {
+        return (int) DB::table('categories')->where('status', 1)->value('category_id');
+    }
+
+    private function staffId(): int
+    {
+        return (int) DB::table('staffs')->where('status', 1)->value('staff_id');
+    }
+
+    public function test_insert_persists_stod_touched_per_row_matching_what_the_frontend_sends(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $stocks = $this->pickFixtureStocks(2);
+        $this->assertCount(2, $stocks, 'fixture needs at least 2 distinct product_stocks rows in Gudang Pusat');
+        [$touchedStock, $untouchedStock] = $stocks;
+
+        $response = $this->post('/insertStockOpname', [
+            'sto_date' => now()->toDateString(),
+            'staff_id' => $this->staffId(),
+            'category_id' => $this->categoryId(),
+            'sto_notes' => 'PDF highlight test',
+            'is_draft' => 0,
+            'item' => json_encode([
+                [
+                    'product_id' => $touchedStock->product_id,
+                    'product_variant_id' => $touchedStock->product_variant_id,
+                    'stod_system' => $touchedStock->ps_stock.' pcs',
+                    'stod_real' => $touchedStock->ps_stock.' pcs',
+                    'stod_selisih' => '0 pcs',
+                    'stod_notes' => null,
+                    // What CreateStockOpname.js now sends when the staff actually typed a value.
+                    'stod_touched' => 1,
+                ],
+                [
+                    'product_id' => $untouchedStock->product_id,
+                    'product_variant_id' => $untouchedStock->product_variant_id,
+                    'stod_system' => $untouchedStock->ps_stock.' pcs',
+                    'stod_real' => $untouchedStock->ps_stock.' pcs',
+                    'stod_selisih' => '0 pcs',
+                    'stod_notes' => null,
+                    // Left blank client-side -> real qty auto-defaulted to system qty, not typed.
+                    'stod_touched' => 0,
+                ],
+            ]),
+        ]);
+        $response->assertStatus(200);
+        $stoId = (int) $response->json('sto_id');
+
+        $this->assertDatabaseHas('stock_opname_details', [
+            'sto_id' => $stoId,
+            'product_variant_id' => $touchedStock->product_variant_id,
+            'stod_touched' => 1,
+        ]);
+        $this->assertDatabaseHas('stock_opname_details', [
+            'sto_id' => $stoId,
+            'product_variant_id' => $untouchedStock->product_variant_id,
+            'stod_touched' => 0,
+        ]);
+
+        // getDetail() (what generateStockOpname() feeds the PDF view) must round-trip the flag.
+        $detail = StockOpnameDetail::getDetail(['sto_id' => $stoId])->keyBy('product_variant_id');
+        $this->assertSame(1, (int) $detail[$touchedStock->product_variant_id]->stod_touched);
+        $this->assertSame(0, (int) $detail[$untouchedStock->product_variant_id]->stod_touched);
+    }
+
+    private function renderOpnameRow(array $item): string
+    {
+        return View::make('Backoffice.PDF.Opname', [
+            'stockOpname' => ['sto_code' => 'SP0001', 'sto_date' => now()->toDateString(), 'sto_notes' => null],
+            'staff_name' => ['staff_name' => 'Tester'],
+            'status' => 'Disetujui',
+            'detail' => [$item],
+        ])->render();
+    }
+
+    public function test_untouched_row_gets_no_highlight(): void
+    {
+        $html = $this->renderOpnameRow([
+            'product_variant_sku' => 'SKU-UNTOUCHED',
+            'pr_name' => 'Produk Untouched',
+            'product_variant_name' => 'Default',
+            'stod_system' => '10 pcs',
+            'stod_real' => '10 pcs',
+            'stod_selisih' => '0 pcs',
+            'stod_notes' => null,
+            'stod_touched' => 0,
+        ]);
+
+        $this->assertStringNotContainsString(self::YELLOW, $html);
+        $this->assertStringNotContainsString(self::GREEN, $html);
+    }
+
+    public function test_touched_row_with_no_selisih_gets_green_highlight(): void
+    {
+        $html = $this->renderOpnameRow([
+            'product_variant_sku' => 'SKU-MATCH',
+            'pr_name' => 'Produk Match',
+            'product_variant_name' => 'Default',
+            'stod_system' => '10 pcs',
+            'stod_real' => '10 pcs',
+            'stod_selisih' => '0 pcs',
+            'stod_notes' => null,
+            'stod_touched' => 1,
+        ]);
+
+        $this->assertStringContainsString(self::GREEN, $html);
+        $this->assertStringNotContainsString(self::YELLOW, $html);
+    }
+
+    public function test_touched_row_with_selisih_gets_yellow_highlight(): void
+    {
+        $html = $this->renderOpnameRow([
+            'product_variant_sku' => 'SKU-DIFF',
+            'pr_name' => 'Produk Diff',
+            'product_variant_name' => 'Default',
+            'stod_system' => '10 pcs',
+            'stod_real' => '8 pcs',
+            'stod_selisih' => '-2 pcs',
+            'stod_notes' => null,
+            'stod_touched' => 1,
+        ]);
+
+        $this->assertStringContainsString(self::YELLOW, $html);
+        $this->assertStringNotContainsString(self::GREEN, $html);
+    }
+}

--- a/tests/Workflow/StockOpnamePdfLiveSystemStockTest.php
+++ b/tests/Workflow/StockOpnamePdfLiveSystemStockTest.php
@@ -1,0 +1,175 @@
+<?php
+
+namespace Tests\Workflow;
+
+use App\Http\Controllers\StockController;
+use App\Models\ProductStock;
+use App\Models\StockOpnameDetail;
+use App\Models\Unit;
+use Illuminate\Support\Facades\DB;
+use ReflectionMethod;
+use Tests\Support\ActingAsStaff;
+use Tests\TestCase;
+
+/**
+ * Follow-up to GitHub #53, reported by the user after the PDF-highlight fix shipped:
+ * stod_system/stod_selisih are frozen at creation/edit time and never refresh. The race that
+ * exposes it: Opname A is created (freezing "system stock" at that instant), then — before A is
+ * approved — Opname B for the SAME product is approved, which overwrites the real system stock.
+ * A's PDF, if printed while still pending, would silently show the stale pre-B system figure.
+ *
+ * Fix (StockController):
+ *  - accStockOpname()/accStockOpnameBahan() now re-freeze stod_system/stod_selisih (Bahan:
+ *    stobd_*) to the TRUE value used at approval — the same "before" figure already written to
+ *    log_stocks — instead of leaving the creation-time snapshot in place.
+ *  - refreshLiveSystemQty() (called from generateStockOpname()/generateStockOpnameBahan() only
+ *    for status==1/pending docs) recomputes system/selisih live from the already-attached
+ *    ->stock collection (see ProductVariant::getProductVariantBulk()/Supplies::getSuppliesBulk())
+ *    instead of trusting the stored string — an approved/rejected doc's frozen snapshot is a
+ *    deliberate historical record and must NOT be recomputed live.
+ */
+class StockOpnamePdfLiveSystemStockTest extends TestCase
+{
+    use ActingAsStaff;
+
+    private function pickFixtureStock(): ProductStock
+    {
+        return ProductStock::withoutGlobalScope('active_warehouse')
+            ->where('status', 1)
+            ->where('warehouse_id', 1) // Gudang Pusat (main), seeded 2026-08-01
+            ->where('ps_stock', '>', 30)
+            ->firstOrFail();
+    }
+
+    private function categoryId(): int
+    {
+        return (int) DB::table('categories')->where('status', 1)->value('category_id');
+    }
+
+    private function staffId(): int
+    {
+        return (int) DB::table('staffs')->where('status', 1)->value('staff_id');
+    }
+
+    private function unitShortName(ProductStock $stock): string
+    {
+        return (string) (Unit::find($stock->unit_id)->unit_short_name ?? 'pcs');
+    }
+
+    private function insertStockOpname(ProductStock $stock, string $unit, int $realQty): int
+    {
+        $response = $this->post('/insertStockOpname', [
+            'sto_date' => now()->toDateString(),
+            'staff_id' => $this->staffId(),
+            'category_id' => $this->categoryId(),
+            'sto_notes' => 'Live system stock race test',
+            'is_draft' => 0,
+            'item' => json_encode([[
+                'product_id' => $stock->product_id,
+                'product_variant_id' => $stock->product_variant_id,
+                'stod_system' => $stock->ps_stock.' '.$unit,
+                'stod_real' => $realQty.' '.$unit,
+                'stod_selisih' => ($realQty - $stock->ps_stock).' '.$unit,
+                'stod_notes' => null,
+                'stod_touched' => 1,
+            ]]),
+        ]);
+        $response->assertStatus(200);
+
+        return (int) $response->json('sto_id');
+    }
+
+    private function approve(ProductStock $stock, int $stoId, int $realQty): void
+    {
+        $this->post('/accStockOpname', [
+            'sto_id' => $stoId,
+            'item' => json_encode([[
+                'product_variant_id' => $stock->product_variant_id,
+                'units' => [[
+                    'unit_id' => $stock->unit_id,
+                    'real_qty' => $realQty,
+                ]],
+            ]]),
+        ])->assertStatus(200);
+    }
+
+    private function parseQty(?string $string, string $unit): ?int
+    {
+        if (!$string) {
+            return null;
+        }
+        foreach (explode(',', $string) as $part) {
+            [$qty, $u] = array_pad(explode(' ', trim($part)), 2, null);
+            if ($u === $unit) {
+                return (int) $qty;
+            }
+        }
+        return null;
+    }
+
+    public function test_a_still_pending_document_pdf_data_reflects_live_stock_not_the_stale_creation_time_snapshot(): void
+    {
+        $this->actingAsSuperAdminStaff();
+        $stock = $this->pickFixtureStock();
+        $unit = $this->unitShortName($stock);
+        $startingStock = $stock->ps_stock;
+
+        // A created first, matching system stock at that instant.
+        $stoIdA = $this->insertStockOpname($stock, $unit, realQty: $startingStock);
+
+        // Before A is approved, B (same product) is approved and moves the real stock.
+        $stoIdB = $this->insertStockOpname($stock, $unit, realQty: $startingStock - 15);
+        $this->approve($stock, $stoIdB, $startingStock - 15);
+
+        $stock->refresh();
+        $this->assertSame($startingStock - 15, $stock->ps_stock, "sanity: B's approval must have moved the live stock");
+
+        // Prove the stored row really is stale (this is the bug being guarded against).
+        $this->assertDatabaseHas('stock_opname_details', [
+            'sto_id' => $stoIdA,
+            'product_variant_id' => $stock->product_variant_id,
+            'stod_system' => $startingStock.' '.$unit,
+        ]);
+
+        // What generateStockOpname() feeds the PDF for a still-pending doc must be live, not that
+        // stale row -- refreshLiveSystemQty() is private, called only from there, so invoke it
+        // directly (ReflectionMethod is already an established pattern in this suite, see
+        // tests/Health/SchemaConsistencyTest.php).
+        $detail = StockOpnameDetail::getDetail(['sto_id' => $stoIdA]);
+        $refresh = new ReflectionMethod(StockController::class, 'refreshLiveSystemQty');
+        $refresh->setAccessible(true);
+        $refresh->invoke(new StockController(), $detail, 'stod_real', 'stod_system', 'stod_selisih', 'ps_stock');
+
+        $row = $detail->firstWhere('product_variant_id', $stock->product_variant_id);
+        $this->assertSame($startingStock - 15, $this->parseQty($row->stod_system, $unit), 'PDF data for a pending doc must show the CURRENT live system stock');
+        $this->assertSame(15, $this->parseQty($row->stod_selisih, $unit), 'selisih must be recomputed against the live system stock too');
+    }
+
+    public function test_approving_freezes_the_true_system_stock_at_that_moment_not_the_creation_time_one(): void
+    {
+        $this->actingAsSuperAdminStaff();
+        $stock = $this->pickFixtureStock();
+        $unit = $this->unitShortName($stock);
+        $startingStock = $stock->ps_stock;
+
+        $stoIdA = $this->insertStockOpname($stock, $unit, realQty: $startingStock);
+        $stoIdB = $this->insertStockOpname($stock, $unit, realQty: $startingStock - 15);
+        $this->approve($stock, $stoIdB, $startingStock - 15);
+
+        // A is approved with real_qty = $startingStock (the count taken before B's approval
+        // moved anything) -- accStockOpname() re-fetches live stock right before overwriting, so
+        // the true "before" value here is $startingStock - 15, NOT the stale creation-time
+        // $startingStock baked into A's stod_system.
+        $this->approve($stock, $stoIdA, $startingStock);
+
+        $row = StockOpnameDetail::where('sto_id', $stoIdA)
+            ->where('product_variant_id', $stock->product_variant_id)
+            ->firstOrFail();
+
+        $this->assertSame($startingStock - 15, $this->parseQty($row->stod_system, $unit), 'approval must freeze the TRUE system stock at approval time');
+        $this->assertSame(15, $this->parseQty($row->stod_selisih, $unit), 'the frozen selisih must reflect the true discrepancy found at approval, not a stale one');
+
+        $stock->refresh();
+        $this->assertSame($startingStock, $stock->ps_stock, "A's approval must still overwrite with A's own real_qty, unaffected by this fix");
+    }
+}


### PR DESCRIPTION
## Ringkasan

Menyelesaikan [#53](https://github.com/denny011299/pegasus/issues/53) — dua perbaikan di modul Stock Opname (Produk & Bahan Mentah) plus traceability di dashboard Changelog.

Ada 3 masalah yang diperbaiki:
1. Highlight PDF Stock Opname yang tidak jelas (request awal dari WA).
2. Angka "Stok Sistem" di PDF yang bisa basi/salah (ditemukan setelah #1 selesai).
3. Dashboard Changelog belum mencatat siapa yang membuka menu, jam berapa, dan berapa lama.

---

## 1. Highlight di PDF salah

**Masalah lama:** PDF cuma punya 2 kondisi — **kuning** kalau ada selisih, **tanpa warna** kalau tidak ada selisih. Masalahnya, "tidak ada selisih" ini mencakup dua kondisi yang beda maknanya:
- Barang yang memang **dicek dan cocok** dengan sistem.
- Barang yang **tidak sempat diinput** stok real-nya (dikosongkan saat input) — sistem otomatis anggap real = stok sistem, jadi kelihatan "cocok" padahal sebenarnya **belum dicek sama sekali**.

Dua kondisi ini sebelumnya tidak bisa dibedakan di PDF.

**Solusi:**
- Kolom baru `stod_touched` (Produk) / `stobd_touched` (Bahan) — diisi otomatis dari form: kalau staf benar-benar mengetik angka di stok real, `touched = 1`; kalau dikosongkan, `touched = 0`.
- PDF sekarang 3 kondisi:
  - **Tanpa warna** → belum diisi sama sekali.
  - **Hijau** → sudah diisi, dan cocok dengan sistem.
  - **Kuning** → sudah diisi, dan ada selisih (sama seperti sebelumnya).

Dipastikan ini murni perubahan tampilan — proses approve (`accStockOpname`/`accStockOpnameBahan`) tidak pernah membaca kolom ini, jadi tidak berpengaruh ke mutasi stok.

## 2. Angka "Stok Sistem" di PDF bisa basi

**Masalah:** Angka "Stok Sistem" yang tercetak itu **dibekukan sekali saat dokumen dibuat**, lalu tidak pernah diperbarui. Kalau ada Stock Opname lain untuk produk yang sama yang **disetujui duluan** sebelum dokumen ini disetujui/dicetak, stok sistem sebenarnya sudah berubah — tapi PDF tetap menampilkan angka lama. Akar masalahnya: proses approve itu sendiri **selalu** ambil stok live dari database (jadi proses approve-nya sendiri tidak pernah salah) — yang salah cuma laporannya, karena baca dari data yang dibekukan di awal.

**Solusi — dibedakan berdasarkan status dokumen:**
- **Menunggu (pending):** saat PDF dicetak, stok sistem dihitung **ulang secara live** dari stok gudang saat itu juga — bukan angka beku dari saat dokumen dibuat.
- **Disetujui (approved):** dibekukan ke **angka yang benar** persis di detik approve terjadi (bukan live terus-menerus) — kalau tetap live, laporan akan selalu terlihat "tidak ada selisih" setelah approve, padahal justru selisih yang ditemukan saat itulah yang harus jadi bukti historis permanen di laporan.
- **Ditolak:** dibiarkan seperti semula (risiko rendah, tidak ada stok yang berubah).

Singkatnya: **pending → live saat dicetak, approved → dibekukan ke nilai yang benar saat approve (bukan saat dokumen dibuat)**.

**Belum diubah (di luar cakupan):** halaman edit/approve (form input sebelum klik ACC) masih menampilkan "Stok Sistem" versi lama kalau dokumen dibuat lalu didiamkan lama. Ini **tidak memengaruhi hasil approve** (approve selalu ambil data live sendiri) — cuma tampilan yang berpotensi membingungkan staf saat memutuskan. Bisa jadi perbaikan lanjutan kalau dibutuhkan.

## 3. Traceability di dashboard Changelog

**Request:** catat nama user, jam buka menu, dan durasinya di Changelog dashboard yang sudah ada.

**Solusi:**
- `LogDashboardActivity` sekarang juga mencatat baris "menu dibuka" (bukan cuma mutasi data seperti sebelumnya) — nama staf, jam buka, dan durasi (estimasi pasif: jarak waktu ke request berikutnya dari staf yang sama, di-debounce 15 menit per modul supaya tidak spam).
- Tetap di tabel Changelog yang sama sesuai permintaan, tapi KPI "Changelog" (jumlah yang perlu ACC Direktur) di-filter supaya baris "buka menu" ini tidak ikut terhitung — biar KPI-nya tetap berarti.
- Tabel Changelog di dashboard dapat 2 kolom baru: **User** dan **Jam / Durasi**.

---

## Testing

15 test baru (Workflow), semua hijau: 4 highlight PDF, 2 live-system-stock, 5 traceability menu, plus regression suite Stock Opname yang sudah ada (approve/reject/draft gate, repeat-approval idempotency) tetap hijau — tidak ada regresi.

Closes #53
