### PR TITLE
Batch 9: permission-error handler + Stock Opname PDF/dashboard traceability (main → fase2)

### DIFF
--- a/app/Http/Controllers/ReportController.php
+++ b/app/Http/Controllers/ReportController.php
@@ -2399,7 +2399,11 @@ class ReportController extends Controller
             ->where('status', 1)
             ->whereRaw('DATE(COALESCE(pi_date, created_at)) BETWEEN ? AND ?', [$s, $e])
             ->count();
+        // GitHub #53: dashboard_change_logs sekarang juga menyimpan baris activity_type='open'
+        // ("staf membuka menu X", lihat LogDashboardActivity) -- itu bukan sesuatu yang
+        // "menunggu ACC Direktur", jadi tidak ikut dihitung di KPI ini.
         $changelogPending += (int) DB::table('dashboard_change_logs')
+            ->where('activity_type', 'change')
             ->whereRaw('DATE(created_at) BETWEEN ? AND ?', [$s, $e])
             ->count();
 
@@ -2471,6 +2475,31 @@ class ReportController extends Controller
             return 'INV '.$so;
         };
 
+        // GitHub #53: format durasi pasif dari LogDashboardActivity::logOpen() jadi teks ringkas.
+        $fmtDuration = static function ($seconds) {
+            $seconds = (int) $seconds;
+            if ($seconds < 60) {
+                return $seconds.' detik';
+            }
+            $minutes = intdiv($seconds, 60);
+            if ($minutes < 60) {
+                return $minutes.' menit';
+            }
+            $hours = intdiv($minutes, 60);
+            $restMinutes = $minutes % 60;
+            return $restMinutes > 0 ? ($hours.' jam '.$restMinutes.' menit') : ($hours.' jam');
+        };
+        $fmtOpenedAt = static function ($createdAt) {
+            if (!$createdAt) {
+                return '-';
+            }
+            try {
+                return \Carbon\Carbon::parse($createdAt)->format('d M Y H:i');
+            } catch (\Throwable $e) {
+                return (string) $createdAt;
+            }
+        };
+
         $changelog = [];
 
         $piRows = DB::table('product_issues as pi')
@@ -2478,7 +2507,36 @@ class ReportController extends Controller
             ->whereRaw('DATE(COALESCE(pi.pi_date, pi.created_at)) BETWEEN ? AND ?', [$s, $e])
             ->orderByDesc('pi.created_at')
             ->limit($limit)
-            ->get(['pi.pi_id', 'pi.pi_code', 'pi.pi_type', 'pi.tipe_return', 'pi.pi_notes', 'pi.pi_date']);
+            ->get(['pi.pi_id', 'pi.pi_code', 'pi.pi_type', 'pi.tipe_return', 'pi.pi_notes', 'pi.pi_date', 'pi.created_at', 'pi.created_by']);
+
+        $masterChangeRows = DB::table('dashboard_change_logs as dcl')
+            ->whereRaw('DATE(dcl.created_at) BETWEEN ? AND ?', [$s, $e])
+            ->orderByDesc('dcl.created_at')
+            ->limit($limit)
+            ->get([
+                'dcl.id',
+                'dcl.module_key',
+                'dcl.activity_type',
+                'dcl.module_label',
+                'dcl.reference',
+                'dcl.what_changed',
+                'dcl.summary',
+                'dcl.url',
+                'dcl.url_label',
+                'dcl.created_at',
+                'dcl.created_by',
+                'dcl.duration_seconds',
+            ]);
+
+        // Satu query untuk semua nama staf (retur + changelog), hindari N+1.
+        $staffIds = $piRows->pluck('created_by')
+            ->concat($masterChangeRows->pluck('created_by'))
+            ->filter()
+            ->unique()
+            ->values();
+        $staffNames = $staffIds->isEmpty()
+            ? collect()
+            : DB::table('staffs')->whereIn('staff_id', $staffIds)->pluck('staff_name', 'staff_id');
 
         foreach ($piRows as $pi) {
             $tipe = (int) ($pi->tipe_return ?? 0);
@@ -2493,28 +2551,23 @@ class ReportController extends Controller
                 'summary' => trim($tipeLabel.(($pi->pi_notes ?? '') !== '' ? ' — '.(string) $pi->pi_notes : '')),
                 'url' => url('productIssue').'?pi_id='.(int) $pi->pi_id,
                 'url_label' => 'Buka baris ini',
+                'staff_name' => $staffNames[$pi->created_by ?? 0] ?? '-',
+                'opened_at' => $fmtOpenedAt($pi->created_at ?? $pi->pi_date),
+                'duration_label' => '-',
             ];
         }
 
-        $masterChangeRows = DB::table('dashboard_change_logs as dcl')
-            ->whereRaw('DATE(dcl.created_at) BETWEEN ? AND ?', [$s, $e])
-            ->orderByDesc('dcl.created_at')
-            ->limit($limit)
-            ->get([
-                'dcl.id',
-                'dcl.module_key',
-                'dcl.module_label',
-                'dcl.reference',
-                'dcl.what_changed',
-                'dcl.summary',
-                'dcl.url',
-                'dcl.url_label',
-                'dcl.created_at',
-            ]);
         foreach ($masterChangeRows as $log) {
             $safeUrl = $this->normalizeDashboardLogUrl((string) ($log->url ?? ''));
             if ($safeUrl === url('admin')) {
                 $safeUrl = $this->fallbackDashboardLogUrlByModule((string) ($log->module_key ?? ''));
+            }
+            $isOpen = ($log->activity_type ?? 'change') === 'open';
+            $durationLabel = '-';
+            if ($isOpen) {
+                $durationLabel = $log->duration_seconds !== null
+                    ? $fmtDuration($log->duration_seconds)
+                    : 'Sedang dibuka';
             }
             $changelog[] = [
                 'kind' => (string) ($log->module_key ?? 'master_change'),
@@ -2526,6 +2579,9 @@ class ReportController extends Controller
                 'summary' => (string) ($log->summary ?? ''),
                 'url' => $safeUrl,
                 'url_label' => (string) ($log->url_label ?? 'Buka'),
+                'staff_name' => $staffNames[$log->created_by ?? 0] ?? '-',
+                'opened_at' => $fmtOpenedAt($log->created_at),
+                'duration_label' => $durationLabel,
             ];
         }
 

--- a/app/Http/Controllers/StockController.php
+++ b/app/Http/Controllers/StockController.php
@@ -222,6 +222,52 @@ class StockController extends Controller
         return 0;
     }
 
+    // Kebalikan dari getQty() -- rakit ['DOS' => 10, 'pcs' => 2] jadi "10 DOS, 2 pcs".
+    private function buildQtyString(array $qtyByUnit): string
+    {
+        $parts = [];
+        foreach ($qtyByUnit as $unit => $qty) {
+            $parts[] = $qty . ' ' . $unit;
+        }
+        return implode(', ', $parts);
+    }
+
+    /**
+     * stod_system/stod_selisih (stobd_* untuk Bahan) dibekukan sekali saat dokumen dibuat/diedit
+     * dan tidak pernah di-refresh -- begitu ada peristiwa stok LAIN APAPUN sebelum dokumen ini
+     * diputuskan (stock opname lain di-ACC, SO dikirim, dst.), PDF-nya diam-diam membandingkan
+     * dengan angka sistem yang sudah basi. getDetail()/getDetailBulk() sudah menempelkan koleksi
+     * stok LIVE per unit (`->stock`, lihat ProductVariant::getProductVariantBulk()/
+     * Supplies::getSuppliesBulk()) -- pakai itu, bukan string yang tersimpan, TAPI HANYA untuk
+     * dokumen yang belum diputuskan (status masih 1/menunggu). Snapshot dokumen yang sudah
+     * disetujui/ditolak adalah catatan historis yang sengaja dibekukan (lihat accStockOpname() --
+     * dibekukan ke nilai sebenarnya saat itu terjadi) dan TIDAK BOLEH dihitung ulang live, atau
+     * dokumen yang sudah disetujui akan selalu terlihat "tidak ada selisih" selamanya setelahnya.
+     */
+    private function refreshLiveSystemQty($detail, string $realKey, string $systemKey, string $selisihKey, string $stockQtyKey)
+    {
+        foreach ($detail as $item) {
+            $liveByUnit = [];
+            foreach ($item->stock ?? [] as $s) {
+                $liveByUnit[$s->unit_short_name] = (int) $s->{$stockQtyKey};
+            }
+            if (empty($liveByUnit)) {
+                continue;
+            }
+
+            $selisihByUnit = [];
+            foreach ($liveByUnit as $unitName => $systemQty) {
+                $realQty = $this->getQty($item->{$realKey} ?? '', $unitName);
+                $selisihByUnit[$unitName] = $realQty - $systemQty;
+            }
+
+            $item->{$systemKey} = $this->buildQtyString($liveByUnit);
+            $item->{$selisihKey} = $this->buildQtyString($selisihByUnit);
+        }
+
+        return $detail;
+    }
+
     function getDetailStockOpname(Request $req)
     {
         $data = StockOpnameDetail::getDetail($req->all());
@@ -282,10 +328,30 @@ class StockController extends Controller
             ]);
         }
 
+        // GitHub #53 follow-up: bekukan stod_system/stod_selisih ke nilai SEBENARNYA yang dipakai
+        // approval ini (bukan lagi nilai basi dari saat dokumen dibuat/diedit) -- ini jadi catatan
+        // historis permanen dokumen, mirror persis "before" yang sudah ditulis ke log_stocks di
+        // bawah, cuma sekarang juga disimpan balik ke stock_opname_details.
+        $detailRows = StockOpnameDetail::where('sto_id', $sto->sto_id)
+            ->where('status', 1)
+            ->get()
+            ->keyBy('product_variant_id');
+        $allUnitIds = collect($stod)
+            ->flatMap(fn ($v) => collect($v['units'] ?? [])->pluck('unit_id'))
+            ->filter()
+            ->unique()
+            ->values()
+            ->all();
+        $unitNames = $allUnitIds !== []
+            ? Unit::whereIn('unit_id', $allUnitIds)->pluck('unit_short_name', 'unit_id')
+            : collect();
+
         DB::beginTransaction();
         try {
         $produk_gagal = [];
         foreach ($stod as $key => $value) {
+            $liveSystemByUnit = [];
+            $realByUnit = [];
             foreach ($value['units'] as $u) {
                 $q = ProductStock::withoutGlobalScope('active_warehouse')
                     ->where('status', 1)
@@ -346,6 +412,21 @@ class StockController extends Controller
                     'unit_id' => $u['unit_id'],
                     'warehouse_id' => $wid > 0 ? $wid : null,
                 ]);
+
+                $unitName = $unitNames[$u['unit_id']] ?? ('unit#'.$u['unit_id']);
+                $liveSystemByUnit[$unitName] = (int) $oldQty;
+                $realByUnit[$unitName] = (int) $u['real_qty'];
+            }
+
+            $detailRow = $detailRows->get($value['product_variant_id']);
+            if ($detailRow && !empty($liveSystemByUnit)) {
+                $selisihByUnit = [];
+                foreach ($liveSystemByUnit as $unitName => $systemQty) {
+                    $selisihByUnit[$unitName] = ($realByUnit[$unitName] ?? 0) - $systemQty;
+                }
+                $detailRow->stod_system = $this->buildQtyString($liveSystemByUnit);
+                $detailRow->stod_selisih = $this->buildQtyString($selisihByUnit);
+                $detailRow->save();
             }
         }
 
@@ -397,6 +478,10 @@ class StockController extends Controller
             ->sortBy(fn($item) => strtolower((data_get($item, 'pr_name') ?? '') . '|' . (data_get($item, 'product_variant_name') ?? '')))
             ->values()
             ->all();
+
+        if ((int) $param['stockOpname']['status'] === 1) {
+            $this->refreshLiveSystemQty($param['detail'], 'stod_real', 'stod_system', 'stod_selisih', 'ps_stock');
+        }
 
         if ($param['stockOpname']['status'] == 1) $param['status'] = "Menunggu";
         else if ($param['stockOpname']['status'] == 2) $param['status'] = "Disetujui";
@@ -589,10 +674,28 @@ class StockController extends Controller
             ]);
         }
 
+        // GitHub #53 follow-up: mirrors accStockOpname() above -- bekukan stobd_system/
+        // stobd_selisih ke nilai sebenarnya yang dipakai approval ini.
+        $detailRows = StockOpnameDetailBahan::where('stob_id', $stob->stob_id)
+            ->where('status', 1)
+            ->get()
+            ->keyBy('supplies_id');
+        $allUnitIds = collect($stod)
+            ->flatMap(fn ($v) => collect($v['sp_units'] ?? [])->pluck('unit_id'))
+            ->filter()
+            ->unique()
+            ->values()
+            ->all();
+        $unitNames = $allUnitIds !== []
+            ? Unit::whereIn('unit_id', $allUnitIds)->pluck('unit_short_name', 'unit_id')
+            : collect();
+
         DB::beginTransaction();
         try {
         $bahan_gagal = [];
         foreach ($stod as $key => $value) {
+            $liveSystemByUnit = [];
+            $realByUnit = [];
             foreach ($value['sp_units'] as $u) {
                 $q = SuppliesStock::withoutGlobalScope('active_warehouse')
                     ->where('status', 1)
@@ -646,6 +749,21 @@ class StockController extends Controller
                     'unit_id' => $u['unit_id'],
                     'warehouse_id' => $wid > 0 ? $wid : null,
                 ]);
+
+                $unitName = $unitNames[$u['unit_id']] ?? ('unit#'.$u['unit_id']);
+                $liveSystemByUnit[$unitName] = (int) $oldQty;
+                $realByUnit[$unitName] = (int) $u['real_qty'];
+            }
+
+            $detailRow = $detailRows->get($value['supplies_id']);
+            if ($detailRow && !empty($liveSystemByUnit)) {
+                $selisihByUnit = [];
+                foreach ($liveSystemByUnit as $unitName => $systemQty) {
+                    $selisihByUnit[$unitName] = ($realByUnit[$unitName] ?? 0) - $systemQty;
+                }
+                $detailRow->stobd_system = $this->buildQtyString($liveSystemByUnit);
+                $detailRow->stobd_selisih = $this->buildQtyString($selisihByUnit);
+                $detailRow->save();
             }
         }
 
@@ -697,6 +815,10 @@ class StockController extends Controller
             ->sortBy(fn($item) => strtolower(data_get($item, 'supplies_name') ?? ''))
             ->values()
             ->all();
+
+        if ((int) $param['stockOpname']['status'] === 1) {
+            $this->refreshLiveSystemQty($param['detail'], 'stobd_real', 'stobd_system', 'stobd_selisih', 'ss_stock');
+        }
 
         if ($param['stockOpname']['status'] == 1) $param['status'] = "Menunggu";
         else if ($param['stockOpname']['status'] == 2) $param['status'] = "Disetujui";

--- a/app/Http/Middleware/LogDashboardActivity.php
+++ b/app/Http/Middleware/LogDashboardActivity.php
@@ -5,7 +5,9 @@ namespace App\Http\Middleware;
 use App\Models\DashboardChangeLog;
 use Closure;
 use Illuminate\Http\Request;
+use Illuminate\Http\Response as HttpResponse;
 use Illuminate\Support\Str;
+use Illuminate\View\View;
 use Symfony\Component\HttpFoundation\Response;
 
 class LogDashboardActivity
@@ -14,13 +16,24 @@ class LogDashboardActivity
     {
         $response = $next($request);
 
-        if (!$this->shouldLog($request, $response)) {
-            return $response;
+        if ($this->shouldLogChange($request, $response)) {
+            $this->logChange($request);
+        } elseif ($this->shouldLogOpen($request, $response)) {
+            // GitHub #53: "jam dia buka modul atau menu apapun" — traceability tambahan di
+            // samping log mutasi di atas. Baris 'open' dicatat dengan activity_type terpisah
+            // supaya ReportController::dashboardChangeLogCounts() (KPI "Changelog" = antrean
+            // butuh ACC Direktur) tidak ikut menghitung page-view biasa sebagai item pending.
+            $this->logOpen($request);
         }
 
+        return $response;
+    }
+
+    private function logChange(Request $request): void
+    {
         $action = $this->detectAction($request);
         if ($action === null) {
-            return $response;
+            return;
         }
 
         $moduleKey = $this->detectModuleKey($request);
@@ -30,6 +43,7 @@ class LogDashboardActivity
 
         DashboardChangeLog::create([
             'module_key' => $moduleKey,
+            'activity_type' => 'change',
             'module_label' => $moduleLabel,
             'reference' => $reference,
             'what_changed' => ucfirst($action).' pada '.$moduleLabel,
@@ -43,11 +57,78 @@ class LogDashboardActivity
                 'action' => $action,
             ],
         ]);
-
-        return $response;
     }
 
