### PR TITLE
fix: dashboard Changelog follow-ups — close on '/', human-readable labels

### DIFF
--- a/app/Http/Middleware/LogDashboardActivity.php
+++ b/app/Http/Middleware/LogDashboardActivity.php
@@ -171,8 +171,15 @@ class LogDashboardActivity
             return false;
         }
 
+        // Ditambahkan (2026-08-15): '' (root '/') SEBELUMNYA ikut dikecualikan di sini, disalin
+        // dari daftar exclude shouldLogChange() -- tapi routes/web.php me-render dashboard
+        // langsung di GET '/' (bukan redirect ke '/admin'), jadi itu JUSTRU rute yang paling
+        // sering dipakai user untuk "kembali ke dashboard". Mengecualikannya berarti baris 'open'
+        // sebelumnya (menu apa pun yang masih terbuka) tidak pernah ditutup saat user balik ke
+        // dashboard lewat '/' -- selalu nyangkut di "Sedang dibuka". session()->has('user') di
+        // atas sudah cukup menyaring pengunjung yang belum login, jadi '' aman untuk dicatat.
         $path = strtolower(trim($request->path(), '/'));
-        if (in_array($path, ['', 'up', 'login', 'logout'], true)) {
+        if (in_array($path, ['up', 'login', 'logout'], true)) {
             return false;
         }
 
@@ -208,8 +215,83 @@ class LogDashboardActivity
         return $seg !== '' ? $seg : 'dashboard';
     }
 
+    /**
+     * module_key adalah segmen pertama URL apa adanya (mis. "detailstockopname",
+     * "insertstockopname") -- Str::title() begitu saja menghasilkan label yang teknis dan
+     * membingungkan (user melaporkan: "Insertstockopname" dikira halaman untuk MEMBUKA form,
+     * padahal itu baris mutasi AJAX; halaman form aslinya berlabel "Detailstockopname"). Basis
+     * data ini menerjemahkan awalan aksi (insert/update/delete/detail/acc/dst.) + nama modul
+     * dasar jadi label Indonesia yang jelas, mis. "detailstockopname" -> "Input Stok Opname",
+     * "insertstockopname" -> "Tambah Stok Opname". module_key yang tidak dikenal tetap jatuh ke
+     * fallback Str::title() lama, jadi modul yang belum dipetakan tidak pernah rusak/kosong --
+     * cuma tetap teknis seperti sebelumnya. Hanya memengaruhi baris yang BARU dibuat setelah ini
+     * (module_label disimpan permanen saat insert, bukan dihitung ulang saat ditampilkan).
+     */
+    private const MODULE_BASE_LABELS = [
+        'dashboard' => 'Dashboard',
+        'admin' => 'Dashboard',
+        'stockopnamebahan' => 'Stok Opname Bahan Mentah',
+        'stockopname' => 'Stok Opname',
+        'stockalertsupplies' => 'Stock Alert Bahan',
+        'stockalert' => 'Stock Alert',
+        'customer' => 'Customer',
+        'supplier' => 'Supplier',
+        'product' => 'Produk',
+        'supplies' => 'Bahan Mentah',
+        'staff' => 'Staff',
+        'purchaseorder' => 'Purchase Order',
+        'salesorder' => 'Sales Order',
+        'production' => 'Produksi',
+        'productissues' => 'Retur Produk',
+        'returnsupplies' => 'Retur Bahan Mentah',
+        'role' => 'Role / Hak Akses',
+        'area' => 'Area',
+        'bank' => 'Bank',
+        'category' => 'Kategori',
+        'unit' => 'Satuan',
+        'variant' => 'Variasi',
+        'bom' => 'BOM (Resep Produksi)',
+        'cashadmin' => 'Kas Operasional',
+        'cashgudang' => 'Kas Gudang',
+        'casharmada' => 'Kas Armada',
+        'cashsales' => 'Kas Sales',
+        'tt' => 'Tanda Terima',
+        'sodelivery' => 'Pengiriman SO',
+        'podelivery' => 'Pengiriman PO',
+        'invoicepo' => 'Invoice PO',
+        'invoiceso' => 'Invoice SO',
+    ];
+
+    // Diperiksa berurutan sesuai array ini -- "accept" HARUS sebelum "acc", kalau tidak
+    // "acceptcashadmin" akan salah terpotong jadi "acc" + "eptcashadmin".
+    private const MODULE_ACTION_PREFIXES = [
+        'accept' => 'Terima',
+        'decline' => 'Tolak',
+        'insert' => 'Tambah',
+        'update' => 'Ubah',
+        'delete' => 'Hapus',
+        'detail' => 'Input',
+        'tolak' => 'Tolak',
+        'acc' => 'ACC',
+    ];
+
     private function formatModuleLabel(string $moduleKey): string
     {
+        $key = strtolower($moduleKey);
+
+        if (isset(self::MODULE_BASE_LABELS[$key])) {
+            return self::MODULE_BASE_LABELS[$key];
+        }
+
+        foreach (self::MODULE_ACTION_PREFIXES as $prefix => $verb) {
+            if (str_starts_with($key, $prefix)) {
+                $base = substr($key, strlen($prefix));
+                if (isset(self::MODULE_BASE_LABELS[$base])) {
+                    return $verb.' '.self::MODULE_BASE_LABELS[$base];
+                }
+            }
+        }
+
         return Str::title(str_replace('_', ' ', $moduleKey));
     }
 

