### PR TITLE
fix(db): backfill stod_touched/stobd_touched untuk dokumen Stock Opname lama

### DIFF
--- a/database/migrations/2026_08_21_010000_backfill_stod_touched_from_real_vs_system.php
+++ b/database/migrations/2026_08_21_010000_backfill_stod_touched_from_real_vs_system.php
@@ -1,0 +1,57 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Follow-up to GitHub #53's PDF highlight (see 2026_08_14_010000_add_touched_to_stock_opname_...
+ * -tables): that migration added stod_touched/stobd_touched with a blanket default(false) but
+ * never backfilled it, so EVERY row written before 2026-08-14 is stuck at "untouched" -- the PDF
+ * (Backoffice/PDF/Opname.blade.php + OpnameBahan.blade.php) now silently shows NO highlight at
+ * all for those documents, whether the row genuinely had a selisih (should be yellow) or matched
+ * exactly (should be green), because both states render identically once touched=0.
+ *
+ * Confirmed against the live `pegasus` DB 2026-08-21: 227 stock_opname_details rows and 820
+ * stock_opname_detail_bahans rows have a real genuine selisih (stod_real != stod_system) but are
+ * still touched=0.
+ *
+ * Backfill is one-directional and only handles the deterministic half of the bug: if stod_real
+ * differs from stod_system, that difference can ONLY exist because a staff member typed it --
+ * CreateStockOpname.js/CreateStockOpnameSupplies.js always default real = system when the input
+ * is left blank (see insertData()). So any mismatch is unambiguous proof of human input, safe to
+ * mark touched=1.
+ *
+ * NOT fixed here (and not fixable): pre-2026-08-14 rows where real == system. Whether that was a
+ * staff member typing the exact matching value (should be green) or leaving the field blank
+ * (should stay unhighlighted) is genuinely unrecoverable -- both produce the identical stored
+ * string, and the distinguishing signal (the client-side "was this input non-blank" flag) was
+ * simply never captured before that migration existed. Left as untouched (the conservative
+ * default); documents created/edited since 2026-08-14 already track this correctly going forward.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasColumn('stock_opname_details', 'stod_touched')) {
+            DB::table('stock_opname_details')
+                ->where('stod_touched', 0)
+                ->whereColumn('stod_real', '<>', 'stod_system')
+                ->update(['stod_touched' => 1]);
+        }
+
+        if (Schema::hasColumn('stock_opname_detail_bahans', 'stobd_touched')) {
+            DB::table('stock_opname_detail_bahans')
+                ->where('stobd_touched', 0)
+                ->whereColumn('stobd_real', '<>', 'stobd_system')
+                ->update(['stobd_touched' => 1]);
+        }
+    }
+
+    public function down(): void
+    {
+        // Deliberately irreversible: we have no record of which touched=1 rows this backfill set
+        // vs. which were already genuinely touched=1 before it ran, so there is nothing safe to
+        // revert to. Rolling back would either no-op or destroy real data -- neither is correct.
+    }
+};

--- a/database/sql/2026_08_21_010000_backfill_stod_touched_from_real_vs_system.sql
+++ b/database/sql/2026_08_21_010000_backfill_stod_touched_from_real_vs_system.sql
@@ -1,0 +1,44 @@
+-- Migration: 2026_08_21_010000_backfill_stod_touched_from_real_vs_system
+-- Idempotent (re-running only affects rows still stuck at touched=0). Alternatif: php artisan migrate
+--
+-- GitHub #53 follow-up: stod_touched/stobd_touched (2026_08_14_010000_add_touched_to_stock_opname_
+-- ..._tables) were added with default(false) and never backfilled -- every row written before that
+-- migration is stuck "untouched", so the PDF highlight (Backoffice/PDF/Opname.blade.php +
+-- OpnameBahan.blade.php) silently shows NO color for those documents' rows, whether they had a
+-- genuine selisih (should be yellow) or matched exactly (should be green).
+--
+-- Only the deterministic half is backfillable: if stod_real != stod_system, that can only exist
+-- because a staff member typed it (the JS always defaults real = system when left blank), so it's
+-- safe to mark touched=1. Rows where real == system stay untouched -- unrecoverably ambiguous
+-- whether that was a typed match or a blank field, see the migration file for the full writeup.
+
+SET @db := DATABASE();
+
+SET @sql := IF(
+  (SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+   WHERE TABLE_SCHEMA = @db AND TABLE_NAME = 'stock_opname_details' AND COLUMN_NAME = 'stod_touched') = 1,
+  'UPDATE `stock_opname_details`
+     SET `stod_touched` = 1
+     WHERE `stod_touched` = 0 AND `stod_real` <> `stod_system`',
+  'SELECT ''skip stock_opname_details backfill'' AS info'
+);
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql := IF(
+  (SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+   WHERE TABLE_SCHEMA = @db AND TABLE_NAME = 'stock_opname_detail_bahans' AND COLUMN_NAME = 'stobd_touched') = 1,
+  'UPDATE `stock_opname_detail_bahans`
+     SET `stobd_touched` = 1
+     WHERE `stobd_touched` = 0 AND `stobd_real` <> `stobd_system`',
+  'SELECT ''skip stock_opname_detail_bahans backfill'' AS info'
+);
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- Catat di migrations (supaya artisan migrate tidak bentrok)
+INSERT INTO `migrations` (`migration`, `batch`)
+SELECT '2026_08_21_010000_backfill_stod_touched_from_real_vs_system',
+       (SELECT IFNULL(MAX(batch), 0) + 1 FROM migrations AS m)
+WHERE EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = @db AND TABLE_NAME = 'migrations')
+  AND NOT EXISTS (SELECT 1 FROM `migrations` WHERE `migration` = '2026_08_21_010000_backfill_stod_touched_from_real_vs_system');
+
+SELECT '2026_08_21_010000_backfill_stod_touched_from_real_vs_system OK' AS result;