-    private function shouldLog(Request $request, Response $response): bool
+    /**
+     * Catat "staf X membuka menu Y" + isi durasi baris 'open' sebelumnya milik staf yang sama.
+     * Ini estimasi pasif (jarak waktu ke request berikutnya), bukan sinyal tab-ditutup yang
+     * sesungguhnya — lihat catatan cap 4 jam di bawah.
+     */
+    private function logOpen(Request $request): void
+    {
+        $staffId = (int) (session('user')->staff_id ?? 0);
+        if ($staffId <= 0) {
+            return;
+        }
+
+        $moduleKey = $this->detectModuleKey($request);
+        $moduleLabel = $this->formatModuleLabel($moduleKey);
+        $now = now();
+
+        // Debounce: staf yang sama membuka modul yang sama berkali-kali (klik-klik/refresh)
+        // dalam jendela singkat tidak perlu jadi baris baru tiap kali.
+        $recentlyOpened = DashboardChangeLog::where('created_by', $staffId)
+            ->where('module_key', $moduleKey)
+            ->where('activity_type', 'open')
+            ->where('created_at', '>=', $now->copy()->subMinutes(15))
+            ->exists();
+        if ($recentlyOpened) {
+            return;
+        }
+
+        // Tutup baris 'open' terakhir milik staf ini (modul manapun) yang belum punya durasi —
+        // durasinya = jarak ke pembukaan menu berikutnya ini. Kalau jaraknya lebih dari 4 jam,
+        // anggap tab lama itu cuma ditinggal (idle/browser ditutup tanpa navigasi lagi) dan
+        // jangan diisi durasi yang menyesatkan.
+        $previous = DashboardChangeLog::where('created_by', $staffId)
+            ->where('activity_type', 'open')
+            ->whereNull('duration_seconds')
+            ->orderByDesc('created_at')
+            ->first();
+        if ($previous) {
+            // Explicit $absolute=true + cast to int: Carbon 3's diffInSeconds() defaults to a
+            // signed, sub-second-precision float (negative here since $previous is in the past).
+            $seconds = (int) $now->diffInSeconds($previous->created_at, true);
+            if ($seconds <= 4 * 3600) {
+                $previous->duration_seconds = $seconds;
+                $previous->save();
+            }
+        }
+
+        $staffName = session('user')->staff_name ?? '-';
+
+        DashboardChangeLog::create([
+            'module_key' => $moduleKey,
+            'activity_type' => 'open',
+            'module_label' => $moduleLabel,
+            'reference' => null,
+            'what_changed' => 'Membuka menu '.$moduleLabel,
+            'summary' => $staffName.' membuka '.$moduleLabel,
+            // Beda dari logChange(): request GET ini SENDIRI adalah halaman yang dibuka, jadi
+            // link-nya ke path saat ini -- bukan detectSafeUrl() (referer) yang dipakai untuk
+            // baris mutasi karena POST tidak punya halaman sendiri untuk dituju.
+            'url' => url(trim($request->path(), '/')),
+            'url_label' => 'Buka menu',
+            'created_by' => $staffId,
+            'meta' => [
+                'method' => $request->method(),
+                'path' => $request->path(),
+            ],
+            'duration_seconds' => null,
+        ]);
+    }
+
+    private function shouldLogChange(Request $request, Response $response): bool
     {
         if (!in_array(strtoupper($request->method()), ['POST', 'PUT', 'PATCH', 'DELETE'], true)) {
             return false;
@@ -64,6 +145,34 @@ class LogDashboardActivity
             return false;
         }
         if (in_array($path, ['dismissdashboardqueueitem', 'updatedashboardwidgets', 'updatepermission'], true)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Hanya GET yang benar-benar me-render sebuah halaman (bukan endpoint AJAX/data) yang
+     * dihitung sebagai "buka menu" — dibedakan lewat $response->original instanceof View,
+     * karena response()->json(...)/JsonResponse tidak punya properti itu sama sekali.
+     */
+    private function shouldLogOpen(Request $request, Response $response): bool
+    {
+        if (strtoupper($request->method()) !== 'GET') {
+            return false;
+        }
+        if ($response->getStatusCode() >= 400) {
+            return false;
+        }
+        if (!session()->has('user')) {
+            return false;
+        }
+        if (!($response instanceof HttpResponse) || !(($response->original ?? null) instanceof View)) {
+            return false;
+        }
+
+        $path = strtolower(trim($request->path(), '/'));
+        if (in_array($path, ['', 'up', 'login', 'logout'], true)) {
             return false;
         }
 
@@ -153,4 +262,3 @@ class LogDashboardActivity
         return url('admin');
     }
 }
-

--- a/app/Http/Middleware/LogDashboardActivity.php
+++ b/app/Http/Middleware/LogDashboardActivity.php
@@ -75,16 +75,14 @@ class LogDashboardActivity
         $moduleLabel = $this->formatModuleLabel($moduleKey);
         $now = now();
 
-        // Debounce: staf yang sama membuka modul yang sama berkali-kali (klik-klik/refresh)
-        // dalam jendela singkat tidak perlu jadi baris baru tiap kali.
-        $recentlyOpened = DashboardChangeLog::where('created_by', $staffId)
-            ->where('module_key', $moduleKey)
-            ->where('activity_type', 'open')
-            ->where('created_at', '>=', $now->copy()->subMinutes(15))
-            ->exists();
-        if ($recentlyOpened) {
-            return;
-        }
+        // Ditambahkan (2026-08-14), dihapus lagi (2026-08-15): sempat ada debounce 15 menit
+        // per staf+modul di sini supaya klik-klik/refresh cepat tidak jadi baris baru tiap
+        // kali. Ternyata itu menutupi bug yang jauh lebih parah -- `return` dini di sini
+        // melompati juga logika "tutup sesi 'open' sebelumnya" di bawah, bukan cuma logika
+        // insert baris baru. Jadi membuka ulang modul yang SAMA dalam 15 menit (mis. balik ke
+        // Dashboard yang baru saja dibuka) diam-diam gagal menutup modul LAIN yang sedang
+        // terbuka -- persis gejala yang dilaporkan user ("Dashboard nav click still not
+        // ending the previous page session"). Setiap kunjungan sekarang selalu dicatat.
 
         // Tutup baris 'open' terakhir milik staf ini (modul manapun) yang belum punya durasi —
         // durasinya = jarak ke pembukaan menu berikutnya ini. Kalau jaraknya lebih dari 4 jam,
@@ -171,8 +169,15 @@ class LogDashboardActivity
             return false;
         }
 
+        // Ditambahkan (2026-08-15): '' (root '/') SEBELUMNYA ikut dikecualikan di sini, disalin
+        // dari daftar exclude shouldLogChange() -- tapi routes/web.php me-render dashboard
+        // langsung di GET '/' (bukan redirect ke '/admin'), jadi itu JUSTRU rute yang paling
+        // sering dipakai user untuk "kembali ke dashboard". Mengecualikannya berarti baris 'open'
+        // sebelumnya (menu apa pun yang masih terbuka) tidak pernah ditutup saat user balik ke
+        // dashboard lewat '/' -- selalu nyangkut di "Sedang dibuka". session()->has('user') di
+        // atas sudah cukup menyaring pengunjung yang belum login, jadi '' aman untuk dicatat.
         $path = strtolower(trim($request->path(), '/'));
-        if (in_array($path, ['', 'up', 'login', 'logout'], true)) {
+        if (in_array($path, ['up', 'login', 'logout'], true)) {
             return false;
         }
 
@@ -208,8 +213,83 @@ class LogDashboardActivity
         return $seg !== '' ? $seg : 'dashboard';
     }
 
+    /**
+     * module_key adalah segmen pertama URL apa adanya (mis. "detailstockopname",
+     * "insertstockopname") -- Str::title() begitu saja menghasilkan label yang teknis dan
+     * membingungkan (user melaporkan: "Insertstockopname" dikira halaman untuk MEMBUKA form,
+     * padahal itu baris mutasi AJAX; halaman form aslinya berlabel "Detailstockopname"). Basis
+     * data ini menerjemahkan awalan aksi (insert/update/delete/detail/acc/dst.) + nama modul
+     * dasar jadi label Indonesia yang jelas, mis. "detailstockopname" -> "Input Stok Opname",
+     * "insertstockopname" -> "Tambah Stok Opname". module_key yang tidak dikenal tetap jatuh ke
+     * fallback Str::title() lama, jadi modul yang belum dipetakan tidak pernah rusak/kosong --
+     * cuma tetap teknis seperti sebelumnya. Hanya memengaruhi baris yang BARU dibuat setelah ini
+     * (module_label disimpan permanen saat insert, bukan dihitung ulang saat ditampilkan).
+     */
+    private const MODULE_BASE_LABELS = [
+        'dashboard' => 'Dashboard',
+        'admin' => 'Dashboard',
+        'stockopnamebahan' => 'Stok Opname Bahan Mentah',
+        'stockopname' => 'Stok Opname',
+        'stockalertsupplies' => 'Stock Alert Bahan',
+        'stockalert' => 'Stock Alert',
+        'customer' => 'Customer',
+        'supplier' => 'Supplier',
+        'product' => 'Produk',
+        'supplies' => 'Bahan Mentah',
+        'staff' => 'Staff',
+        'purchaseorder' => 'Purchase Order',
+        'salesorder' => 'Sales Order',
+        'production' => 'Produksi',
+        'productissues' => 'Retur Produk',
+        'returnsupplies' => 'Retur Bahan Mentah',
+        'role' => 'Role / Hak Akses',
+        'area' => 'Area',
+        'bank' => 'Bank',
+        'category' => 'Kategori',
+        'unit' => 'Satuan',
+        'variant' => 'Variasi',
+        'bom' => 'BOM (Resep Produksi)',
+        'cashadmin' => 'Kas Operasional',
+        'cashgudang' => 'Kas Gudang',
+        'casharmada' => 'Kas Armada',
+        'cashsales' => 'Kas Sales',
+        'tt' => 'Tanda Terima',
+        'sodelivery' => 'Pengiriman SO',
+        'podelivery' => 'Pengiriman PO',
+        'invoicepo' => 'Invoice PO',
+        'invoiceso' => 'Invoice SO',
+    ];
+
+    // Diperiksa berurutan sesuai array ini -- "accept" HARUS sebelum "acc", kalau tidak
+    // "acceptcashadmin" akan salah terpotong jadi "acc" + "eptcashadmin".
+    private const MODULE_ACTION_PREFIXES = [
+        'accept' => 'Terima',
+        'decline' => 'Tolak',
+        'insert' => 'Tambah',
+        'update' => 'Ubah',
+        'delete' => 'Hapus',
+        'detail' => 'Input',
+        'tolak' => 'Tolak',
+        'acc' => 'ACC',
+    ];
+
     private function formatModuleLabel(string $moduleKey): string
     {
+        $key = strtolower($moduleKey);
+
+        if (isset(self::MODULE_BASE_LABELS[$key])) {
+            return self::MODULE_BASE_LABELS[$key];
+        }
+
+        foreach (self::MODULE_ACTION_PREFIXES as $prefix => $verb) {
+            if (str_starts_with($key, $prefix)) {
+                $base = substr($key, strlen($prefix));
+                if (isset(self::MODULE_BASE_LABELS[$base])) {
+                    return $verb.' '.self::MODULE_BASE_LABELS[$base];
+                }
+            }
+        }
+
         return Str::title(str_replace('_', ' ', $moduleKey));
     }
 

--- a/app/Http/Middleware/checkLogin.php
+++ b/app/Http/Middleware/checkLogin.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Middleware;
 
+use App\Models\Role;
 use Closure;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Session;
@@ -16,9 +17,45 @@ class checkLogin
      */
     public function handle(Request $request, Closure $next)
     {
-        if(!Session::has('user')){ 
+        if(!Session::has('user')){
             return redirect('/login');
         }
+
+        $this->refreshRoleOnHardReload($request);
+
         return $next($request);
+    }
+
+    /**
+     * role_access dipatri ke session sejak login, jadi perubahan hak akses oleh admin
+     * baru kepakai kalau staff itu login ulang. Sebagai jalan pintas tanpa perlu logout,
+     * browser hard-refresh (Ctrl+Shift+R / Cmd+Shift+R) mengirim header Cache-Control/
+     * Pragma: no-cache yang tidak dikirim saat refresh biasa (F5, max-age=0) atau request
+     * AJAX biasa — jadi dipakai sebagai sinyal untuk menarik ulang role_access dari DB.
+     */
+    private function refreshRoleOnHardReload(Request $request): void
+    {
+        if ($request->ajax() || $request->wantsJson()) {
+            return;
+        }
+
+        $cacheControl = strtolower((string) $request->header('Cache-Control'));
+        $pragma = strtolower((string) $request->header('Pragma'));
+        $isHardReload = str_contains($cacheControl, 'no-cache') || str_contains($pragma, 'no-cache');
+        if (!$isHardReload) {
+            return;
+        }
+
+        $user = Session::get('user');
+        $roleId = (int) ($user->role_id ?? 0);
+        if ($roleId <= 0) {
+            return;
+        }
+
+        $role = Role::find($roleId);
+        if ($role) {
+            $user->role_access = $role->role_access;
+            Session::put('user', $user);
+        }
     }
 }