--- a/app/Http/Middleware/LogDashboardActivity.php
+++ b/app/Http/Middleware/LogDashboardActivity.php
@@ -75,16 +75,14 @@ class LogDashboardActivity
         $moduleLabel = $this->formatModuleLabel($moduleKey);
         $now = now();
 
-        // Debounce: staf yang sama membuka modul yang sama berkali-kali (klik-klik/refresh)
-        // dalam jendela singkat tidak perlu jadi baris baru tiap kali.
-        $recentlyOpened = DashboardChangeLog::where('created_by', $staffId)
-            ->where('module_key', $moduleKey)
-            ->where('activity_type', 'open')
-            ->where('created_at', '>=', $now->copy()->subMinutes(15))
-            ->exists();
-        if ($recentlyOpened) {
-            return;
-        }
+        // Ditambahkan (2026-08-14), dihapus lagi (2026-08-15): sempat ada debounce 15 menit
+        // per staf+modul di sini supaya klik-klik/refresh cepat tidak jadi baris baru tiap
+        // kali. Ternyata itu menutupi bug yang jauh lebih parah -- `return` dini di sini
+        // melompati juga logika "tutup sesi 'open' sebelumnya" di bawah, bukan cuma logika
+        // insert baris baru. Jadi membuka ulang modul yang SAMA dalam 15 menit (mis. balik ke
+        // Dashboard yang baru saja dibuka) diam-diam gagal menutup modul LAIN yang sedang
+        // terbuka -- persis gejala yang dilaporkan user ("Dashboard nav click still not
+        // ending the previous page session"). Setiap kunjungan sekarang selalu dicatat.
 
         // Tutup baris 'open' terakhir milik staf ini (modul manapun) yang belum punya durasi —
         // durasinya = jarak ke pembukaan menu berikutnya ini. Kalau jaraknya lebih dari 4 jam,

--- a/tests/Workflow/DashboardChangelogMenuOpenTrackingTest.php
+++ b/tests/Workflow/DashboardChangelogMenuOpenTrackingTest.php
@@ -76,7 +76,15 @@ class DashboardChangelogMenuOpenTrackingTest extends TestCase
         ]);
     }
 