--- a/tests/Workflow/StockOpnameTouchedBackfillTest.php
+++ b/tests/Workflow/StockOpnameTouchedBackfillTest.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Tests\Workflow;
+
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+/**
+ * GitHub #53 follow-up, reported by the user after the PDF highlight fix shipped: reprinting an
+ * OLD Stock Opname (created before 2026-08-14) showed no highlight at all, even for rows with a
+ * genuine selisih. Root cause: stod_touched/stobd_touched (added by
+ * 2026_08_14_010000_add_touched_to_stock_opname_details_tables) were added with a blanket
+ * default(false) and never backfilled -- every pre-existing row is stuck "untouched", and the PDF
+ * (Backoffice/PDF/Opname.blade.php + OpnameBahan.blade.php) renders untouched exactly like an
+ * exact match: no color either way.
+ *
+ * Confirmed empirically against the live `pegasus` DB 2026-08-21: 227 stock_opname_details rows
+ * and 820 stock_opname_detail_bahans rows had stod_real/stobd_real != stod_system/stobd_system
+ * (proof of real human input -- CreateStockOpname.js/CreateStockOpnameSupplies.js always default
+ * real = system when the field is left blank) but were still touched=0.
+ *
+ * See database/migrations/2026_08_21_010000_backfill_stod_touched_from_real_vs_system.php for the
+ * one-directional backfill and why the real==system case (staff typed a matching value vs. left
+ * it blank) is deliberately NOT touched -- that distinction is unrecoverable for pre-existing rows.
+ */
+class StockOpnameTouchedBackfillTest extends TestCase
+{
+    private function runBackfill(): void
+    {
+        $migration = require database_path('migrations/2026_08_21_010000_backfill_stod_touched_from_real_vs_system.php');
+        $migration->up();
+    }
+
+    public function test_mismatched_legacy_row_gets_backfilled_to_touched(): void
+    {
+        $id = DB::table('stock_opname_details')->insertGetId([
+            'sto_id' => 1,
+            'product_id' => 1,
+            'product_variant_id' => 1,
+            'stod_system' => '210 pcs',
+            'stod_real' => '214 pcs',
+            'stod_selisih' => '4 pcs',
+            'stod_touched' => 0,
+            'status' => 1,
+        ]);
+
+        $this->runBackfill();
+
+        $this->assertSame(1, (int) DB::table('stock_opname_details')->where('stod_id', $id)->value('stod_touched'));
+    }
+
+    public function test_exact_match_legacy_row_stays_untouched_because_it_is_unrecoverably_ambiguous(): void
+    {
+        $id = DB::table('stock_opname_details')->insertGetId([
+            'sto_id' => 1,
+            'product_id' => 1,
+            'product_variant_id' => 1,
+            'stod_system' => '210 pcs',
+            'stod_real' => '210 pcs',
+            'stod_selisih' => '0 pcs',
+            'stod_touched' => 0,
+            'status' => 1,
+        ]);
+
+        $this->runBackfill();
+
+        $this->assertSame(0, (int) DB::table('stock_opname_details')->where('stod_id', $id)->value('stod_touched'));
+    }
+
+    public function test_already_touched_row_is_left_alone(): void
+    {
+        $id = DB::table('stock_opname_details')->insertGetId([
+            'sto_id' => 1,
+            'product_id' => 1,
+            'product_variant_id' => 1,
+            'stod_system' => '210 pcs',
+            'stod_real' => '214 pcs',
+            'stod_selisih' => '4 pcs',
+            'stod_touched' => 1,
+            'status' => 1,
+        ]);
+
+        $this->runBackfill();
+
+        $this->assertSame(1, (int) DB::table('stock_opname_details')->where('stod_id', $id)->value('stod_touched'));
+    }
+
+    public function test_bahan_mismatched_legacy_row_gets_backfilled_to_touched(): void
+    {
+        $id = DB::table('stock_opname_detail_bahans')->insertGetId([
+            'stob_id' => 1,
+            'supplies_id' => 1,
+            'stobd_system' => '210 kg',
+            'stobd_real' => '214 kg',
+            'stobd_selisih' => '4 kg',
+            'stobd_touched' => 0,
+            'status' => 1,
+        ]);
+
+        $this->runBackfill();
+
+        $this->assertSame(1, (int) DB::table('stock_opname_detail_bahans')->where('stobd_id', $id)->value('stobd_touched'));
+    }
+
+    public function test_bahan_exact_match_legacy_row_stays_untouched(): void
+    {
+        $id = DB::table('stock_opname_detail_bahans')->insertGetId([
+            'stob_id' => 1,
+            'supplies_id' => 1,
+            'stobd_system' => '210 kg',
+            'stobd_real' => '210 kg',
+            'stobd_selisih' => '0 kg',
+            'stobd_touched' => 0,
+            'status' => 1,
+        ]);
+
+        $this->runBackfill();
+
+        $this->assertSame(0, (int) DB::table('stock_opname_detail_bahans')->where('stobd_id', $id)->value('stobd_touched'));
+    }
+}