--- a/app/Models/DashboardChangeLog.php
+++ b/app/Models/DashboardChangeLog.php
@@ -10,6 +10,7 @@ class DashboardChangeLog extends Model
 
     protected $fillable = [
         'module_key',
+        'activity_type',
         'module_label',
         'reference',
         'what_changed',
@@ -18,6 +19,7 @@ class DashboardChangeLog extends Model
         'url_label',
         'created_by',
         'meta',
+        'duration_seconds',
     ];
 
     protected $casts = [

--- a/app/Models/StockOpnameDetail.php
+++ b/app/Models/StockOpnameDetail.php
@@ -50,6 +50,7 @@ class StockOpnameDetail extends Model
             $temp->stod_real = $value->stod_real;
             $temp->stod_selisih = $value->stod_selisih;
             $temp->stod_notes = $value->stod_notes;
+            $temp->stod_touched = $value->stod_touched;
             $temp->stod_id = $value->stod_id;
             $temp->sto_id = $value->sto_id;
             $result[$key] = $temp;
@@ -91,6 +92,7 @@ class StockOpnameDetail extends Model
             $temp->stod_real = $value->stod_real;
             $temp->stod_selisih = $value->stod_selisih;
             $temp->stod_notes = $value->stod_notes;
+            $temp->stod_touched = $value->stod_touched;
             $temp->stod_id = $value->stod_id;
             $temp->sto_id = $value->sto_id;
 
@@ -116,6 +118,7 @@ class StockOpnameDetail extends Model
         $t->stod_real = $data['stod_real'] ?? null;
         $t->stod_selisih = $data['stod_selisih'] ?? null;
         $t->stod_notes = $data['stod_notes'] ?? null;
+        $t->stod_touched = !empty($data['stod_touched']);
         $t->save();
 
         return $t->stod_id;
@@ -136,6 +139,7 @@ class StockOpnameDetail extends Model
         $t->stod_real = $data['stod_real'] ?? null;
         $t->stod_selisih = $data['stod_selisih'] ?? null;
         $t->stod_notes = $data['stod_notes'] ?? null;
+        $t->stod_touched = !empty($data['stod_touched']);
         $t->save();
 
         return $t->stod_id;

--- a/app/Models/StockOpnameDetailBahan.php
+++ b/app/Models/StockOpnameDetailBahan.php
@@ -49,6 +49,7 @@ class StockOpnameDetailBahan extends Model
             $temp->stobd_real = $value->stobd_real;
             $temp->stobd_selisih = $value->stobd_selisih;
             $temp->stobd_notes = $value->stobd_notes;
+            $temp->stobd_touched = $value->stobd_touched;
             $temp->stobd_id = $value->stobd_id;
             $temp->stob_id = $value->stob_id;
             $result[$key] = $temp;
@@ -83,6 +84,7 @@ class StockOpnameDetailBahan extends Model
             $temp->stobd_real    = $value->stobd_real;
             $temp->stobd_selisih = $value->stobd_selisih;
             $temp->stobd_notes   = $value->stobd_notes;
+            $temp->stobd_touched = $value->stobd_touched;
             $temp->stobd_id      = $value->stobd_id;
             $temp->stob_id       = $value->stob_id;
 
@@ -107,6 +109,7 @@ class StockOpnameDetailBahan extends Model
         $t->stobd_real = $data['stobd_real'] ?? null;
         $t->stobd_selisih = $data['stobd_selisih'] ?? null;
         $t->stobd_notes = $data['stobd_notes'] ?? null;
+        $t->stobd_touched = !empty($data['stobd_touched']);
         $t->save();
 
         return $t->stobd_id;
@@ -126,6 +129,7 @@ class StockOpnameDetailBahan extends Model
         $t->stobd_real = $data['stobd_real'] ?? null;
         $t->stobd_selisih = $data['stobd_selisih'] ?? null;
         $t->stobd_notes = $data['stobd_notes'] ?? null;
+        $t->stobd_touched = !empty($data['stobd_touched']);
         $t->save();
 
         return $t->stobd_id;

--- a/database/migrations/2026_08_14_010000_add_touched_to_stock_opname_details_tables.php
+++ b/database/migrations/2026_08_14_010000_add_touched_to_stock_opname_details_tables.php
@@ -1,0 +1,47 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * GitHub #53: PDF Stock Opname perlu membedakan baris yang benar-benar diisi staf (real-stock
+ * di-input manual) dari baris yang cuma ikut tersimpan dengan real qty auto = stok sistem karena
+ * dibiarkan kosong (lihat CreateStockOpname.js/CreateStockOpnameSupplies.js insertData()) --
+ * tanpa kolom ini keduanya sama-sama terlihat "cocok, tidak ada selisih" di PDF.
+ *
+ * Kolom ini murni tampilan/PDF -- accStockOpname(Bahan) tidak membaca stock_opname_details sama
+ * sekali (lihat cdocs/docs/flows/stock-opname/FLOW.md), jadi tidak menyentuh logika approval/stok.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasColumn('stock_opname_details', 'stod_touched')) {
+            Schema::table('stock_opname_details', function (Blueprint $table) {
+                $table->boolean('stod_touched')->default(false)->after('stod_notes');
+            });
+        }
+
+        if (! Schema::hasColumn('stock_opname_detail_bahans', 'stobd_touched')) {
+            Schema::table('stock_opname_detail_bahans', function (Blueprint $table) {
+                $table->boolean('stobd_touched')->default(false)->after('stobd_notes');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        if (Schema::hasColumn('stock_opname_details', 'stod_touched')) {
+            Schema::table('stock_opname_details', function (Blueprint $table) {
+                $table->dropColumn('stod_touched');
+            });
+        }
+
+        if (Schema::hasColumn('stock_opname_detail_bahans', 'stobd_touched')) {
+            Schema::table('stock_opname_detail_bahans', function (Blueprint $table) {
+                $table->dropColumn('stobd_touched');
+            });
+        }
+    }
+};

--- a/database/migrations/2026_08_14_010100_add_activity_tracking_to_dashboard_change_logs_table.php
+++ b/database/migrations/2026_08_14_010100_add_activity_tracking_to_dashboard_change_logs_table.php
@@ -1,0 +1,47 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * GitHub #53: dashboard Changelog perlu mencatat kapan staf membuka sebuah menu dan berapa lama,
+ * bukan cuma mutasi data (lihat LogDashboardActivity). `activity_type` membedakan baris "open"
+ * (menu dibuka) dari baris "change" (mutasi data, perilaku lama) SUPAYA
+ * ReportController::dashboardChangeLogCounts() -- yang menghitung SEMUA baris dashboard_change_logs
+ * di periode sebagai "menunggu ACC Direktur" -- tidak ikut menghitung page-view biasa.
+ * `duration_seconds` diisi belakangan (saat request berikutnya dari staf yang sama terdeteksi),
+ * jadi harus nullable.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasColumn('dashboard_change_logs', 'activity_type')) {
+            Schema::table('dashboard_change_logs', function (Blueprint $table) {
+                $table->string('activity_type', 20)->default('change')->after('module_key');
+            });
+        }
+
+        if (! Schema::hasColumn('dashboard_change_logs', 'duration_seconds')) {
+            Schema::table('dashboard_change_logs', function (Blueprint $table) {
+                $table->unsignedInteger('duration_seconds')->nullable()->after('meta');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        if (Schema::hasColumn('dashboard_change_logs', 'duration_seconds')) {
+            Schema::table('dashboard_change_logs', function (Blueprint $table) {
+                $table->dropColumn('duration_seconds');
+            });
+        }
+
+        if (Schema::hasColumn('dashboard_change_logs', 'activity_type')) {
+            Schema::table('dashboard_change_logs', function (Blueprint $table) {
+                $table->dropColumn('activity_type');
+            });
+        }
+    }
+};

--- a/database/sql/2026_07_31_010000_add_is_draft_to_stock_opnames_table.sql
+++ b/database/sql/2026_07_31_010000_add_is_draft_to_stock_opnames_table.sql
@@ -1,0 +1,32 @@
+-- Migration: 2026_07_31_010000_add_is_draft_to_stock_opnames_table
+-- Idempotent (cek kolom dulu). Alternatif: php artisan migrate
+--
+-- BLOCKING pada deploy baru: StockOpname::insertStockOpname()/updateStockOpname()
+-- menulis is_draft tanpa Schema::hasColumn() guard -- tanpa kolom ini, SETIAP
+-- pembuatan Stock Opname (Produk) crash 500 ("Unknown column 'is_draft'"), bukan
+-- cuma alur draft-nya. Jalankan migration ini SEBELUM database dipakai.
+--
+-- Draft disimpan sebagai flag terpisah dari `status`, bukan nilai baru di
+-- kolomnya -- lihat migration aslinya di fase2/main untuk alasan lengkap.
+
+SET @db := DATABASE();
+
+SET @sql := IF(
+  (SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+   WHERE TABLE_SCHEMA = @db AND TABLE_NAME = 'stock_opnames' AND COLUMN_NAME = 'is_draft') = 0
+  AND (SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES
+   WHERE TABLE_SCHEMA = @db AND TABLE_NAME = 'stock_opnames') = 1,
+  'ALTER TABLE `stock_opnames`
+     ADD COLUMN `is_draft` TINYINT(1) NOT NULL DEFAULT 0 AFTER `status`',
+  'SELECT ''skip stock_opnames.is_draft'' AS info'
+);
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- Catat di migrations (supaya artisan migrate tidak bentrok)
+INSERT INTO `migrations` (`migration`, `batch`)
+SELECT '2026_07_31_010000_add_is_draft_to_stock_opnames_table',
+       (SELECT IFNULL(MAX(batch), 0) + 1 FROM migrations AS m)
+WHERE EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = @db AND TABLE_NAME = 'migrations')
+  AND NOT EXISTS (SELECT 1 FROM `migrations` WHERE `migration` = '2026_07_31_010000_add_is_draft_to_stock_opnames_table');
+
+SELECT '2026_07_31_010000_add_is_draft_to_stock_opnames_table OK' AS result;

--- a/database/sql/2026_07_31_020000_add_is_draft_to_stock_opname_bahans_table.sql
+++ b/database/sql/2026_07_31_020000_add_is_draft_to_stock_opname_bahans_table.sql
@@ -1,0 +1,33 @@
+-- Migration: 2026_07_31_020000_add_is_draft_to_stock_opname_bahans_table
+-- Idempotent (cek kolom dulu). Alternatif: php artisan migrate
+--
+-- BLOCKING pada deploy baru: StockOpnameBahan::insertStockOpnameBahan()/
+-- updateStockOpnameBahan() menulis is_draft tanpa Schema::hasColumn() guard --
+-- tanpa kolom ini, SETIAP pembuatan Stock Opname Bahan crash 500 ("Unknown
+-- column 'is_draft'"), bukan cuma alur draft-nya. Jalankan migration ini
+-- SEBELUM database dipakai.
+--
+-- Sama seperti add_is_draft_to_stock_opnames_table: flag terpisah dari
+-- `status`, bukan nilai baru di kolomnya.
+
+SET @db := DATABASE();
+
+SET @sql := IF(
+  (SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+   WHERE TABLE_SCHEMA = @db AND TABLE_NAME = 'stock_opname_bahans' AND COLUMN_NAME = 'is_draft') = 0
+  AND (SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES
+   WHERE TABLE_SCHEMA = @db AND TABLE_NAME = 'stock_opname_bahans') = 1,
+  'ALTER TABLE `stock_opname_bahans`
+     ADD COLUMN `is_draft` TINYINT(1) NOT NULL DEFAULT 0 AFTER `status`',
+  'SELECT ''skip stock_opname_bahans.is_draft'' AS info'
+);
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- Catat di migrations (supaya artisan migrate tidak bentrok)
+INSERT INTO `migrations` (`migration`, `batch`)
+SELECT '2026_07_31_020000_add_is_draft_to_stock_opname_bahans_table',
+       (SELECT IFNULL(MAX(batch), 0) + 1 FROM migrations AS m)
+WHERE EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = @db AND TABLE_NAME = 'migrations')
+  AND NOT EXISTS (SELECT 1 FROM `migrations` WHERE `migration` = '2026_07_31_020000_add_is_draft_to_stock_opname_bahans_table');
+
+SELECT '2026_07_31_020000_add_is_draft_to_stock_opname_bahans_table OK' AS result;

--- a/public/Custom_js/Backoffice/Area/Area.js
+++ b/public/Custom_js/Backoffice/Area/Area.js
@@ -77,6 +77,7 @@
                 feather.replace(); // Biar icon feather muncul lagi
             },
             error: function (err) {
+                if (handlePermissionError(err)) return;
                 console.error("Gagal load wilayah:", err);
             }
         });
@@ -125,7 +126,8 @@
                 afterInsert();
             },
             error:function(e){
-                ResetLoadingButton('.btn-save', mode == 1?"Tambah Wilayah" : "Update Wilayah"); 
+                ResetLoadingButton('.btn-save', mode == 1?"Tambah Wilayah" : "Update Wilayah");
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });
@@ -178,6 +180,7 @@
                 
             },
             error:function(e){
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });

--- a/public/Custom_js/Backoffice/Customers/Customer.js
+++ b/public/Custom_js/Backoffice/Customers/Customer.js
@@ -97,6 +97,7 @@
                 $('#tableCustomer-wrap').removeClass('dt-pending');
             },
             error: function (err) {
+                if (handlePermissionError(err)) return;
                 console.error("Gagal load:", err);
                 $('#tableCustomer-wrap').removeClass('dt-pending');
             }
@@ -125,6 +126,7 @@
                 
             },
             error:function(e){
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });

--- a/public/Custom_js/Backoffice/Customers/Sales_Order.js
+++ b/public/Custom_js/Backoffice/Customers/Sales_Order.js
@@ -114,6 +114,7 @@ function loadSalesOrderWithItems(soId, onSuccess, onError) {
             }
         },
         error: function (err) {
+            if (handlePermissionError(err)) return;
             console.error("Gagal load detail SO:", err);
             if (typeof onError === "function") {
                 onError(err);
@@ -477,7 +478,8 @@ function doScanAddSo() {
 
             $("#so_scan_barcode").val("").focus();
         },
-        error: function () {
+        error: function (xhr) {
+            if (handlePermissionError(xhr)) return;
             toastr.error("", "Gagal mencari produk");
             $("#so_scan_barcode").val("").focus();
         },
@@ -695,6 +697,7 @@ function salesOrderAjax(data, callback) {
         },
         error: function (err) {
             if (err && err.statusText === "abort") return;
+            if (handlePermissionError(err)) return;
             console.error("Gagal load so:", err);
             callback({
                 draw: data.draw,
@@ -1337,6 +1340,7 @@ $(document).on("click", ".btn-save", function () {
                 ".btn-save",
                 mode == 1 ? "Tambah Pengiriman" : "Update Pengiriman",
             );
+            if (handlePermissionError(e)) return;
             console.log(e);
         },
     });
@@ -1501,6 +1505,7 @@ $(document).on("click", "#btn-delete-sales", function () {
             );
         },
         error: function (e) {
+            if (handlePermissionError(e)) return;
             console.log(e);
         },
     });
@@ -1559,38 +1564,21 @@ $(document).on("click", "#btn-accept-so", function () {
                         $(".modal").modal("hide");
                         refreshSalesOrder();
                     }
-                    return false;
-                } else {
-                    ResetLoadingButton(".btn-konfirmasi", "Konfirmasi");
-                    var fallbackNames =
-                        $("#btn-accept-so").data("fallback_products") || [];
-                    var stockText = normalizeProductErrorMessage(
-                        e,
-                        fallbackNames,
-                    );
-                    notifikasi(
-                        "error",
-                        "Gagal Update",
-                        "Stock Product yang tidak mencukupi : " + stockText,
-                    );
                 }
             } else {
                 ResetLoadingButton(".btn-konfirmasi", "Konfirmasi");
                 refreshSalesOrder();
                 $(".modal").modal("hide");
-                notifikasi(
-                    "success",
-                    "Berhasil Terima",
-                    "Berhasil Terima Pengiriman",
-                );
+                notifikasi("success", "Berhasil Terima", "Berhasil Terima Pengiriman");
             }
         },
         error: function (e) {
-            console.log(e);
             ResetLoadingButton(".btn-konfirmasi", "Konfirmasi");
-        },
-    });
-});
+            if (handlePermissionError(e)) return;
+            console.log(e);
+        }
+        });
+    })
 
 function formatStockRecommendations(res) {
     var parts = [];
@@ -1780,8 +1768,9 @@ $(document).on("click", "#btn-decline-so", function () {
             notifikasi("success", "Berhasil Tolak", "Berhasil Tolak Pengajuan");
         },
         error: function (e) {
-            console.log(e);
             ResetLoadingButton(".btn-konfirmasi", "Konfirmasi");
+            if (handlePermissionError(e)) return;
+            console.log(e);
         },
     });
 });

--- a/public/Custom_js/Backoffice/Customers/Sales_Order_detail.js
+++ b/public/Custom_js/Backoffice/Customers/Sales_Order_detail.js
@@ -261,6 +261,7 @@
                 feather.replace(); // Biar icon feather muncul lagi
             },
             error: function (err) {
+                if (handlePermissionError(err)) return;
                 console.error("Gagal load:", err);
             }
         });
@@ -312,6 +313,7 @@
                 feather.replace(); // Biar icon feather muncul lagi
             },
             error: function (err) {
+                if (handlePermissionError(err)) return;
                 console.error("Gagal load:", err);
             }
         });
@@ -499,6 +501,7 @@
             },
             error:function(e){
                 ResetLoadingButton(".save-qty", 'Simpan perubahan');
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });
@@ -582,6 +585,7 @@
             },
             error:function(e){
                 ResetLoadingButton(".btn-save-delivery", 'Simpan perubahan');
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });
@@ -640,6 +644,7 @@
             },
             error:function(e){
                 ResetLoadingButton(".btn-approve", 'Setujui');
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });
@@ -698,6 +703,7 @@
             },
             error:function(e){
                 ResetLoadingButton(".btn-decline", 'Tolak');
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });
@@ -772,6 +778,7 @@
                 
             },
             error:function(e){
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });
@@ -880,6 +887,7 @@
             },
             error: function (e) {
                 ResetLoadingButton('.btn-save-invoice', 'Simpan Perubahan');
+                if (handlePermissionError(e)) return;
                 console.log(e);
             },
         });
@@ -931,6 +939,7 @@
                 notifikasi('success', "Berhasil Delete", "Berhasil delete invoice");
             },
             error:function(e){
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });
@@ -955,6 +964,7 @@
             },
             error:function(e){
                 ResetLoadingButton(btn, 'Tolak');
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });
@@ -987,7 +997,8 @@
             },
             error:function(e){
                  ResetLoadingButton(btn, 'Setujui');
-                console.log(e);
+                 if (handlePermissionError(e)) return;
+                 console.log(e);
             }
         });
     });

--- a/public/Custom_js/Backoffice/Customers/insertCustomer.js
+++ b/public/Custom_js/Backoffice/Customers/insertCustomer.js
@@ -60,6 +60,7 @@ $(document).on("click", ".btn-save", function () {
         error: function (xhr) {
             // Re-enable button
             ResetLoadingButton(".btn-save", mode == 1?"Tambah Armada" : "Update Armada");
+            if (handlePermissionError(xhr)) return;
             console.log(xhr);
         },
     });

--- a/public/Custom_js/Backoffice/Dashboard/Dashboard-Admin.js
+++ b/public/Custom_js/Backoffice/Dashboard/Dashboard-Admin.js
@@ -203,10 +203,16 @@
     function renderApprovalTable(tbodySelector, rows, emptyMsg) {
         var $tb = $(tbodySelector);
         if (!$tb.length) return;
+        // GitHub #53: hanya panel Changelog yang dapat kolom User + Jam/Durasi -- Confirmation
+        // dan Revision tetap 4 kolom seperti sebelumnya.
+        var isChangelog = tbodySelector === "#dash_changelog_body";
+        var colspan = isChangelog ? 6 : 4;
         $tb.empty();
         if (!rows || !rows.length) {
             $tb.append(
-                '<tr><td colspan="4" class="text-center text-muted">' +
+                '<tr><td colspan="' +
+                    colspan +
+                    '" class="text-center text-muted">' +
                     escHtml(emptyMsg) +
                     "</td></tr>"
             );
@@ -222,6 +228,16 @@
                       ? "revision"
                       : "changelog";
             var queueKey = String(r.queue_key || "");
+            var extraCols = isChangelog
+                ? "<td>" +
+                  escHtml(r.staff_name || "-") +
+                  "</td><td>" +
+                  escHtml(r.opened_at || "-") +
+                  (r.duration_label
+                      ? " · " + escHtml(r.duration_label)
+                      : "") +
+                  "</td>"
+                : "";
             $tb.append(
                 "<tr><td>" +
                     escHtml(r.module_label || "-") +
@@ -231,7 +247,9 @@
                     escHtml(r.what_changed || r.summary || "") +
                     '">' +
                     escHtml(r.what_changed || r.summary || "-") +
-                    '</span></td><td class="dash-col-actions">' +
+                    "</span></td>" +
+                    extraCols +
+                    '<td class="dash-col-actions">' +
                     '<div class="d-inline-flex gap-1 align-items-center">' +
                     '<a class="btn btn-sm dash-log-btn px-2" title="Buka" href="' +
                     url.replace(/"/g, "&quot;") +

--- a/public/Custom_js/Backoffice/Dashboard/Dashboard-Admin.js
+++ b/public/Custom_js/Backoffice/Dashboard/Dashboard-Admin.js
@@ -297,7 +297,8 @@
             success: function () {
                 if (typeof done === "function") done(true);
             },
-            error: function () {
+            error: function (xhr) {
+                if (handlePermissionError(xhr)) return;
                 if (typeof done === "function") done(false);
             },
         });
@@ -753,7 +754,8 @@
                 tryBrowserNotifyBahan(lastBahanPack);
                 renderChart(data);
             },
-            error: function () {
+            error: function (xhr) {
+                if (handlePermissionError(xhr)) return;
                 $("#dash_filter_label").text("Gagal memuat dashboard.");
             },
         });

--- a/public/Custom_js/Backoffice/ExternalApi/ApplicationDetail.js
+++ b/public/Custom_js/Backoffice/ExternalApi/ApplicationDetail.js
@@ -87,6 +87,7 @@ function refreshExternalApiKey() {
             feather.replace();
         },
         error: function (err) {
+            if (handlePermissionError(err)) return;
             console.error("Gagal load API Key:", err);
         }
     });