-    public function test_reopening_the_same_module_within_the_debounce_window_does_not_duplicate(): void
+    /**
+     * There used to be a 15-minute debounce here (skip logging a repeat visit to the same
+     * module). Removed 2026-08-15: it was coupled to the same early `return` as the
+     * close-previous-open-row logic below, so re-opening a module you'd visited recently
+     * silently failed to close whatever ELSE was open in between — e.g. Dashboard -> Customer
+     * -> Dashboard again within 15 minutes left Customer's row stuck on "Sedang dibuka" forever.
+     * User's call: every navigation gets recorded now, no debounce, duplicates included.
+     */
+    public function test_every_visit_is_recorded_even_repeat_visits_to_the_same_module(): void
     {
         $staff = $this->actingAsSuperAdminStaff();
 
@@ -88,7 +96,15 @@ class DashboardChangelogMenuOpenTrackingTest extends TestCase
             ->where('module_key', 'stockopname')
             ->where('activity_type', 'open')
             ->count();
-        $this->assertSame(1, $count, 'opening the same module repeatedly within 15 minutes must debounce to a single row');
+        $this->assertSame(3, $count, 'every visit must be recorded, including repeats of the same module');
+
+        // Only the LAST one is still "open" -- each earlier visit gets closed by the next one.
+        $openCount = DashboardChangeLog::where('created_by', $staff->staff_id)
+            ->where('module_key', 'stockopname')
+            ->where('activity_type', 'open')
+            ->whereNull('duration_seconds')
+            ->count();
+        $this->assertSame(1, $openCount, 'each repeat visit must close the previous one, not just accumulate open sessions');
     }
 
     public function test_opening_a_different_module_closes_the_previous_open_row_with_a_duration(): void
@@ -169,6 +185,33 @@ class DashboardChangelogMenuOpenTrackingTest extends TestCase
             'created_by' => $staff->staff_id,
             'duration_seconds' => null,
         ]);
+    }
+
+    public function test_revisiting_a_recently_opened_module_still_closes_whatever_is_currently_open(): void
+    {
+        // The exact user-reported scenario: Dashboard -> Customer -> Dashboard again (within
+        // what used to be the 15-minute debounce window) must still close Customer's session.
+        $staff = $this->actingAsSuperAdminStaff();
+
+        $this->get('/')->assertStatus(200);
+        $dashboardOpen = DashboardChangeLog::where('created_by', $staff->staff_id)
+            ->where('module_key', 'dashboard')->where('activity_type', 'open')
+            ->firstOrFail();
+
+        $this->get('/customer')->assertStatus(200);
+        $dashboardOpen->refresh();
+        $this->assertNotNull($dashboardOpen->duration_seconds, 'opening Customer must close the Dashboard session');
+
+        $customerOpen = DashboardChangeLog::where('created_by', $staff->staff_id)
+            ->where('module_key', 'customer')->where('activity_type', 'open')
+            ->firstOrFail();
+        $this->assertNull($customerOpen->duration_seconds);
+
+        // Back to Dashboard again, well within the old 15-minute debounce window.
+        $this->get('/')->assertStatus(200);
+
+        $customerOpen->refresh();
+        $this->assertNotNull($customerOpen->duration_seconds, "revisiting Dashboard must close Customer's session even though Dashboard was opened moments ago");
     }
 
     public function test_menu_open_rows_are_excluded_from_the_changelog_pending_kpi(): void

--- a/tests/Workflow/DashboardChangelogMenuOpenTrackingTest.php
+++ b/tests/Workflow/DashboardChangelogMenuOpenTrackingTest.php
@@ -31,6 +31,51 @@ class DashboardChangelogMenuOpenTrackingTest extends TestCase
         ]);
     }
 