### PR DESCRIPTION
## Ringkasan

Follow-up dari #53. Highlight 3-state (kuning/hijau/tanpa warna) di PDF Stock Opname (Produk & Bahan) sudah benar untuk dokumen yang dibuat **setelah** kolom `stod_touched`/`stobd_touched` ditambahkan, tapi kolom itu ditambahkan dengan `default(false)` dan **tidak pernah di-backfill** untuk baris yang sudah ada sebelumnya — jadi setiap dokumen lama yang dicetak ulang tampil **tanpa highlight sama sekali**.

## Laporan user

1. Stock sistem 210, stock real 214, selisih 4 — seharusnya kuning, tapi tidak ter-highlight.
2. Beberapa baris yang sudah diisi manual dan nilainya cocok persis dengan sistem — seharusnya hijau, tapi tidak ter-highlight.

## Root cause

`2026_08_14_010000_add_touched_to_stock_opname_details_tables` menambahkan kolom dengan default `false` tanpa migrasi data untuk baris lama. PDF (`Backoffice/PDF/Opname.blade.php` + `OpnameBahan.blade.php`) merender "belum pernah disentuh" persis sama dengan "cocok persis" — sama-sama tanpa warna — jadi baris lama kehilangan highlight-nya sepenuhnya, baik yang seharusnya kuning maupun hijau.

Dibuktikan langsung ke DB `pegasus`: 227 baris `stock_opname_details` dan 820 baris `stock_opname_detail_bahans` punya `real != system` (bukti input manusia asli — `CreateStockOpname.js`/`CreateStockOpnameSupplies.js` selalu menyamakan real = system kalau field dikosongkan) tapi masih `touched=0`. Dokumen yang dibuat setelah fix #53 (mis. sto_id 63) sudah benar — jadi mekanismenya sendiri tidak bermasalah, murni data lama yang belum termigrasi.

## Fix

- `database/migrations/2026_08_21_010000_backfill_stod_touched_from_real_vs_system.php` + companion SQL di `database/sql/` — backfill `touched=1` untuk semua baris lama dengan `real != system`. Ini satu-satunya bagian yang bisa dipastikan aman, karena selisih itu cuma bisa terjadi dari input manusia.
- Kasus `real == system` pada baris lama **sengaja tidak** di-backfill — datanya ambigu (tidak bisa dibedakan antara "staf mengetik angka yang sama dengan sistem" vs "field dikosongkan lalu auto-default"), jadi dibiarkan default (tanpa highlight) daripada menebak dan salah. Ini hanya berdampak ke dokumen lama; dokumen baru ke depannya sudah ter-track dengan benar.
- Sudah diverifikasi manual oleh user juga.

## Testing

- `tests/Workflow/StockOpnameTouchedBackfillTest.php` (5 test baru, termasuk kasus 210/214/4 persis seperti laporan user).
- Full suite Stock Opname: 31 test, semua hijau.
- Migration sudah dijalankan & diverifikasi di DB lokal `pegasus` dan `pegasus_testing`.

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)