@@ -147,6 +148,7 @@ $(document).on('click', '.btn_edit', function () {
             $('#add_external_api_key').modal("show");
         },
         error: function (err) {
+            if (handlePermissionError(err)) return;
             console.error("Gagal load API Key:", err);
         }
     });
@@ -211,9 +213,10 @@ $(document).on("click", ".btn-save-key", function () {
             refreshExternalApiKey();
         },
         error: function (err) {
+            ResetLoadingButton('.btn-save-key', mode == 1 ? "Buat API Key" : "Update API Key");
+            if (handlePermissionError(err)) return;
             console.error("Gagal simpan API Key:", err);
             notifikasi('error', "Gagal", 'Terjadi kesalahan saat menyimpan');
-            ResetLoadingButton('.btn-save-key', mode == 1 ? "Buat API Key" : "Update API Key");
         }
     });
 });
@@ -263,6 +266,7 @@ $(document).on('click', '#btn-revoke-external-api-key', function () {
             notifikasi('success', "Berhasil Dicabut", "API Key sudah tidak berlaku");
         },
         error: function (err) {
+            if (handlePermissionError(err)) return;
             console.error("Gagal cabut API Key:", err);
             notifikasi('error', "Gagal", 'Terjadi kesalahan saat mencabut kunci');
         }
@@ -288,6 +292,7 @@ $(document).on('click', '#btn-delete-external-api-key', function () {
             notifikasi('success', "Berhasil Delete", "API Key berhasil dihapus");
         },
         error: function (err) {
+            if (handlePermissionError(err)) return;
             console.error("Gagal delete API Key:", err);
             notifikasi('error', "Gagal", 'Terjadi kesalahan saat menghapus');
         }

--- a/public/Custom_js/Backoffice/ExternalApi/Applications.js
+++ b/public/Custom_js/Backoffice/ExternalApi/Applications.js
@@ -91,6 +91,7 @@ function refreshExternalApplication() {
             feather.replace();
         },
         error: function (err) {
+            if (handlePermissionError(err)) return;
             console.error("Gagal load Aplikasi Eksternal:", err);
         }
     });
@@ -152,6 +153,7 @@ $(document).on('click', '.btn_edit', function () {
             $('#add_external_application').modal("show");
         },
         error: function (err) {
+            if (handlePermissionError(err)) return;
             console.error("Gagal load Aplikasi Eksternal:", err);
         }
     });
@@ -208,9 +210,10 @@ $(document).on("click", ".btn-save", function () {
             ResetLoadingButton('.btn-save', mode == 1 ? "Tambah Aplikasi" : "Update Aplikasi");
         },
         error: function (err) {
+            ResetLoadingButton('.btn-save', mode == 1 ? "Tambah Aplikasi" : "Update Aplikasi");
+            if (handlePermissionError(err)) return;
             console.error("Gagal simpan Aplikasi Eksternal:", err);
             notifikasi('error', "Gagal", 'Terjadi kesalahan saat menyimpan');
-            ResetLoadingButton('.btn-save', mode == 1 ? "Tambah Aplikasi" : "Update Aplikasi");
         }
     });
 });
@@ -237,6 +240,7 @@ $(document).on('click', '#btn-delete-external-application', function () {
             notifikasi('success', "Berhasil Delete", "Aplikasi eksternal berhasil dihapus");
         },
         error: function (err) {
+            if (handlePermissionError(err)) return;
             console.error("Gagal delete Aplikasi Eksternal:", err);
             notifikasi('error', "Gagal", 'Terjadi kesalahan saat menghapus');
         }

--- a/public/Custom_js/Backoffice/ExternalApi/Logs.js
+++ b/public/Custom_js/Backoffice/ExternalApi/Logs.js
@@ -78,6 +78,7 @@ function refreshExternalApiLog() {
             feather.replace();
         },
         error: function (err) {
+            if (handlePermissionError(err)) return;
             console.error("Gagal load Log API Eksternal:", err);
         }
     });
@@ -94,6 +95,7 @@ function refreshRingkasan() {
             $('#statNewest').html(e.newest_at ? moment(e.newest_at).format('D MMM YYYY HH:mm') : '-');
         },
         error: function (err) {
+            if (handlePermissionError(err)) return;
             console.error("Gagal load ringkasan log:", err);
         }
     });
@@ -148,6 +150,7 @@ $(document).on('change', '#toggleLogging', function () {
                 : "Pencatatan permintaan dinonaktifkan");
         },
         error: function (err) {
+            if (handlePermissionError(err)) return;
             console.error("Gagal ubah status pencatatan:", err);
             notifikasi('error', "Gagal", 'Terjadi kesalahan saat mengubah status pencatatan');
             $('#toggleLogging').prop('checked', !enabled);
@@ -230,9 +233,10 @@ $(document).on('click', '.btn-confirm-cleanup', function () {
             notifikasi('success', "Berhasil", e.message);
         },
         error: function (err) {
+            ResetLoadingButton('.btn-confirm-cleanup', "Hapus Log");
+            if (handlePermissionError(err)) return;
             console.error("Gagal bersihkan log:", err);
             notifikasi('error', "Gagal", 'Terjadi kesalahan saat membersihkan log');
-            ResetLoadingButton('.btn-confirm-cleanup', "Hapus Log");
         }
     });
 });

--- a/public/Custom_js/Backoffice/Inventory/CreateStockOpname.js
+++ b/public/Custom_js/Backoffice/Inventory/CreateStockOpname.js
@@ -214,7 +214,8 @@ function refreshStockOpname(callback) {
             if (typeof callback === "function") callback();
         },
         error: function (e) {
-            if (reqId !== stockOpnameReqSeq) return; // request lama yang dibatalkan (abort)
+            if (handlePermissionError(e)) return;
+            if (reqId !== stockOpnameReqSeq) return;
             console.log(e);
         },
     });
@@ -376,8 +377,9 @@ $(document).on("click", ".btn-ajukan", function () {
                         window.location.href = "/stockOpname";
                     },
                     error: function (e) {
-                        console.log(e);
                         ResetLoadingButton(".btn-ajukan", "Ajukan");
+                        if (handlePermissionError(e)) return;
+                        console.log(e);
                     },
                 });
             },
@@ -412,8 +414,9 @@ $(document).on("click", "#btn-delete-draft-confirm", function () {
             window.location.href = "/stockOpname";
         },
         error: function (e) {
-            console.log(e);
             ResetLoadingButton(".btn-konfirmasi", "Delete");
+            if (handlePermissionError(e)) return;
+            console.log(e);
         },
     });
 });
@@ -579,8 +582,9 @@ function insertData(options) {
             window.location.href = "/stockOpname";
         },
         error: function (e) {
-            toastr.success("", "Terjadi Kesalahan Saat Tambah Stok Opname");
             ResetLoadingButton(btnSelector, doneText);
+            if (handlePermissionError(e)) return;
+            toastr.success("", "Terjadi Kesalahan Saat Tambah Stok Opname");
             console.log(e);
         },
     });
@@ -686,8 +690,9 @@ $(document).on("click", "#btn-acc-sto", function () {
             window.open("/stockOpname", "_self");
         },
         error: function (e) {
-            console.log(e);
             ResetLoadingButton(".btn-konfirmasi", "Konfirmasi");
+            if (handlePermissionError(e)) return;
+            console.log(e);
         },
     });
 });
@@ -721,8 +726,9 @@ $(document).on("click", "#btn-tolak-sto", function () {
             window.open("/stockOpname", "_self");
         },
         error: function (e) {
-            console.log(e);
             ResetLoadingButton(".btn-konfirmasi", "Delete");
+            if (handlePermissionError(e)) return;
+            console.log(e);
         },
     });
 });

--- a/public/Custom_js/Backoffice/Inventory/CreateStockOpname.js
+++ b/public/Custom_js/Backoffice/Inventory/CreateStockOpname.js
@@ -537,6 +537,10 @@ function insertData(options) {
         item.stod_system = systemArr.join(", ");
         item.stod_real = realArr.join(", ");
         item.stod_selisih = selisihArr.join(", ");
+        // GitHub #53: baris ini pernah benar-benar diisi user, dibedakan dari yang cuma
+        // ikut tersimpan dengan real qty auto = stok sistem karena dibiarkan kosong --
+        // dipakai PDF (Backoffice/PDF/Opname.blade.php) untuk highlight.
+        item.stod_touched = hasValue ? 1 : 0;
 
         productSubmit.push(item);
     });

--- a/public/Custom_js/Backoffice/Inventory/CreateStockOpnameSupplies.js
+++ b/public/Custom_js/Backoffice/Inventory/CreateStockOpnameSupplies.js
@@ -243,7 +243,8 @@ function refreshStockOpname(callback) {
             supplies = e;
         },
         error: function (e) {
-            if (reqId !== stockOpnameReqSeq) return; // request lama yang dibatalkan (abort)
+            if (handlePermissionError(e)) return;
+            if (reqId !== stockOpnameReqSeq) return;
             console.log(e);
         },
     });
@@ -440,8 +441,9 @@ $(document).on("click", ".btn-ajukan", function () {
                         window.location.href = "/stockOpnameBahan";
                     },
                     error: function (e) {
-                        console.log(e);
                         ResetLoadingButton(".btn-ajukan", "Ajukan");
+                        if (handlePermissionError(e)) return;
+                        console.log(e);
                     },
                 });
             },
@@ -476,8 +478,9 @@ $(document).on("click", "#btn-delete-draft-confirm", function () {
             window.location.href = "/stockOpnameBahan";
         },
         error: function (e) {
-            console.log(e);
             ResetLoadingButton(".btn-konfirmasi", "Delete");
+            if (handlePermissionError(e)) return;
+            console.log(e);
         },
     });
 });
@@ -642,8 +645,9 @@ function insertData(options) {
             window.location.href = "/stockOpnameBahan";
         },
         error: function (e) {
-            toastr.success("", "Terjadi Kesalahan Saat Tambah Stok Opname");
             ResetLoadingButton(btnSelector, doneText);
+            if (handlePermissionError(e)) return;
+            toastr.success("", "Terjadi Kesalahan Saat Tambah Stok Opname");
             console.log(e);
         },
     });
@@ -748,8 +752,9 @@ $(document).on("click", "#btn-acc-stob", function () {
             window.open("/stockOpnameBahan", "_self");
         },
         error: function (e) {
-            console.log(e);
             ResetLoadingButton(".btn-konfirmasi", "Konfirmasi");
+            if (handlePermissionError(e)) return;
+            console.log(e);
         },
     });
 });
@@ -784,6 +789,7 @@ $(document).on("click", "#btn-tolak-stob", function () {
         },
         error: function (e) {
             ResetLoadingButton(".btn-konfirmasi", "Delete");
+            if (handlePermissionError(e)) return;
             console.log(e);
         },
     });

--- a/public/Custom_js/Backoffice/Inventory/CreateStockOpnameSupplies.js
+++ b/public/Custom_js/Backoffice/Inventory/CreateStockOpnameSupplies.js
@@ -600,6 +600,10 @@ function insertData(options) {
         item.stobd_system = systemArr.join(", ");
         item.stobd_real = realArr.join(", ");
         item.stobd_selisih = selisihArr.join(", ");
+        // GitHub #53: baris ini pernah benar-benar diisi user, dibedakan dari yang cuma
+        // ikut tersimpan dengan real qty auto = stok sistem karena dibiarkan kosong --
+        // dipakai PDF (Backoffice/PDF/OpnameBahan.blade.php) untuk highlight.
+        item.stobd_touched = hasValue ? 1 : 0;
 
         suppliesSubmit.push(item);
     });

--- a/public/Custom_js/Backoffice/Inventory/Manage_Stock.js
+++ b/public/Custom_js/Backoffice/Inventory/Manage_Stock.js
@@ -180,6 +180,7 @@ function refreshManageStock(){
             feather.replace();
         },
         error: function (e) {
+            if (handlePermissionError(e)) return;
             console.log(e.responseText);
         },
     });
@@ -323,7 +324,8 @@ function insertData() {
             afterInsert();
         },
         error:function(e){
-            $('.row-input input').attr("disabled",false); // reset input
+            if (handlePermissionError(e)) return;
+            $('.row-input input').attr("disabled",false);
             $('#input_barcode').val("");
             $('#input_barcode').trigger("focus");
             console.log(e);

--- a/public/Custom_js/Backoffice/Inventory/Product_Issues.js
+++ b/public/Custom_js/Backoffice/Inventory/Product_Issues.js
@@ -241,6 +241,7 @@
                 openProductIssueFromDashboardLink();
             },
             error: function (err) {
+                if (handlePermissionError(err)) return;
                 console.error("Gagal load:", err);
             }
         });
@@ -501,8 +502,9 @@ function loadPiType() {
                 afterInsert();
             },
             error: function (e) {
-                console.log(e);
-                ResetLoadingButton('.btn-save', mode == 1?"Tambah Produk" : "Update Produk"); 
+                ResetLoadingButton('.btn-save', mode == 1?"Tambah Produk" : "Update Produk");
+                if (handlePermissionError(e)) return;
+                console.log(e); 
             },
         });
     });
@@ -887,8 +889,9 @@ $(document).on("click", ".btn_view", function () {
                 }                
             },
             error:function(e){
-                console.log(e);
                 ResetLoadingButton('.btn-konfirmasi', "Konfirmasi");
+                if (handlePermissionError(e)) return;
+                console.log(e);
             }
         });
     })
@@ -923,8 +926,9 @@ $(document).on("click", ".btn_view", function () {
                 
             },
             error:function(e){
-                console.log(e);
                 ResetLoadingButton('.btn-konfirmasi', "Konfirmasi");
+                if (handlePermissionError(e)) return;
+                console.log(e);
             }
         });
     })
@@ -1011,8 +1015,9 @@ $(document).on("click", "#btn-delete-issues", function () {
             }
         },
         error: function (e) {
-            console.log(e);
             ResetLoadingButton(".btn-konfirmasi", "Delete");
+            if (handlePermissionError(e)) return;
+            console.log(e);
         },
     });
 });

--- a/public/Custom_js/Backoffice/Inventory/Stock_Alert.js
+++ b/public/Custom_js/Backoffice/Inventory/Stock_Alert.js
@@ -153,6 +153,7 @@
                 feather.replace(); // Biar icon feather muncul lagi
             },
             error: function (err) {
+                if (handlePermissionError(err)) return;
                 console.error("Gagal load:", err);
             }
         });

--- a/public/Custom_js/Backoffice/Inventory/Stock_Alert_Supplies.js
+++ b/public/Custom_js/Backoffice/Inventory/Stock_Alert_Supplies.js
@@ -150,6 +150,7 @@
                 feather.replace(); // Biar icon feather muncul lagi
             },
             error: function (err) {
+                if (handlePermissionError(err)) return;
                 console.error("Gagal load:", err);
             }
         });

--- a/public/Custom_js/Backoffice/Inventory/Stock_Opname.js
+++ b/public/Custom_js/Backoffice/Inventory/Stock_Opname.js
@@ -92,6 +92,7 @@
                 feather.replace(); // Biar icon feather muncul lagi
             },
             error: function (err) {
+                if (handlePermissionError(err)) return;
                 console.error("Gagal load:", err);
             }
         });
@@ -123,6 +124,7 @@ function loadCategory() {
             }
         },
         error: function (e) {
+            if (handlePermissionError(e)) return;
             console.log(e);
         },
     });

--- a/public/Custom_js/Backoffice/Inventory/Stock_Opname_Bahan.js
+++ b/public/Custom_js/Backoffice/Inventory/Stock_Opname_Bahan.js
@@ -92,6 +92,7 @@
                 feather.replace(); // Biar icon feather muncul lagi
             },
             error: function (err) {
+                if (handlePermissionError(err)) return;
                 console.error("Gagal load:", err);
             }
         });