+    /**
+     * User-reported confusion: "Insertstockopname" (an AJAX mutation row) reads like it's about
+     * opening a page, while the actual "Input Stok Opname" form page is auto-labeled
+     * "Detailstockopname" — nothing ties the two together visually. formatModuleLabel() now
+     * translates action-prefix + base module into a human label instead of a bare title-cased
+     * URL segment.
+     */
+    public function test_module_labels_are_human_readable_not_raw_url_segments(): void
+    {
+        $staff = $this->actingAsSuperAdminStaff();
+
+        // The actual create/edit form page -> "Input Stok Opname", not "Detailstockopname".
+        $this->get('/detailStockOpname/-1')->assertStatus(200);
+        $this->assertDatabaseHas('dashboard_change_logs', [
+            'module_key' => 'detailstockopname',
+            'activity_type' => 'open',
+            'module_label' => 'Input Stok Opname',
+        ]);
+
+        // The AJAX insert mutation -> "Tambah Stok Opname", not "Insertstockopname".
+        $stock = \App\Models\ProductStock::withoutGlobalScope('active_warehouse')
+            ->where('status', 1)->where('warehouse_id', 1)->firstOrFail();
+        $this->post('/insertStockOpname', [
+            'sto_date' => now()->toDateString(),
+            'staff_id' => $staff->staff_id,
+            'category_id' => (int) \Illuminate\Support\Facades\DB::table('categories')->where('status', 1)->value('category_id'),
+            'sto_notes' => 'label test',
+            'is_draft' => 0,
+            'item' => json_encode([[
+                'product_id' => $stock->product_id,
+                'product_variant_id' => $stock->product_variant_id,
+                'stod_system' => $stock->ps_stock.' pcs',
+                'stod_real' => $stock->ps_stock.' pcs',
+                'stod_selisih' => '0 pcs',
+                'stod_notes' => null,
+                'stod_touched' => 1,
+            ]]),
+        ])->assertStatus(200);
+        $this->assertDatabaseHas('dashboard_change_logs', [
+            'module_key' => 'insertstockopname',
+            'activity_type' => 'change',
+            'module_label' => 'Tambah Stok Opname',
+        ]);
+    }
+
     public function test_reopening_the_same_module_within_the_debounce_window_does_not_duplicate(): void
     {
         $staff = $this->actingAsSuperAdminStaff();
@@ -92,6 +137,38 @@ class DashboardChangelogMenuOpenTrackingTest extends TestCase
 
         $firstOpen->refresh();
         $this->assertNull($firstOpen->duration_seconds, 'a gap beyond the cap must not be recorded as a real duration');
+    }
+
+    public function test_navigating_back_to_the_dashboard_root_closes_the_previous_open_row(): void
+    {
+        // GitHub #53 follow-up (user-reported): routes/web.php renders the dashboard directly at
+        // GET '/' (not just '/admin') -- '/' used to be excluded from shouldLogOpen() (copied
+        // from shouldLogChange()'s exclude list), so the most common "back to dashboard" path
+        // never closed out whatever menu was left open, leaving it stuck on "Sedang dibuka"
+        // forever even while the user was actively looking at the Changelog panel itself.
+        $staff = $this->actingAsSuperAdminStaff();
+
+        $this->get('/stockOpname')->assertStatus(200);
+        $firstOpen = DashboardChangeLog::where('created_by', $staff->staff_id)
+            ->where('module_key', 'stockopname')
+            ->where('activity_type', 'open')
+            ->firstOrFail();
+        $this->assertNull($firstOpen->duration_seconds);
+
+        $firstOpen->created_at = now()->subMinutes(3);
+        $firstOpen->save();
+
+        $this->get('/')->assertStatus(200);
+
+        $firstOpen->refresh();
+        $this->assertNotNull($firstOpen->duration_seconds, "navigating to '/' must retroactively close the previous open row too");
+
+        $this->assertDatabaseHas('dashboard_change_logs', [
+            'module_key' => 'dashboard',
+            'activity_type' => 'open',
+            'created_by' => $staff->staff_id,
+            'duration_seconds' => null,
+        ]);
     }
 
     public function test_menu_open_rows_are_excluded_from_the_changelog_pending_kpi(): void


### PR DESCRIPTION
## Ringkasan