--- a/public/Custom_js/Backoffice/Inventory/Stock_Product.js
+++ b/public/Custom_js/Backoffice/Inventory/Stock_Product.js
@@ -71,6 +71,7 @@
             },
             error: function (err) {
                 if (err && err.statusText === "abort") return;
+                if (handlePermissionError(err)) return;
                 console.error("Gagal load:", err);
                 callback({
                     draw: data.draw,
@@ -301,6 +302,7 @@
                 }
             },
             error: function (xhr) {
+                if (handlePermissionError(xhr)) return;
                 var msg =
                     (xhr.responseJSON && xhr.responseJSON.message) || "Gagal menyimpan";
                 if (typeof toastr !== "undefined") toastr.error("", msg);
@@ -356,6 +358,7 @@
                 }
             },
             error: function (xhr) {
+                if (handlePermissionError(xhr)) return;
                 var msg =
                     (xhr.responseJSON && xhr.responseJSON.message) || "Gagal transfer";
                 if (typeof toastr !== "undefined") toastr.error("", msg);
@@ -755,6 +758,7 @@
                 if (xhr.statusText === "abort") return;
                 logLazy.loading = false;
                 setLogFooterLoading(false);
+                if (handlePermissionError(xhr)) return;
                 console.error("Gagal load:", xhr);
                 if (!append) {
                     setHistoryLogLoading(false);

--- a/public/Custom_js/Backoffice/Inventory/Stock_Supplies.js
+++ b/public/Custom_js/Backoffice/Inventory/Stock_Supplies.js
@@ -44,6 +44,7 @@
                 callback(json);
             },
             error: function (err) {
+                if (handlePermissionError(err)) return;
                 console.error("Gagal load:", err);
                 callback({
                     draw: data.draw,
@@ -351,6 +352,7 @@
                 if (xhr.statusText === "abort") return;
                 logLazy.loading = false;
                 setLogFooterLoading(false);
+                if (handlePermissionError(xhr)) return;
                 console.error("Gagal load:", xhr);
                 if (!append) {
                     setHistoryLogLoading(false);

--- a/public/Custom_js/Backoffice/Login.js
+++ b/public/Custom_js/Backoffice/Login.js
@@ -47,6 +47,7 @@ $(document).on("click", "#btn-login", function () {
         },
         error: function (xhr, status, error) {
             ResetLoadingButton("#btn-login", "Login");
+            if (handlePermissionError(xhr)) return;
             notifikasi("error", "Login Gagal", "");
         },
     });

--- a/public/Custom_js/Backoffice/Product/Barcode.js
+++ b/public/Custom_js/Backoffice/Product/Barcode.js
@@ -134,7 +134,8 @@
             success: function (rows) {
                 renderResults(rows || []);
             },
-            error: function () {
+            error: function (xhr) {
+                if (handlePermissionError(xhr)) return;
                 renderResults([]);
             },
             complete: function () {

--- a/public/Custom_js/Backoffice/Product/Category.js
+++ b/public/Custom_js/Backoffice/Product/Category.js
@@ -82,6 +82,7 @@
                 feather.replace(); // Biar icon feather muncul lagi
             },
             error: function (err) {
+                if (handlePermissionError(err)) return;
                 console.error("Gagal load kategori:", err);
             }
         });
@@ -130,6 +131,7 @@
             },
             error:function(e){
                 ResetLoadingButton('.btn-save', mode == 1?"Tambah Kategori" : "Update Kategori");
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });
@@ -181,6 +183,7 @@
                 
             },
             error:function(e){
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });

--- a/public/Custom_js/Backoffice/Product/Product.js
+++ b/public/Custom_js/Backoffice/Product/Product.js
@@ -93,6 +93,7 @@
                 notifikasi("success", "Berhasil Delete", "Berhasil delete produk");
             },
             error: function (e) {
+                if (handlePermissionError(e)) return;
                 console.log(e);
             },
         });

--- a/public/Custom_js/Backoffice/Product/Supplies.js
+++ b/public/Custom_js/Backoffice/Product/Supplies.js
@@ -156,6 +156,7 @@
                 feather.replace(); // Biar icon feather muncul lagi
             },
             error: function (err) {
+                if (handlePermissionError(err)) return;
                 console.error("Gagal load:", err);
             }
         });
@@ -253,7 +254,8 @@
                 }
             },
             error:function(e){
-                ResetLoadingButton('.btn-save', mode == 1?"Tambah Bahan Mentah" : "Update Bahan Mentah"); 
+                ResetLoadingButton('.btn-save', mode == 1?"Tambah Bahan Mentah" : "Update Bahan Mentah");
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });
@@ -382,6 +384,7 @@
                 
             },
             error:function(e){
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });

--- a/public/Custom_js/Backoffice/Product/Units.js
+++ b/public/Custom_js/Backoffice/Product/Units.js
@@ -86,6 +86,7 @@
                 feather.replace(); // Biar icon feather muncul lagi
             },
             error: function (err) {
+                if (handlePermissionError(err)) return;
                 console.error("Gagal load unit:", err);
             }
         });
@@ -134,7 +135,8 @@
                 afterInsert();
             },
             error:function(e){
-                ResetLoadingButton('.btn-save', mode == 1?"Tambah Satuan" : "Update Satuan"); 
+                ResetLoadingButton('.btn-save', mode == 1?"Tambah Satuan" : "Update Satuan");
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });
@@ -187,6 +189,7 @@
                 
             },
             error:function(e){
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });

--- a/public/Custom_js/Backoffice/Product/Variants.js
+++ b/public/Custom_js/Backoffice/Product/Variants.js
@@ -89,7 +89,8 @@
                 feather.replace();
             },
             error:function(e){
-                ResetLoadingButton('.btn-save', mode == 1?"Tambah Variasi" : "Update Variasi"); 
+                ResetLoadingButton('.btn-save', mode == 1?"Tambah Variasi" : "Update Variasi");
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });
@@ -139,7 +140,8 @@
                 afterInsert();
             },
             error:function(e){
-                ResetLoadingButton('.btn-save', mode == 1?"Tambah Variasi" : "Update Variasi"); 
+                ResetLoadingButton('.btn-save', mode == 1?"Tambah Variasi" : "Update Variasi");
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });
@@ -195,6 +197,7 @@
                 
             },
             error:function(e){
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });

--- a/public/Custom_js/Backoffice/Product/insertProduct.js
+++ b/public/Custom_js/Backoffice/Product/insertProduct.js
@@ -294,6 +294,7 @@ $(document).on("click",".btn-save",function(){
         },
         error:function(e){
             ResetLoadingButton(".btn-save", mode == 1?"Tambah Produk" : "Update Produk");
+            if (handlePermissionError(e)) return;
             console.log(e);
         }
     });

--- a/public/Custom_js/Backoffice/Production/Bom.js
+++ b/public/Custom_js/Backoffice/Production/Bom.js
@@ -168,6 +168,7 @@
                 feather.replace(); // Biar icon feather muncul lagi
             },
             error: function (err) {
+                if (handlePermissionError(err)) return;
                 console.error("Gagal load bom:", err);
             }
         });
@@ -243,7 +244,8 @@
                 ResetLoadingButton('.btn-save', mode == 1?"Tambah Resep" : "Update Resep");       
             },
             error:function(e){
-                ResetLoadingButton('.btn-save', mode == 1?"Tambah Resep" : "Update Resep"); 
+                ResetLoadingButton('.btn-save', mode == 1?"Tambah Resep" : "Update Resep");
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });
@@ -368,6 +370,7 @@
                 }
             },
             error: function (err) {
+                if (handlePermissionError(err)) return;
                 console.error('Gagal load detail BOM:', err);
                 notifikasi('error', 'Gagal', 'Gagal memuat detail resep.');
             }
@@ -664,6 +667,7 @@
                 notifikasi('success', "Berhasil Delete", "Berhasil delete resep bahan mentah");
             },
             error:function(e){
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });

--- a/public/Custom_js/Backoffice/Production/Production.js
+++ b/public/Custom_js/Backoffice/Production/Production.js
@@ -187,7 +187,8 @@ function loadBomForValidation(bomId, callback) {
         success: function (response) {
             callback(response && response[0] ? response[0] : null);
         },
-        error: function () {
+        error: function (xhr) {
+            if (handlePermissionError(xhr)) return;
             callback(null);
         },
     });
@@ -771,6 +772,7 @@ function refreshProduction() {
         },
         error: function (err) {
             if (err && err.statusText === "abort") return;
+            if (handlePermissionError(err)) return;
             console.error("Gagal load produksi:", err);
         },
         complete: function () {
@@ -1024,6 +1026,7 @@ $(document).on("click", ".btn-save", function () {
                 ".btn-save",
                 mode == 1 ? "Tambah Produksi" : "Update Produksi",
             );
+            if (handlePermissionError(a)) return;
             console.log(a);
         },
     });
@@ -1406,6 +1409,10 @@ function getBom(id, index = null) {
             }
             console.log(list_bahan);
         },
+        error: function (xhr) {
+            if (handlePermissionError(xhr)) return;
+            console.error("Gagal load resep:", xhr);
+        },
     });
 }
 
@@ -1489,6 +1496,7 @@ $(document).on("click", "#btn-delete-production", function () {
         },
         error: function (e) {
             ResetLoadingButton(".btn-konfirmasi", "Batal Produksi");
+            if (handlePermissionError(e)) return;
             console.log(e);
         },
     });
@@ -1552,6 +1560,7 @@ $(document).on("click", "#btn-acc-delete-production", function () {
         },
         error: function (e) {
             ResetLoadingButton(".btn-konfirmasi", "Batal Produksi");
+            if (handlePermissionError(e)) return;
             console.log(e);
         },
     });
@@ -1600,6 +1609,7 @@ $(document).on("click", "#btn-cancel-delete-production", function () {
         },
         error: function (e) {
             ResetLoadingButton(".btn-konfirmasi", '<i class="fe fe-check-circle me-1"></i>Konfirmasi Batal Produksi');
+            if (handlePermissionError(e)) return;
             console.log(e);
         },
     });
@@ -1676,6 +1686,7 @@ function submitAccProduction(productionId, confirmCreateStock) {
             }
         },
         error: function (e) {
+            if (handlePermissionError(e)) return;
             console.log(e);
             ResetLoadingButton(".btn-konfirmasi", '<i class="fe fe-check-circle me-1"></i>Konfirmasi');
         },
@@ -1733,6 +1744,7 @@ $(document).on("click", "#btn-decline-production", function () {
             notifikasi("success", "Berhasil Tolak", "Berhasil Tolak Pengajuan");
         },
         error: function (e) {
+            if (handlePermissionError(e)) return;
             console.log(e);
             ResetLoadingButton(".btn-konfirmasi", '<i class="fe fe-check-circle me-1"></i>Konfirmasi');
         },
@@ -1795,6 +1807,7 @@ $(document).on("click", ".LihatfotoProduksi", function () {
             $("#modalViewPhoto").modal("show");
         },
         error: function (e) {
+            if (handlePermissionError(e)) return;
             console.log(e);
         },
     });

--- a/public/Custom_js/Backoffice/Reports/Bahan_Baku.js
+++ b/public/Custom_js/Backoffice/Reports/Bahan_Baku.js
@@ -153,6 +153,7 @@
                 feather.replace();
             },
             error: function (err) {
+                if (handlePermissionError(err)) return;
                 console.error("Gagal load pemakaian bahan:", err);
             }
         });

--- a/public/Custom_js/Backoffice/Reports/Cash.js
+++ b/public/Custom_js/Backoffice/Reports/Cash.js
@@ -191,6 +191,7 @@
                 }, 100);
             },
             error: function (err) {
+                if (handlePermissionError(err)) return;
                 console.error("Gagal load kas:", err);
             }
         });
@@ -616,6 +617,7 @@
             },
             error:function(e){
                 ResetLoadingButton(".btn-save", mode == 1?"Tambah Pencatatan" : "Update Pencatatan");
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });
@@ -686,6 +688,7 @@
             },
             error:function(e){
                 ResetLoadingButton('.btn-konfirmasi', "Konfirmasi");
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });
@@ -723,6 +726,7 @@
             },
             error:function(e){
                 ResetLoadingButton('.btn-konfirmasi', "Konfirmasi");
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });

--- a/public/Custom_js/Backoffice/Reports/Cash_Operational.js
+++ b/public/Custom_js/Backoffice/Reports/Cash_Operational.js
@@ -707,6 +707,7 @@
                 openCashFromDashboardLink();
             },
             error: function (err) {
+                if (handlePermissionError(err)) return;
                 console.error("Gagal load kategori:", err);
             }
         });
@@ -807,6 +808,7 @@
                 openCashFromDashboardLink();
             },
             error: function (err) {
+                if (handlePermissionError(err)) return;
                 console.error("Gagal load kategori:", err);
             }
         });
@@ -917,6 +919,7 @@
                 openCashFromDashboardLink();
             },
             error: function (err) {
+                if (handlePermissionError(err)) return;
                 console.error("Gagal load kategori:", err);
             }
         });
@@ -1019,6 +1022,7 @@
                 openCashFromDashboardLink();
             },
             error: function (err) {
+                if (handlePermissionError(err)) return;
                 console.error("Gagal load kategori:", err);
             }
         });
@@ -1516,6 +1520,7 @@
             },
             error:function(e){
                 ResetLoadingButton(".btn-save-admin", mode == 1?"Tambah Aktivitas" : "Update Aktivitas");
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });
@@ -1710,6 +1715,7 @@
             },
             error:function(e){
                 ResetLoadingButton(".btn-save-gudang", mode == 1?"Tambah Aktivitas" : "Update Aktivitas");
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });
@@ -1914,6 +1920,7 @@
             },
             error:function(e){
                 ResetLoadingButton(".btn-save-armada", mode == 1?"Tambah Aktivitas" : "Update Aktivitas");
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });
@@ -2147,6 +2154,7 @@
             },
             error:function(e){
                 ResetLoadingButton(".btn-save-sales", mode == 1?"Tambah Aktivitas" : "Update Aktivitas");
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });
@@ -2292,6 +2300,7 @@
             },
             error:function(e){
                 ResetLoadingButton('#btn-delete-admin', "Delete");
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });
@@ -2427,6 +2436,7 @@
             },
             error:function(e){
                 ResetLoadingButton('#btn-delete-gudang', "Delete");
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });
@@ -2585,6 +2595,7 @@
             },
             error:function(e){
                 ResetLoadingButton('#btn-delete-armada', "Delete");
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });
@@ -2743,6 +2754,7 @@
             },
             error:function(e){
                 ResetLoadingButton('#btn-delete-sales', "Delete");
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });
@@ -2821,8 +2833,9 @@
                 
             },
             error:function(e){
-                console.log(e);
                 ResetLoadingButton('.btn-konfirmasi', "Konfirmasi");
+                if (handlePermissionError(e)) return;
+                console.log(e);
             }
         });
     })
@@ -2896,8 +2909,9 @@
                 
             },
             error:function(e){
-                console.log(e);
                 ResetLoadingButton('.btn-konfirmasi', "Konfirmasi");
+                if (handlePermissionError(e)) return;
+                console.log(e);
             }
         });
     })

--- a/public/Custom_js/Backoffice/Reports/Cash_Out_Report.js
+++ b/public/Custom_js/Backoffice/Reports/Cash_Out_Report.js
@@ -85,7 +85,8 @@
                 $("#cash_out_total_pengeluaran").text(fmtRp(summary.total_pengeluaran || 0));
                 $("#cash_out_total_transaksi").text(String(summary.jumlah_transaksi || 0));
             },
-            error: function () {
+            error: function (xhr) {
+                if (handlePermissionError(xhr)) return;
                 table.clear().draw();
                 $("#cash_out_period_label").text("Gagal memuat data");
                 $("#cash_out_total_pengeluaran").text("Rp 0");

--- a/public/Custom_js/Backoffice/Reports/Category_Cash.js
+++ b/public/Custom_js/Backoffice/Reports/Category_Cash.js
@@ -82,6 +82,7 @@
                 feather.replace(); // Biar icon feather muncul lagi
             },
             error: function (err) {
+                if (handlePermissionError(err)) return;
                 console.error("Gagal load kategori:", err);
             }
         });
@@ -130,7 +131,8 @@
                 afterInsert();
             },
             error:function(e){
-                ResetLoadingButton('.btn-save', mode == 1?"Tambah Kategori Kas" : "Update Kategori Kas");  
+                ResetLoadingButton('.btn-save', mode == 1?"Tambah Kategori Kas" : "Update Kategori Kas");
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });
@@ -183,6 +185,7 @@
                 
             },
             error:function(e){
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });

--- a/public/Custom_js/Backoffice/Reports/DashboardPemakaianBahan.js
+++ b/public/Custom_js/Backoffice/Reports/DashboardPemakaianBahan.js
@@ -222,7 +222,8 @@
             success: function (payload) {
                 fillProcurementTables(payload);
             },
-            error: function () {
+            error: function (xhr) {
+                if (handlePermissionError(xhr)) return;
                 var errFull =
                     '<tr><td colspan="7" class="text-center text-danger py-3">Gagal memuat estimasi pembelian.</td></tr>';
                 var $a = $("#dash_procurement_body_kemasan");
@@ -258,7 +259,8 @@
                 renderChart(payload);
                 loadProcurementEstimate();
             },
-            error: function () {
+            error: function (xhr) {
+                if (handlePermissionError(xhr)) return;
                 var err =
                     '<tr><td colspan="3" class="text-center text-danger py-3">Gagal memuat data</td></tr>';
                 $("#dash_top_body_kemasan").html(err);

--- a/public/Custom_js/Backoffice/Reports/Inward_Outward.js
+++ b/public/Custom_js/Backoffice/Reports/Inward_Outward.js
@@ -55,6 +55,7 @@
                 feather.replace(); // Biar icon feather muncul lagi
             },
             error: function (err) {
+                if (handlePermissionError(err)) return;
                 console.error("Gagal load:", err);
             }
         });

--- a/public/Custom_js/Backoffice/Reports/Pay_Receive.js
+++ b/public/Custom_js/Backoffice/Reports/Pay_Receive.js
@@ -114,6 +114,7 @@
                 $('#totalInvoice').html(e.length);
             },
             error: function (err) {
+                if (handlePermissionError(err)) return;
                 console.error("Gagal load:", err);
             }
         });
@@ -208,6 +209,7 @@
                 $('#jumlah_terpilih').text("0 Selected");
             },
             error:function(e){
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });
@@ -233,6 +235,7 @@
                 window.open('/generateHutang?' + $.param(params), '_self');
             },
             error: function(e){
+                if (handlePermissionError(e)) return;
                 console.error(e);
             }
         })

--- a/public/Custom_js/Backoffice/Reports/Petty_Cash.js
+++ b/public/Custom_js/Backoffice/Reports/Petty_Cash.js
@@ -115,6 +115,7 @@
                 feather.replace(); // Biar icon feather muncul lagi
             },
             error: function (err) {
+                if (handlePermissionError(err)) return;
                 console.error("Gagal load kategori:", err);
             }
         });
@@ -168,6 +169,7 @@
             },
             error:function(e){
                 ResetLoadingButton(".btn-save", mode == 1?"Tambah Kas" : "Update Kas");
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });

--- a/public/Custom_js/Backoffice/Reports/ProductReturn.js
+++ b/public/Custom_js/Backoffice/Reports/ProductReturn.js
@@ -167,6 +167,7 @@
                 feather.replace();
             },
             error: function (err) {
+                if (handlePermissionError(err)) return;
                 console.error("Gagal load retur:", err);
             }
         });

--- a/public/Custom_js/Backoffice/Reports/Profit_Loss.js
+++ b/public/Custom_js/Backoffice/Reports/Profit_Loss.js
@@ -74,6 +74,7 @@
                 tableProfit.clear().rows.add(e).draw();
             },
             error: function (err) {
+                if (handlePermissionError(err)) return;
                 console.error("Gagal load:", err);
             }
         });
@@ -93,6 +94,7 @@
                 tableLoss.clear().rows.add(e).draw();
             },
             error: function (err) {
+                if (handlePermissionError(err)) return;
                 console.error("Gagal load:", err);
             }
         });

--- a/public/Custom_js/Backoffice/Reports/ReportEfisiensiProduksi.js
+++ b/public/Custom_js/Backoffice/Reports/ReportEfisiensiProduksi.js
@@ -201,6 +201,7 @@ function refreshEfisiensi() {
             feather.replace();
         },
         error: function (err) {
+            if (handlePermissionError(err)) return;
             console.error("Gagal load report efisiensi produksi:", err);
             updateKpiSummary([]);
         },

--- a/public/Custom_js/Backoffice/Reports/ReportProduction.js
+++ b/public/Custom_js/Backoffice/Reports/ReportProduction.js
@@ -187,6 +187,7 @@
                 feather.replace(); // Biar icon feather muncul lagi
             },
             error: function (err) {
+                if (handlePermissionError(err)) return;
                 console.error("Gagal load produksi:", err);
             }
         });

--- a/public/Custom_js/Backoffice/Reports/ReportReturProdukArmada.js
+++ b/public/Custom_js/Backoffice/Reports/ReportReturProdukArmada.js
@@ -164,6 +164,7 @@ function refreshReturArmada() {
             if (typeof feather !== 'undefined') feather.replace();
         },
         error: function (err) {
+            if (handlePermissionError(err)) return;
             console.error('Gagal load laporan retur armada:', err);
         },
     });

--- a/public/Custom_js/Backoffice/Reports/StockAging.js
+++ b/public/Custom_js/Backoffice/Reports/StockAging.js
@@ -111,6 +111,7 @@ function refreshStockAging() {
             feather.replace();
         },
         error: function (err) {
+            if (handlePermissionError(err)) return;
             console.error("Gagal load stock aging:", err);
         },
     });

--- a/public/Custom_js/Backoffice/Reports/StockOpnameDifference.js
+++ b/public/Custom_js/Backoffice/Reports/StockOpnameDifference.js
@@ -155,6 +155,7 @@ function refreshSelisihOpname() {
             feather.replace();
         },
         error: function (err) {
+            if (handlePermissionError(err)) return;
             console.error("Gagal load report selisih opname:", err);
         },
     });

--- a/public/Custom_js/Backoffice/Settings/Profiles.js
+++ b/public/Custom_js/Backoffice/Settings/Profiles.js
@@ -105,6 +105,7 @@ $(document).on('click', '.btn-save', function(){
         error: function (xhr) {
             // Re-enable button
             ResetLoadingButton(".btn-save", 'Simpan perubahan');
+            if (handlePermissionError(xhr)) return;
             console.log(xhr);
         },
     });

--- a/public/Custom_js/Backoffice/Settings/Settings.js
+++ b/public/Custom_js/Backoffice/Settings/Settings.js
@@ -51,6 +51,7 @@ $(document).on('click', '.btn-save', function(){
            
         },
         error: function(e) {
+            if (handlePermissionError(e)) return;
             notifikasi('error', "Terjadi Kesalahan", "");
             console.log(e);
         }

--- a/public/Custom_js/Backoffice/Suppliers/Purchase_Order.js
+++ b/public/Custom_js/Backoffice/Suppliers/Purchase_Order.js
@@ -160,7 +160,8 @@
 
                 $('#po_scan_barcode').val('').focus();
             },
-            error: function () {
+            error: function (xhr) {
+                if (handlePermissionError(xhr)) return;
                 toastr.error('', 'Gagal mencari produk');
                 $('#po_scan_barcode').val('').focus();
             }
@@ -388,6 +389,7 @@
                 feather.replace(); // Biar icon feather muncul lagi
             },
             error: function (err) {
+                if (handlePermissionError(err)) return;
                 console.error("Gagal load so:", err);
             }
         });
@@ -527,7 +529,8 @@
                 afterInsert();
             },
             error:function(e){
-                ResetLoadingButton('.btn-save', mode == 1?"Tambah Pembelian" : "Update Pembelian"); 
+                ResetLoadingButton('.btn-save', mode == 1?"Tambah Pembelian" : "Update Pembelian");
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });
@@ -582,6 +585,7 @@
                 
             },
             error:function(e){
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });

--- a/public/Custom_js/Backoffice/Suppliers/Purchase_Order_Detail.js
+++ b/public/Custom_js/Backoffice/Suppliers/Purchase_Order_Detail.js
@@ -262,6 +262,7 @@
                 feather.replace(); // Biar icon feather muncul lagi
             },
             error: function (err) {
+                if (handlePermissionError(err)) return;
                 console.error("Gagal load:", err);
             }
         });
@@ -320,6 +321,7 @@
                 feather.replace(); // Biar icon feather muncul lagi
             },
             error: function (err) {
+                if (handlePermissionError(err)) return;
                 console.error("Gagal load:", err);
             }
         });
@@ -376,6 +378,7 @@
                 feather.replace(); // Biar icon feather muncul lagi
             },
             error: function (err) {
+                if (handlePermissionError(err)) return;
                 console.error("Gagal load:", err);
             }
         });
@@ -636,8 +639,9 @@
                 ResetLoadingButton('.btn-save-retur', mode == 1?"Tambah Retur" : "Update Retur");
             },
             error: function (e) {
-                console.log(e);
-                ResetLoadingButton('.btn-save-retur', mode == 1?"Tambah Retur" : "Update Retur"); 
+                ResetLoadingButton('.btn-save-retur', mode == 1?"Tambah Retur" : "Update Retur");
+                if (handlePermissionError(e)) return;
+                console.log(e); 
             },
         });
     })
@@ -673,6 +677,7 @@
             },
             error:function(e){
                 ResetLoadingButton("#btn-delete-retur", "Delete");
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });
@@ -881,6 +886,7 @@
             },
             error:function(e){
                 ResetLoadingButton(".save-qty", 'Simpan perubahan');
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });
@@ -964,6 +970,7 @@
             },
             error:function(e){
                 ResetLoadingButton(".btn-save-delivery", 'Simpan perubahan');
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });
@@ -1024,6 +1031,7 @@
             },
             error:function(e){
                 ResetLoadingButton(".btn-approve", 'Setujui');
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });
@@ -1080,6 +1088,7 @@
             },
             error:function(e){
                 ResetLoadingButton(".btn-decline", 'Tolak');
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });
@@ -1156,6 +1165,7 @@
                 
             },
             error:function(e){
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });
@@ -1261,6 +1271,7 @@
                 
             },
             error: function (e) {
+                if (handlePermissionError(e)) return;
                 console.log(e);
             },
         });
@@ -1323,6 +1334,7 @@
                 notifikasi('success', "Berhasil Delete", "Berhasil delete invoice");
             },
             error:function(e){
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });
@@ -1347,6 +1359,7 @@
             },
             error:function(e){
                 ResetLoadingButton(btn, 'Tolak');
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });
@@ -1384,7 +1397,8 @@
             },
             error:function(e){
                  ResetLoadingButton(btn, 'Setujui');
-                console.log(e);
+                 if (handlePermissionError(e)) return;
+                 console.log(e);
             }
         });
     });
@@ -1422,7 +1436,8 @@
             },
             error:function(e){
                  ResetLoadingButton(btn, 'Setujui');
-                console.log(e);
+                 if (handlePermissionError(e)) return;
+                 console.log(e);
             }
         });
     });
@@ -1473,8 +1488,9 @@ $(document).on("click", "#btn-acc-po", function () {
             window.open('/purchaseOrder', '_self');
         },
         error: function (e) {
-            console.log(e);
             ResetLoadingButton("#btn-acc-po", "Terima");
+            if (handlePermissionError(e)) return;
+            console.log(e);
         },
     });
 });
@@ -1522,6 +1538,7 @@ $(document).on("click", "#btn-acc-po", function () {
             },
             error:function(e){
                 ResetLoadingButton("#btn-tolak-po", "Tolak");
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });

--- a/public/Custom_js/Backoffice/Suppliers/Supplier.js
+++ b/public/Custom_js/Backoffice/Suppliers/Supplier.js
@@ -91,6 +91,7 @@
                 feather.replace(); // Biar icon feather muncul lagi
             },
             error: function (err) {
+                if (handlePermissionError(err)) return;
                 console.error("Gagal load:", err);
             }
         });
@@ -134,6 +135,7 @@
                 viewHistory(e);
             },
             error: function(e){
+                if (handlePermissionError(e)) return;
                 console.error("Gagal load:", e);
             }
         });
@@ -194,6 +196,7 @@
                 
             },
             error:function(e){
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });

--- a/public/Custom_js/Backoffice/Suppliers/insertSupplier.js
+++ b/public/Custom_js/Backoffice/Suppliers/insertSupplier.js
@@ -116,6 +116,7 @@ $(document).on("click", ".btn-save", function () {
         error: function (xhr) {
             // Re-enable button
             ResetLoadingButton(".btn-save", mode == 1?"Tambah Pemasok" : "Update Pemasok");
+            if (handlePermissionError(xhr)) return;
             console.log(xhr);
         },
     });

--- a/public/Custom_js/Backoffice/Suppliers/tt.js
+++ b/public/Custom_js/Backoffice/Suppliers/tt.js
@@ -123,6 +123,7 @@ function updateTtUploadProgress(percent) {
                 feather.replace(); // Biar icon feather muncul lagi
             },
             error: function (err) {
+                if (handlePermissionError(err)) return;
                 console.error("Gagal load so:", err);
             }
         });
@@ -186,9 +187,10 @@ function updateTtUploadProgress(percent) {
                 
             },
             error:function(e){
+                ResetLoadingButton('#add_acc_tt .btn-save', "Konfirmasi");
+                if (handlePermissionError(e)) return;
                 console.log(e);
                 resetTtUploadProgress();
-                ResetLoadingButton('#add_acc_tt .btn-save', "Konfirmasi");
             }
         });
     });
@@ -250,6 +252,7 @@ $(document).on("change", "#image", function () {
             $("#file_name").text(compressedImageFile.name + " (" + kb + " KB)");
         },
         error(err) {
+            if (handlePermissionError(err)) return;
             console.error("Gagal kompres gambar:", err);
             compressedImageFile = file;
             let reader = new FileReader();
@@ -301,6 +304,7 @@ $(document).on("change", "#image", function () {
                 
             },
             error:function(e){
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });

--- a/public/Custom_js/Backoffice/Synchronization/Wizard.js
+++ b/public/Custom_js/Backoffice/Synchronization/Wizard.js
@@ -96,6 +96,7 @@
                 }
             },
             error: function (xhr) {
+                if (handlePermissionError(xhr)) return;
                 var res = xhr.responseJSON || {};
                 if (res.state) {
                     renderState(res.state);

--- a/public/Custom_js/Backoffice/User/Bank.js
+++ b/public/Custom_js/Backoffice/User/Bank.js
@@ -82,6 +82,7 @@
                 feather.replace(); // Biar icon feather muncul lagi
             },
             error: function (err) {
+                if (handlePermissionError(err)) return;
                 console.error("Gagal load Bank:", err);
             }
         });
@@ -130,6 +131,7 @@
             },
             error:function(e){
                 ResetLoadingButton('.btn-save', mode == 1?"Tambah Bank" : "Update Bank");
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });
@@ -182,6 +184,7 @@
                 
             },
             error:function(e){
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });

--- a/public/Custom_js/Backoffice/User/Permission.js
+++ b/public/Custom_js/Backoffice/User/Permission.js
@@ -154,6 +154,7 @@
             },
             error:function(e){
                 ResetLoadingButton(".btn-save", 'Perbarui');
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });

--- a/public/Custom_js/Backoffice/User/Role.js
+++ b/public/Custom_js/Backoffice/User/Role.js
@@ -80,6 +80,7 @@
                 feather.replace(); // Biar icon feather muncul lagi
             },
             error: function (err) {
+                if (handlePermissionError(err)) return;
                 console.error("Gagal load role:", err);
             }
         });
@@ -128,6 +129,7 @@
             },
             error:function(e){
                 ResetLoadingButton(".btn-save", 'Simpan perubahan');
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });
@@ -227,6 +229,7 @@
             },
             error: function (e) {
                 ResetLoadingButton("#btn_save_dash_widgets", "Simpan Widget");
+                if (handlePermissionError(e)) return;
                 console.log(e);
                 notifikasi('error', "Gagal Update", "Gagal update widget dashboard role");
             }

--- a/public/Custom_js/Backoffice/User/Staff.js
+++ b/public/Custom_js/Backoffice/User/Staff.js
@@ -87,6 +87,7 @@
                 feather.replace(); // Biar icon feather muncul lagi
             },
             error: function (err) {
+                if (handlePermissionError(err)) return;
                 console.error("Gagal load:", err);
             }
         });
@@ -119,6 +120,7 @@
                 
             },
             error:function(e){
+                if (handlePermissionError(e)) return;
                 console.log(e);
             }
         });

--- a/public/Custom_js/Backoffice/User/insertStaff.js
+++ b/public/Custom_js/Backoffice/User/insertStaff.js
@@ -268,6 +268,7 @@ $(document).on("click", ".btn-save", function () {
                 ".btn-save",
                 mode == 1 ? "Tambah Staff" : "Update Staff",
             );
+            if (handlePermissionError(xhr)) return;
             console.log(xhr);
         },
     });

--- a/resources/views/Backoffice/Dashboard/partials/home-dashboard-widgets.blade.php
+++ b/resources/views/Backoffice/Dashboard/partials/home-dashboard-widgets.blade.php
@@ -683,11 +683,13 @@
                                 <th class="text-nowrap">Modul</th>
                                 <th class="text-nowrap">Ref</th>
                                 <th>Perubahan / status</th>
+                                <th class="text-nowrap">User</th>
+                                <th class="text-nowrap">Jam / Durasi</th>
                                 <th class="text-end text-nowrap">Aksi</th>
                             </tr>
                         </thead>
                         <tbody id="dash_changelog_body">
-                            <tr><td colspan="4" class="text-center text-muted">Memuat…</td></tr>
+                            <tr><td colspan="6" class="text-center text-muted">Memuat…</td></tr>
                         </tbody>
                     </table>
                     </div>

--- a/resources/views/Backoffice/PDF/Opname.blade.php
+++ b/resources/views/Backoffice/PDF/Opname.blade.php
@@ -124,7 +124,13 @@
                                 }
                             }
                         }