Follow-up dari [#53](https://github.com/denny011299/pegasus/issues/53) (sudah di-merge lewat #54) — dua temuan dari testing manual di data asli.

## 1. Balik ke dashboard lewat `/` tidak pernah menutup sesi "buka menu" sebelumnya

**Masalah:** `routes/web.php` me-render dashboard langsung di `GET /` (bukan cuma `/admin`). Tapi `shouldLogOpen()` sebelumnya mengecualikan path `''` (root) — ke-copy dari daftar exclude milik `shouldLogChange()` tanpa dicek ulang apakah relevan di sini. Padahal `/` itu justru jalur PALING SERING dipakai user untuk balik ke dashboard: logo di header (semua varian tema — default/dark/small/collapsed, total 8 tempat) dan menu "Dashboard" di sidebar semuanya mengarah ke `/`, bukan `/admin`. Akibatnya baris "menu dibuka" sebelumnya (di modul apa pun) tidak pernah ditutup selama user baliknya lewat `/` — nyangkut selamanya di "Sedang dibuka", bahkan saat sedang melihat panel Changelog itu sendiri di dashboard.

**Solusi:** hapus `''` dari daftar exclude. `session()->has('user')` di method yang sama sudah cukup menyaring pengunjung yang belum login, jadi aman. Dicoba dulu opsi alternatif (ubah semua link nav ke `/admin`) tapi dianggap kurang efisien karena `/` tetap route yang valid dan tetap bisa diakses langsung (bookmark, ketik URL manual) — jadi mengubah link saja tidak menutup celahnya, cuma mengurangi seberapa sering kena.

## 2. Label modul di Changelog membingungkan

**Masalah:** `module_label` sebelumnya cuma `Str::title()` dari segmen URL mentah, hasilnya nama teknis yang membingungkan — contoh nyata dari testing: baris **"Insertstockopname"** (baris mutasi AJAX) dikira halaman untuk MEMBUKA form input, padahal halaman form aslinya (yang dibuka lewat `/detailStockOpname/{id}`) malah berlabel **"Detailstockopname"** — tidak ada yang menghubungkan keduanya secara visual.

**Solusi:** `formatModuleLabel()` sekarang menerjemahkan awalan aksi (insert/update/delete/detail/acc/dst.) + nama modul dasar jadi label Indonesia yang jelas:
- `detailstockopname` → **"Input Stok Opname"** (halaman form-nya)
- `insertstockopname` → **"Tambah Stok Opname"** (aksi simpan)
- `updatestockopname` → **"Ubah Stok Opname"**
- `accstockopname` → **"ACC Stok Opname"**
- dst., plus modul-modul umum lain (Customer, Supplier, Produk, Purchase Order, Sales Order, Produksi, Kas, dll.)

Modul yang belum ada di tabel pemetaan tetap jatuh ke label lama (title-case dari URL) — tidak ada yang rusak, cuma belum sebagus yang sudah dipetakan. Catatan: `module_label` disimpan permanen saat baris dibuat, jadi ini cuma berlaku untuk baris BARU setelah perubahan ini — baris lama di database tetap pakai label lamanya.

## Testing

2 test baru, keduanya hijau:
- Regression untuk masalah #1 — dikonfirmasi **gagal** dulu di kode lama, **lulus** setelah fix.
- Bukti pemetaan label untuk masalah #2 (skenario persis yang dilaporkan: `detailstockopname` → "Input Stok Opname", `insertstockopname` → "Tambah Stok Opname").

Suite Workflow/Regression/Health lain tidak terpengaruh (3 kegagalan yang sama, sudah ada sebelumnya di `main`, tidak terkait — `SalesOrderRetailAndUnitConversionFlowTest`).


---

## Update: debounce 15 menit dihapus total

Setelah testing lebih lanjut di data asli, ternyata debounce 15 menit per staf+modul (dulu ditambahkan supaya klik-klik/refresh cepat tidak jadi baris baru terus) justru jadi sumber masalah baru yang lebih parah dari yang mau dicegah:

**Akar masalah:** `return` dini di pengecekan debounce ikut melompati logika "tutup sesi 'open' sebelumnya" — bukan cuma logika "jangan buat baris duplikat". Jadi urutan: buka **Dashboard** → buka **Customer** → buka **Dashboard** lagi (masih dalam 15 menit sejak kunjungan Dashboard pertama) → debounce Dashboard aktif → baris Customer **tidak pernah ditutup**, nyangkut selamanya di "Sedang dibuka". Ini kemungkinan besar penyebab dua gejala yang dilaporkan sebelumnya ("Dashboard nav click still not ending the previous page session" dan "not all of my visited page got recorded") — sama-sama berakar dari bug yang sama begitu ditelusuri.

**Solusi (sesuai arahan):** debounce dihapus total. Setiap navigasi sekarang selalu dicatat, termasuk kunjungan berulang ke modul yang sama — hanya baris TERAKHIR per staf yang tetap "Sedang dibuka", semua kunjungan sebelumnya otomatis tertutup begitu ada navigasi berikutnya.

Test baru membuktikan skenario persis yang dilaporkan (Dashboard → Customer → Dashboard lagi tetap menutup sesi Customer), plus test debounce lama dibalik jadi bukti "setiap kunjungan tercatat, termasuk yang berulang".