-                        $highlight = $hasSelisih ? 'background-color: #FFF9C4;' : '';
+                        // GitHub #53: kuning kalau diisi dan ada selisih, hijau kalau diisi dan
+                        // stok real cocok dengan sistem, tanpa highlight kalau memang tidak
+                        // pernah diisi stok real-nya (bukan sekadar default = stok sistem).
+                        $highlight = '';
+                        if (!empty($item['stod_touched'])) {
+                            $highlight = $hasSelisih ? 'background-color: #FFF9C4;' : 'background-color: #C8E6C9;';
+                        }
                     @endphp
                     <tr>
                         <td>{{ empty($item['product_variant_sku']) ? '-' : $item['product_variant_sku'] }}</td>

--- a/resources/views/Backoffice/PDF/OpnameBahan.blade.php
+++ b/resources/views/Backoffice/PDF/OpnameBahan.blade.php
@@ -122,7 +122,13 @@
                                 }
                             }
                         }
-                        $highlight = $hasSelisih ? 'background-color: #FFF9C4;' : '';
+                        // GitHub #53: kuning kalau diisi dan ada selisih, hijau kalau diisi dan
+                        // stok real cocok dengan sistem, tanpa highlight kalau memang tidak
+                        // pernah diisi stok real-nya (bukan sekadar default = stok sistem).
+                        $highlight = '';
+                        if (!empty($item['stobd_touched'])) {
+                            $highlight = $hasSelisih ? 'background-color: #FFF9C4;' : 'background-color: #C8E6C9;';
+                        }
                     @endphp
                     <tr>
                         <td>{{ $item['supplies_name'] ?? '-' }}</td>

--- a/resources/views/Backoffice/PDF/TandaTerima.blade.php
+++ b/resources/views/Backoffice/PDF/TandaTerima.blade.php
@@ -150,7 +150,7 @@
             <div class="info-section">
                 <div class="info-row">
                     <div class="info-label">Tanggal Surat Terima</div>
-                    <div class="info-value">: {{ $tt["tt_date"] ? date('d F Y', strtotime($tt["tt_date"])) . ', ' . now()->format('H:i:s') : null }}</div>
+                    <div class="info-value">: {{ $tt["tt_date"] ? date('d F Y', strtotime($tt["tt_date"])) . ($tt["created_at"] ? ', ' . \Carbon\Carbon::parse($tt["created_at"])->format('H:i:s T') : '') : null }}</div>
                 </div>
                
                 <div class="info-row">

--- a/resources/views/Backoffice/PDF/TandaTerima.blade.php
+++ b/resources/views/Backoffice/PDF/TandaTerima.blade.php
@@ -150,7 +150,7 @@
             <div class="info-section">
                 <div class="info-row">
                     <div class="info-label">Tanggal Surat Terima</div>
-                    <div class="info-value">: {{ date('d F Y', strtotime($tt["tt_date"]))??null }}</div>
+                    <div class="info-value">: {{ $tt["tt_date"] ? date('d F Y', strtotime($tt["tt_date"])) . ', ' . now()->format('H:i:s') : null }}</div>
                 </div>
                
                 <div class="info-row">

--- a/resources/views/layout/partials/footer-scripts.blade.php
+++ b/resources/views/layout/partials/footer-scripts.blade.php
@@ -337,6 +337,22 @@ https://cdn.jsdelivr.net/npm/toastr@2.1.4/toastr.min.js
       text: deskripsi,
     });
   }
+
+  /**
+   * Panggil ini di awal setiap ajax error callback (terutama di popup) supaya pesan
+   * 403 (ditolak middleware permission) konsisten di seluruh aplikasi dan tidak
+   * membocorkan modul/permission apa yang kurang ke user.
+   * Return true kalau sudah ditangani (403) — caller tinggal `return` tanpa
+   * menampilkan notifikasi generiknya sendiri. Return false untuk error lain,
+   * silakan lanjut pakai handling yang sudah ada di masing-masing pemanggil.
+   */
+  function handlePermissionError(xhr) {
+    if (xhr && xhr.status === 403) {
+      notifikasi('error', 'Akses Ditolak', 'Anda tidak memiliki akses terhadap aksi ini, mohon hubungi Admin!');
+      return true;
+    }
+    return false;
+  }
   //munculin modal delete
     function showModalDelete(text, button_id) {
         if ($('#modalDelete .modal-body').is(':empty')) {

--- a/tests/Workflow/DashboardChangelogMenuOpenTrackingTest.php
+++ b/tests/Workflow/DashboardChangelogMenuOpenTrackingTest.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace Tests\Workflow;
+
+use App\Models\DashboardChangeLog;
+use Tests\Support\ActingAsStaff;
+use Tests\TestCase;
+
+/**
+ * GitHub #53: "jam dia buka modul atau menu apapun" — App\Http\Middleware\LogDashboardActivity
+ * now also logs activity_type='open' rows for real page views (GET requests that render a Blade
+ * view), separate from the pre-existing activity_type='change' rows for POST/PUT/PATCH/DELETE
+ * mutations. Duration is a passive estimate: the gap between one 'open' row and that same staff's
+ * next tracked request, filled in retroactively — see LogDashboardActivity::logOpen().
+ */
+class DashboardChangelogMenuOpenTrackingTest extends TestCase
+{
+    use ActingAsStaff;
+
+    public function test_opening_a_page_logs_an_open_row_with_staff_and_null_duration(): void
+    {
+        $staff = $this->actingAsSuperAdminStaff();
+
+        $this->get('/stockOpname')->assertStatus(200);
+
+        $this->assertDatabaseHas('dashboard_change_logs', [
+            'module_key' => 'stockopname',
+            'activity_type' => 'open',
+            'created_by' => $staff->staff_id,
+            'duration_seconds' => null,
+        ]);
+    }
+
+    public function test_reopening_the_same_module_within_the_debounce_window_does_not_duplicate(): void
+    {
+        $staff = $this->actingAsSuperAdminStaff();
+
+        $this->get('/stockOpname')->assertStatus(200);
+        $this->get('/stockOpname')->assertStatus(200);
+        $this->get('/stockOpname')->assertStatus(200);
+
+        $count = DashboardChangeLog::where('created_by', $staff->staff_id)
+            ->where('module_key', 'stockopname')
+            ->where('activity_type', 'open')
+            ->count();
+        $this->assertSame(1, $count, 'opening the same module repeatedly within 15 minutes must debounce to a single row');
+    }
+
+    public function test_opening_a_different_module_closes_the_previous_open_row_with_a_duration(): void
+    {
+        $staff = $this->actingAsSuperAdminStaff();
+
+        $this->get('/stockOpname')->assertStatus(200);
+        $firstOpen = DashboardChangeLog::where('created_by', $staff->staff_id)
+            ->where('module_key', 'stockopname')
+            ->where('activity_type', 'open')
+            ->firstOrFail();
+        $this->assertNull($firstOpen->duration_seconds);
+
+        // Back-date it so the diff is deterministic and clearly under the 4h cap.
+        $firstOpen->created_at = now()->subMinutes(5);
+        $firstOpen->save();
+
+        $this->get('/purchaseOrder')->assertStatus(200);
+
+        $firstOpen->refresh();
+        $this->assertNotNull($firstOpen->duration_seconds, 'navigating away must retroactively fill the previous open row\'s duration');
+        $this->assertGreaterThanOrEqual(290, $firstOpen->duration_seconds); // ~5 minutes, allow test-runtime slack
+
+        $secondOpen = DashboardChangeLog::where('created_by', $staff->staff_id)
+            ->where('module_key', 'purchaseorder')
+            ->where('activity_type', 'open')
+            ->firstOrFail();
+        $this->assertNull($secondOpen->duration_seconds, 'the newly opened module is still an open session');
+    }
+
+    public function test_a_gap_longer_than_the_cap_is_left_without_a_duration(): void
+    {
+        $staff = $this->actingAsSuperAdminStaff();
+
+        $this->get('/stockOpname')->assertStatus(200);
+        $firstOpen = DashboardChangeLog::where('created_by', $staff->staff_id)
+            ->where('module_key', 'stockopname')
+            ->where('activity_type', 'open')
+            ->firstOrFail();
+
+        // Simulate a tab left open overnight: gap far beyond the 4h sanity cap.
+        $firstOpen->created_at = now()->subHours(10);
+        $firstOpen->save();
+
+        $this->get('/purchaseOrder')->assertStatus(200);
+
+        $firstOpen->refresh();
+        $this->assertNull($firstOpen->duration_seconds, 'a gap beyond the cap must not be recorded as a real duration');
+    }
+
+    public function test_menu_open_rows_are_excluded_from_the_changelog_pending_kpi(): void
+    {
+        $staff = $this->actingAsSuperAdminStaff();
+
+        // Baseline via the real endpoint (not a raw table count) so it goes through the same
+        // "current period" date filter as the KPI itself — seeded rows outside that window would
+        // otherwise make a raw count diverge from what the endpoint actually reports.
+        $before = (int) $this->get('/getDashboardOverview')->json('changelog.changelog_pending');
+
+        // A real mutation -> activity_type='change', counted by the KPI.
+        DashboardChangeLog::create([
+            'module_key' => 'master_bahan',
+            'activity_type' => 'change',
+            'module_label' => 'Master Bahan',
+            'reference' => 'BHN #1',
+            'what_changed' => 'Master bahan diperbarui.',
+            'summary' => 'Test',
+            'created_by' => $staff->staff_id,
+        ]);
+
+        // A page view -> activity_type='open', must NOT be counted.
+        $this->get('/stockOpname')->assertStatus(200);
+
+        $response = $this->get('/getDashboardOverview');
+        $response->assertStatus(200);
+        $pending = (int) $response->json('changelog.changelog_pending');
+
+        $this->assertSame($before + 1, $pending, 'the Changelog KPI must count the mutation row but not the menu-open row');
+    }
+}

--- a/tests/Workflow/DashboardChangelogMenuOpenTrackingTest.php
+++ b/tests/Workflow/DashboardChangelogMenuOpenTrackingTest.php
@@ -31,7 +31,60 @@ class DashboardChangelogMenuOpenTrackingTest extends TestCase
         ]);
     }
 
-    public function test_reopening_the_same_module_within_the_debounce_window_does_not_duplicate(): void
+    /**
+     * User-reported confusion: "Insertstockopname" (an AJAX mutation row) reads like it's about
+     * opening a page, while the actual "Input Stok Opname" form page is auto-labeled
+     * "Detailstockopname" — nothing ties the two together visually. formatModuleLabel() now
+     * translates action-prefix + base module into a human label instead of a bare title-cased
+     * URL segment.
+     */
+    public function test_module_labels_are_human_readable_not_raw_url_segments(): void
+    {
+        $staff = $this->actingAsSuperAdminStaff();
+
+        // The actual create/edit form page -> "Input Stok Opname", not "Detailstockopname".
+        $this->get('/detailStockOpname/-1')->assertStatus(200);
+        $this->assertDatabaseHas('dashboard_change_logs', [
+            'module_key' => 'detailstockopname',
+            'activity_type' => 'open',
+            'module_label' => 'Input Stok Opname',
+        ]);
+
+        // The AJAX insert mutation -> "Tambah Stok Opname", not "Insertstockopname".
+        $stock = \App\Models\ProductStock::withoutGlobalScope('active_warehouse')
+            ->where('status', 1)->where('warehouse_id', 1)->firstOrFail();
+        $this->post('/insertStockOpname', [
+            'sto_date' => now()->toDateString(),
+            'staff_id' => $staff->staff_id,
+            'category_id' => (int) \Illuminate\Support\Facades\DB::table('categories')->where('status', 1)->value('category_id'),
+            'sto_notes' => 'label test',
+            'is_draft' => 0,
+            'item' => json_encode([[
+                'product_id' => $stock->product_id,
+                'product_variant_id' => $stock->product_variant_id,
+                'stod_system' => $stock->ps_stock.' pcs',
+                'stod_real' => $stock->ps_stock.' pcs',
+                'stod_selisih' => '0 pcs',
+                'stod_notes' => null,
+                'stod_touched' => 1,
+            ]]),
+        ])->assertStatus(200);
+        $this->assertDatabaseHas('dashboard_change_logs', [
+            'module_key' => 'insertstockopname',
+            'activity_type' => 'change',
+            'module_label' => 'Tambah Stok Opname',
+        ]);
+    }
+
+    /**
+     * There used to be a 15-minute debounce here (skip logging a repeat visit to the same
+     * module). Removed 2026-08-15: it was coupled to the same early `return` as the
+     * close-previous-open-row logic below, so re-opening a module you'd visited recently
+     * silently failed to close whatever ELSE was open in between — e.g. Dashboard -> Customer
+     * -> Dashboard again within 15 minutes left Customer's row stuck on "Sedang dibuka" forever.
+     * User's call: every navigation gets recorded now, no debounce, duplicates included.
+     */
+    public function test_every_visit_is_recorded_even_repeat_visits_to_the_same_module(): void
     {
         $staff = $this->actingAsSuperAdminStaff();
 
@@ -43,7 +96,15 @@ class DashboardChangelogMenuOpenTrackingTest extends TestCase
             ->where('module_key', 'stockopname')
             ->where('activity_type', 'open')
             ->count();
-        $this->assertSame(1, $count, 'opening the same module repeatedly within 15 minutes must debounce to a single row');
+        $this->assertSame(3, $count, 'every visit must be recorded, including repeats of the same module');
+
+        // Only the LAST one is still "open" -- each earlier visit gets closed by the next one.
+        $openCount = DashboardChangeLog::where('created_by', $staff->staff_id)
+            ->where('module_key', 'stockopname')
+            ->where('activity_type', 'open')
+            ->whereNull('duration_seconds')
+            ->count();
+        $this->assertSame(1, $openCount, 'each repeat visit must close the previous one, not just accumulate open sessions');
     }
 
     public function test_opening_a_different_module_closes_the_previous_open_row_with_a_duration(): void
@@ -92,6 +153,65 @@ class DashboardChangelogMenuOpenTrackingTest extends TestCase
 
         $firstOpen->refresh();
         $this->assertNull($firstOpen->duration_seconds, 'a gap beyond the cap must not be recorded as a real duration');
+    }
+
+    public function test_navigating_back_to_the_dashboard_root_closes_the_previous_open_row(): void
+    {
+        // GitHub #53 follow-up (user-reported): routes/web.php renders the dashboard directly at
+        // GET '/' (not just '/admin') -- '/' used to be excluded from shouldLogOpen() (copied
+        // from shouldLogChange()'s exclude list), so the most common "back to dashboard" path
+        // never closed out whatever menu was left open, leaving it stuck on "Sedang dibuka"
+        // forever even while the user was actively looking at the Changelog panel itself.
+        $staff = $this->actingAsSuperAdminStaff();
+
+        $this->get('/stockOpname')->assertStatus(200);
+        $firstOpen = DashboardChangeLog::where('created_by', $staff->staff_id)
+            ->where('module_key', 'stockopname')
+            ->where('activity_type', 'open')
+            ->firstOrFail();
+        $this->assertNull($firstOpen->duration_seconds);
+
+        $firstOpen->created_at = now()->subMinutes(3);
+        $firstOpen->save();
+
+        $this->get('/')->assertStatus(200);
+
+        $firstOpen->refresh();
+        $this->assertNotNull($firstOpen->duration_seconds, "navigating to '/' must retroactively close the previous open row too");
+
+        $this->assertDatabaseHas('dashboard_change_logs', [
+            'module_key' => 'dashboard',
+            'activity_type' => 'open',
+            'created_by' => $staff->staff_id,
+            'duration_seconds' => null,
+        ]);
+    }
+
+    public function test_revisiting_a_recently_opened_module_still_closes_whatever_is_currently_open(): void
+    {
+        // The exact user-reported scenario: Dashboard -> Customer -> Dashboard again (within
+        // what used to be the 15-minute debounce window) must still close Customer's session.
+        $staff = $this->actingAsSuperAdminStaff();
+
+        $this->get('/')->assertStatus(200);
+        $dashboardOpen = DashboardChangeLog::where('created_by', $staff->staff_id)
+            ->where('module_key', 'dashboard')->where('activity_type', 'open')
+            ->firstOrFail();
+
+        $this->get('/customer')->assertStatus(200);
+        $dashboardOpen->refresh();
+        $this->assertNotNull($dashboardOpen->duration_seconds, 'opening Customer must close the Dashboard session');
+
+        $customerOpen = DashboardChangeLog::where('created_by', $staff->staff_id)
+            ->where('module_key', 'customer')->where('activity_type', 'open')
+            ->firstOrFail();
+        $this->assertNull($customerOpen->duration_seconds);
+
+        // Back to Dashboard again, well within the old 15-minute debounce window.
+        $this->get('/')->assertStatus(200);
+
+        $customerOpen->refresh();
+        $this->assertNotNull($customerOpen->duration_seconds, "revisiting Dashboard must close Customer's session even though Dashboard was opened moments ago");
     }
 
     public function test_menu_open_rows_are_excluded_from_the_changelog_pending_kpi(): void

--- a/tests/Workflow/StockOpnamePdfHighlightTest.php
+++ b/tests/Workflow/StockOpnamePdfHighlightTest.php
@@ -1,0 +1,167 @@
+<?php
+
+namespace Tests\Workflow;
+
+use App\Models\ProductStock;
+use App\Models\StockOpnameDetail;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\View;
+use Tests\Support\ActingAsStaff;
+use Tests\TestCase;
+
+/**
+ * GitHub #53: the Stock Opname PDF (Backoffice/PDF/Opname.blade.php) must show three highlight
+ * states per row, not the old binary yellow/none:
+ *   - untouched (real-stock input left blank client-side, real qty just defaulted to system qty)
+ *     -> no highlight
+ *   - touched, no selisih (staff typed a value and it matches the system) -> green
+ *   - touched, has selisih -> yellow (unchanged behaviour)
+ *
+ * See cdocs/testing/workflows/STOCK_OPNAME_FLOW.md — stod_system/stod_real/stod_selisih are pure
+ * display strings never read by accStockOpname(), so stod_touched is purely a display flag too.
+ */
+class StockOpnamePdfHighlightTest extends TestCase
+{
+    use ActingAsStaff;
+
+    private const YELLOW = 'background-color: #FFF9C4;';
+    private const GREEN = 'background-color: #C8E6C9;';
+
+    private function pickFixtureStocks(int $count): \Illuminate\Support\Collection
+    {
+        return ProductStock::withoutGlobalScope('active_warehouse')
+            ->where('status', 1)
+            ->where('warehouse_id', 1) // Gudang Pusat (main), seeded 2026-08-01
+            ->where('ps_stock', '>', 10)
+            ->limit($count)
+            ->get();
+    }
+
+    private function categoryId(): int
+    {
+        return (int) DB::table('categories')->where('status', 1)->value('category_id');
+    }
+
+    private function staffId(): int
+    {
+        return (int) DB::table('staffs')->where('status', 1)->value('staff_id');
+    }
+
+    public function test_insert_persists_stod_touched_per_row_matching_what_the_frontend_sends(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $stocks = $this->pickFixtureStocks(2);
+        $this->assertCount(2, $stocks, 'fixture needs at least 2 distinct product_stocks rows in Gudang Pusat');
+        [$touchedStock, $untouchedStock] = $stocks;
+
+        $response = $this->post('/insertStockOpname', [
+            'sto_date' => now()->toDateString(),
+            'staff_id' => $this->staffId(),
+            'category_id' => $this->categoryId(),
+            'sto_notes' => 'PDF highlight test',
+            'is_draft' => 0,
+            'item' => json_encode([
+                [
+                    'product_id' => $touchedStock->product_id,
+                    'product_variant_id' => $touchedStock->product_variant_id,
+                    'stod_system' => $touchedStock->ps_stock.' pcs',
+                    'stod_real' => $touchedStock->ps_stock.' pcs',
+                    'stod_selisih' => '0 pcs',
+                    'stod_notes' => null,
+                    // What CreateStockOpname.js now sends when the staff actually typed a value.
+                    'stod_touched' => 1,
+                ],
+                [
+                    'product_id' => $untouchedStock->product_id,
+                    'product_variant_id' => $untouchedStock->product_variant_id,
+                    'stod_system' => $untouchedStock->ps_stock.' pcs',
+                    'stod_real' => $untouchedStock->ps_stock.' pcs',
+                    'stod_selisih' => '0 pcs',
+                    'stod_notes' => null,
+                    // Left blank client-side -> real qty auto-defaulted to system qty, not typed.
+                    'stod_touched' => 0,
+                ],
+            ]),
+        ]);
+        $response->assertStatus(200);
+        $stoId = (int) $response->json('sto_id');
+
+        $this->assertDatabaseHas('stock_opname_details', [
+            'sto_id' => $stoId,
+            'product_variant_id' => $touchedStock->product_variant_id,
+            'stod_touched' => 1,
+        ]);
+        $this->assertDatabaseHas('stock_opname_details', [
+            'sto_id' => $stoId,
+            'product_variant_id' => $untouchedStock->product_variant_id,
+            'stod_touched' => 0,
+        ]);
+
+        // getDetail() (what generateStockOpname() feeds the PDF view) must round-trip the flag.
+        $detail = StockOpnameDetail::getDetail(['sto_id' => $stoId])->keyBy('product_variant_id');
+        $this->assertSame(1, (int) $detail[$touchedStock->product_variant_id]->stod_touched);
+        $this->assertSame(0, (int) $detail[$untouchedStock->product_variant_id]->stod_touched);
+    }
+
+    private function renderOpnameRow(array $item): string
+    {
+        return View::make('Backoffice.PDF.Opname', [
+            'stockOpname' => ['sto_code' => 'SP0001', 'sto_date' => now()->toDateString(), 'sto_notes' => null],
+            'staff_name' => ['staff_name' => 'Tester'],
+            'status' => 'Disetujui',
+            'detail' => [$item],
+        ])->render();
+    }
+
+    public function test_untouched_row_gets_no_highlight(): void
+    {
+        $html = $this->renderOpnameRow([
+            'product_variant_sku' => 'SKU-UNTOUCHED',
+            'pr_name' => 'Produk Untouched',
+            'product_variant_name' => 'Default',
+            'stod_system' => '10 pcs',
+            'stod_real' => '10 pcs',
+            'stod_selisih' => '0 pcs',
+            'stod_notes' => null,
+            'stod_touched' => 0,
+        ]);
+
+        $this->assertStringNotContainsString(self::YELLOW, $html);
+        $this->assertStringNotContainsString(self::GREEN, $html);
+    }
+
+    public function test_touched_row_with_no_selisih_gets_green_highlight(): void
+    {
+        $html = $this->renderOpnameRow([
+            'product_variant_sku' => 'SKU-MATCH',
+            'pr_name' => 'Produk Match',
+            'product_variant_name' => 'Default',
+            'stod_system' => '10 pcs',
+            'stod_real' => '10 pcs',
+            'stod_selisih' => '0 pcs',
+            'stod_notes' => null,
+            'stod_touched' => 1,
+        ]);
+
+        $this->assertStringContainsString(self::GREEN, $html);
+        $this->assertStringNotContainsString(self::YELLOW, $html);
+    }
+
+    public function test_touched_row_with_selisih_gets_yellow_highlight(): void
+    {
+        $html = $this->renderOpnameRow([
+            'product_variant_sku' => 'SKU-DIFF',
+            'pr_name' => 'Produk Diff',
+            'product_variant_name' => 'Default',
+            'stod_system' => '10 pcs',
+            'stod_real' => '8 pcs',
+            'stod_selisih' => '-2 pcs',
+            'stod_notes' => null,
+            'stod_touched' => 1,
+        ]);
+
+        $this->assertStringContainsString(self::YELLOW, $html);
+        $this->assertStringNotContainsString(self::GREEN, $html);
+    }
+}

--- a/tests/Workflow/StockOpnamePdfLiveSystemStockTest.php
+++ b/tests/Workflow/StockOpnamePdfLiveSystemStockTest.php
@@ -1,0 +1,175 @@
+<?php
+
+namespace Tests\Workflow;
+
+use App\Http\Controllers\StockController;
+use App\Models\ProductStock;
+use App\Models\StockOpnameDetail;
+use App\Models\Unit;
+use Illuminate\Support\Facades\DB;
+use ReflectionMethod;
+use Tests\Support\ActingAsStaff;
+use Tests\TestCase;
+
+/**
+ * Follow-up to GitHub #53, reported by the user after the PDF-highlight fix shipped:
+ * stod_system/stod_selisih are frozen at creation/edit time and never refresh. The race that
+ * exposes it: Opname A is created (freezing "system stock" at that instant), then — before A is
+ * approved — Opname B for the SAME product is approved, which overwrites the real system stock.
+ * A's PDF, if printed while still pending, would silently show the stale pre-B system figure.
+ *
+ * Fix (StockController):
+ *  - accStockOpname()/accStockOpnameBahan() now re-freeze stod_system/stod_selisih (Bahan:
+ *    stobd_*) to the TRUE value used at approval — the same "before" figure already written to
+ *    log_stocks — instead of leaving the creation-time snapshot in place.
+ *  - refreshLiveSystemQty() (called from generateStockOpname()/generateStockOpnameBahan() only
+ *    for status==1/pending docs) recomputes system/selisih live from the already-attached
+ *    ->stock collection (see ProductVariant::getProductVariantBulk()/Supplies::getSuppliesBulk())
+ *    instead of trusting the stored string — an approved/rejected doc's frozen snapshot is a
+ *    deliberate historical record and must NOT be recomputed live.
+ */
+class StockOpnamePdfLiveSystemStockTest extends TestCase
+{
+    use ActingAsStaff;
+
+    private function pickFixtureStock(): ProductStock
+    {
+        return ProductStock::withoutGlobalScope('active_warehouse')
+            ->where('status', 1)
+            ->where('warehouse_id', 1) // Gudang Pusat (main), seeded 2026-08-01
+            ->where('ps_stock', '>', 30)
+            ->firstOrFail();
+    }
+
+    private function categoryId(): int
+    {
+        return (int) DB::table('categories')->where('status', 1)->value('category_id');
+    }
+
+    private function staffId(): int
+    {
+        return (int) DB::table('staffs')->where('status', 1)->value('staff_id');
+    }
+
+    private function unitShortName(ProductStock $stock): string
+    {
+        return (string) (Unit::find($stock->unit_id)->unit_short_name ?? 'pcs');
+    }
+
+    private function insertStockOpname(ProductStock $stock, string $unit, int $realQty): int
+    {
+        $response = $this->post('/insertStockOpname', [
+            'sto_date' => now()->toDateString(),
+            'staff_id' => $this->staffId(),
+            'category_id' => $this->categoryId(),
+            'sto_notes' => 'Live system stock race test',
+            'is_draft' => 0,
+            'item' => json_encode([[
+                'product_id' => $stock->product_id,
+                'product_variant_id' => $stock->product_variant_id,
+                'stod_system' => $stock->ps_stock.' '.$unit,
+                'stod_real' => $realQty.' '.$unit,
+                'stod_selisih' => ($realQty - $stock->ps_stock).' '.$unit,
+                'stod_notes' => null,
+                'stod_touched' => 1,
+            ]]),
+        ]);
+        $response->assertStatus(200);
+
+        return (int) $response->json('sto_id');
+    }
+
+    private function approve(ProductStock $stock, int $stoId, int $realQty): void
+    {
+        $this->post('/accStockOpname', [
+            'sto_id' => $stoId,
+            'item' => json_encode([[
+                'product_variant_id' => $stock->product_variant_id,
+                'units' => [[
+                    'unit_id' => $stock->unit_id,
+                    'real_qty' => $realQty,
+                ]],
+            ]]),
+        ])->assertStatus(200);
+    }
+
+    private function parseQty(?string $string, string $unit): ?int
+    {
+        if (!$string) {
+            return null;
+        }
+        foreach (explode(',', $string) as $part) {
+            [$qty, $u] = array_pad(explode(' ', trim($part)), 2, null);
+            if ($u === $unit) {
+                return (int) $qty;
+            }
+        }
+        return null;
+    }
+
+    public function test_a_still_pending_document_pdf_data_reflects_live_stock_not_the_stale_creation_time_snapshot(): void
+    {
+        $this->actingAsSuperAdminStaff();
+        $stock = $this->pickFixtureStock();
+        $unit = $this->unitShortName($stock);
+        $startingStock = $stock->ps_stock;
+
+        // A created first, matching system stock at that instant.
+        $stoIdA = $this->insertStockOpname($stock, $unit, realQty: $startingStock);
+
+        // Before A is approved, B (same product) is approved and moves the real stock.
+        $stoIdB = $this->insertStockOpname($stock, $unit, realQty: $startingStock - 15);
+        $this->approve($stock, $stoIdB, $startingStock - 15);
+
+        $stock->refresh();
+        $this->assertSame($startingStock - 15, $stock->ps_stock, "sanity: B's approval must have moved the live stock");
+
+        // Prove the stored row really is stale (this is the bug being guarded against).
+        $this->assertDatabaseHas('stock_opname_details', [
+            'sto_id' => $stoIdA,
+            'product_variant_id' => $stock->product_variant_id,
+            'stod_system' => $startingStock.' '.$unit,
+        ]);
+
+        // What generateStockOpname() feeds the PDF for a still-pending doc must be live, not that
+        // stale row -- refreshLiveSystemQty() is private, called only from there, so invoke it
+        // directly (ReflectionMethod is already an established pattern in this suite, see
+        // tests/Health/SchemaConsistencyTest.php).
+        $detail = StockOpnameDetail::getDetail(['sto_id' => $stoIdA]);
+        $refresh = new ReflectionMethod(StockController::class, 'refreshLiveSystemQty');
+        $refresh->setAccessible(true);
+        $refresh->invoke(new StockController(), $detail, 'stod_real', 'stod_system', 'stod_selisih', 'ps_stock');
+
+        $row = $detail->firstWhere('product_variant_id', $stock->product_variant_id);
+        $this->assertSame($startingStock - 15, $this->parseQty($row->stod_system, $unit), 'PDF data for a pending doc must show the CURRENT live system stock');
+        $this->assertSame(15, $this->parseQty($row->stod_selisih, $unit), 'selisih must be recomputed against the live system stock too');
+    }
+
+    public function test_approving_freezes_the_true_system_stock_at_that_moment_not_the_creation_time_one(): void
+    {
+        $this->actingAsSuperAdminStaff();
+        $stock = $this->pickFixtureStock();
+        $unit = $this->unitShortName($stock);
+        $startingStock = $stock->ps_stock;
+
+        $stoIdA = $this->insertStockOpname($stock, $unit, realQty: $startingStock);
+        $stoIdB = $this->insertStockOpname($stock, $unit, realQty: $startingStock - 15);
+        $this->approve($stock, $stoIdB, $startingStock - 15);
+
+        // A is approved with real_qty = $startingStock (the count taken before B's approval
+        // moved anything) -- accStockOpname() re-fetches live stock right before overwriting, so
+        // the true "before" value here is $startingStock - 15, NOT the stale creation-time
+        // $startingStock baked into A's stod_system.
+        $this->approve($stock, $stoIdA, $startingStock);
+
+        $row = StockOpnameDetail::where('sto_id', $stoIdA)
+            ->where('product_variant_id', $stock->product_variant_id)
+            ->firstOrFail();
+
+        $this->assertSame($startingStock - 15, $this->parseQty($row->stod_system, $unit), 'approval must freeze the TRUE system stock at approval time');
+        $this->assertSame(15, $this->parseQty($row->stod_selisih, $unit), 'the frozen selisih must reflect the true discrepancy found at approval, not a stale one');
+
+        $stock->refresh();
+        $this->assertSame($startingStock, $stock->ps_stock, "A's approval must still overwrite with A's own real_qty, unaffected by this fix");
+    }
+}


### PR DESCRIPTION
## Summary
Batch 9 of the fase1→fase2 merge — 6 new commits picked up from `main` since the last analysis (2026-08-17), on top of Batch 7.

- `e382b3d` — permission error notification message handler (#43): adds a `handlePermissionError(xhr)` helper checking for 403 responses, wired into ajax `error:` callbacks across ~10 JS files.
- `7f2270b` / `998770a` — print-time header adjustments for Tanda Terima PDF.
- `d751106` — Stock Opname PDF 3-way highlight + live system-stock at print time, and dashboard Changelog traceability (#53/#54).
- `63d8ead` — missing `is_draft` migration for stock_opnames/stock_opname_bahans.
- `4e5f299` — dashboard Changelog follow-ups (#56).

## Conflict resolution notes
Several JS files hit the recurring "stale duplicate from main's pre-refactor architecture" pattern (main's diff context predates fase2's DataTables server-side conversion). Resolved by discarding stale duplicate blocks and porting `handlePermissionError` onto fase2's real, current handlers — followed by a full sweep of every `error:` callback per file to confirm coverage. `Production.js` and `Sales_Order.js` needed missing-brace fixes after large conflict-block edits (verified via `node --check` + diff against the pre-merge blob).

`StockController.php` had a real 3-way conflict: fase2 already carries its own LogStock diff-based accounting (from an earlier batch) that main's `d751106` doesn't know about. Ported main's new stod_system/stod_selisih dashboard-traceability write-back onto fase2's existing `$oldQty`/`$newQty` variables instead of reintroducing main's old `$beforeStock` pattern.

## Standing hold check
Per `cdocs/docs/fase2-merge-plan.md`, Batch 9 does **not** touch `accProduction()`/`accDeleteProduction()` in `ProductionController.php` (confirmed via `git diff --name-only` — that file isn't touched at all in this batch). No hold applies.

## Testing
Full suite (Smoke/Health/Workflow/Regression/DatabaseTransaction) run on this branch and diffed against a baseline worktree of the pre-batch-9 tip (`b14b816`):
- This branch: 409 tests, 1240 assertions, 23 failures, 10 skipped.
- Baseline: 395 tests, 1179 assertions, 23 failures, 10 skipped.
- **Failure sets are identical** — zero regressions. The 14 extra tests (3 new Batch-9 test files) all pass. The 23 pre-existing failures are unrelated, already-known Production/Stock-Opname issues on `fase2/merge-fase1-into-fase2` before this batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)