### PR TITLE
Batch 10: Stock Opname touched-backfill + getLog module fix (main → fase2)

### DIFF
--- a/app/Http/Controllers/GeneralController.php
+++ b/app/Http/Controllers/GeneralController.php
@@ -6,6 +6,7 @@ use App\Models\Area;
 use App\Models\LogStock;
 use App\Models\Product;
 use App\Models\ProductStock;
+use App\Support\RoleAccess;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Session;
 
@@ -59,7 +60,24 @@ class GeneralController extends Controller
         return (new Area())->deleteArea($data);
     }
 
+    /**
+     * Riwayat Stok Produk / Bahan Mentah modal (Stock_Product.js & Stock_Supplies.js).
+     * `log_type` (1=produk, 2=bahan mentah -- see LogStock::getLog()) decides which module's
+     * `view` access is required: staf yang punya akses 'Daftar Produk' boleh lihat histori
+     * produk, staf yang punya akses 'Daftar Bahan Mentah' boleh lihat histori bahan mentah.
+     * check.access middleware tidak bisa mengekspresikan ini karena modulnya tergantung
+     * parameter request, bukan route yang tetap (GitHub #68).
+     */
     function getLog(Request $req){
+        $module = match ((int) $req->input('log_type')) {
+            1 => 'Daftar Produk',
+            2 => 'Daftar Bahan Mentah',
+            default => null,
+        };
+        if ($module === null || !RoleAccess::can(Session::get('user'), $module, 'view')) {
+            abort(403, 'Unauthorized');
+        }
+
         $data = (new LogStock())->getLog($req->all());
         return response()->json($data);
     }

--- a/database/migrations/2026_08_21_010000_backfill_stod_touched_from_real_vs_system.php
+++ b/database/migrations/2026_08_21_010000_backfill_stod_touched_from_real_vs_system.php
@@ -1,0 +1,57 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Follow-up to GitHub #53's PDF highlight (see 2026_08_14_010000_add_touched_to_stock_opname_...
+ * -tables): that migration added stod_touched/stobd_touched with a blanket default(false) but
+ * never backfilled it, so EVERY row written before 2026-08-14 is stuck at "untouched" -- the PDF
+ * (Backoffice/PDF/Opname.blade.php + OpnameBahan.blade.php) now silently shows NO highlight at
+ * all for those documents, whether the row genuinely had a selisih (should be yellow) or matched
+ * exactly (should be green), because both states render identically once touched=0.
+ *
+ * Confirmed against the live `pegasus` DB 2026-08-21: 227 stock_opname_details rows and 820
+ * stock_opname_detail_bahans rows have a real genuine selisih (stod_real != stod_system) but are
+ * still touched=0.
+ *
+ * Backfill is one-directional and only handles the deterministic half of the bug: if stod_real
+ * differs from stod_system, that difference can ONLY exist because a staff member typed it --
+ * CreateStockOpname.js/CreateStockOpnameSupplies.js always default real = system when the input
+ * is left blank (see insertData()). So any mismatch is unambiguous proof of human input, safe to
+ * mark touched=1.
+ *
+ * NOT fixed here (and not fixable): pre-2026-08-14 rows where real == system. Whether that was a
+ * staff member typing the exact matching value (should be green) or leaving the field blank
+ * (should stay unhighlighted) is genuinely unrecoverable -- both produce the identical stored
+ * string, and the distinguishing signal (the client-side "was this input non-blank" flag) was
+ * simply never captured before that migration existed. Left as untouched (the conservative
+ * default); documents created/edited since 2026-08-14 already track this correctly going forward.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasColumn('stock_opname_details', 'stod_touched')) {
+            DB::table('stock_opname_details')
+                ->where('stod_touched', 0)
+                ->whereColumn('stod_real', '<>', 'stod_system')
+                ->update(['stod_touched' => 1]);
+        }
+
+        if (Schema::hasColumn('stock_opname_detail_bahans', 'stobd_touched')) {
+            DB::table('stock_opname_detail_bahans')
+                ->where('stobd_touched', 0)
+                ->whereColumn('stobd_real', '<>', 'stobd_system')
+                ->update(['stobd_touched' => 1]);
+        }
+    }
+
+    public function down(): void
+    {
+        // Deliberately irreversible: we have no record of which touched=1 rows this backfill set
+        // vs. which were already genuinely touched=1 before it ran, so there is nothing safe to
+        // revert to. Rolling back would either no-op or destroy real data -- neither is correct.
+    }
+};

--- a/database/sql/2026_08_21_010000_backfill_stod_touched_from_real_vs_system.sql
+++ b/database/sql/2026_08_21_010000_backfill_stod_touched_from_real_vs_system.sql
@@ -1,0 +1,44 @@
+-- Migration: 2026_08_21_010000_backfill_stod_touched_from_real_vs_system
+-- Idempotent (re-running only affects rows still stuck at touched=0). Alternatif: php artisan migrate
+--
+-- GitHub #53 follow-up: stod_touched/stobd_touched (2026_08_14_010000_add_touched_to_stock_opname_
+-- ..._tables) were added with default(false) and never backfilled -- every row written before that
+-- migration is stuck "untouched", so the PDF highlight (Backoffice/PDF/Opname.blade.php +
+-- OpnameBahan.blade.php) silently shows NO color for those documents' rows, whether they had a
+-- genuine selisih (should be yellow) or matched exactly (should be green).
+--
+-- Only the deterministic half is backfillable: if stod_real != stod_system, that can only exist
+-- because a staff member typed it (the JS always defaults real = system when left blank), so it's
+-- safe to mark touched=1. Rows where real == system stay untouched -- unrecoverably ambiguous
+-- whether that was a typed match or a blank field, see the migration file for the full writeup.
+
+SET @db := DATABASE();
+
+SET @sql := IF(
+  (SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+   WHERE TABLE_SCHEMA = @db AND TABLE_NAME = 'stock_opname_details' AND COLUMN_NAME = 'stod_touched') = 1,
+  'UPDATE `stock_opname_details`
+     SET `stod_touched` = 1
+     WHERE `stod_touched` = 0 AND `stod_real` <> `stod_system`',
+  'SELECT ''skip stock_opname_details backfill'' AS info'
+);
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql := IF(
+  (SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+   WHERE TABLE_SCHEMA = @db AND TABLE_NAME = 'stock_opname_detail_bahans' AND COLUMN_NAME = 'stobd_touched') = 1,
+  'UPDATE `stock_opname_detail_bahans`
+     SET `stobd_touched` = 1
+     WHERE `stobd_touched` = 0 AND `stobd_real` <> `stobd_system`',
+  'SELECT ''skip stock_opname_detail_bahans backfill'' AS info'
+);
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- Catat di migrations (supaya artisan migrate tidak bentrok)
+INSERT INTO `migrations` (`migration`, `batch`)
+SELECT '2026_08_21_010000_backfill_stod_touched_from_real_vs_system',
+       (SELECT IFNULL(MAX(batch), 0) + 1 FROM migrations AS m)
+WHERE EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = @db AND TABLE_NAME = 'migrations')
+  AND NOT EXISTS (SELECT 1 FROM `migrations` WHERE `migration` = '2026_08_21_010000_backfill_stod_touched_from_real_vs_system');
+
+SELECT '2026_08_21_010000_backfill_stod_touched_from_real_vs_system OK' AS result;

--- a/routes/web.php
+++ b/routes/web.php
@@ -101,21 +101,13 @@ Route::middleware(checkLogin::class)->group(function () {
     Route::post('/autocompleteWarehouseType', [AutocompleteController::class, 'autocompleteWarehouseType']);
     Route::post('/autocompleteWarehouse', [AutocompleteController::class, 'autocompleteWarehouse'])->name('autocompleteWarehouse');
 
-    Route::middleware('check.access:Kategori|view')->group(function () {});
-    Route::middleware('check.access:Satuan|view')->group(function () {});
-    Route::middleware('check.access:Variasi|view')->group(function () {});
-    Route::middleware('check.access:Resep Bahan Mentah|view')->group(function () {});
-    Route::middleware('check.access.any:Daftar Produk,Stok Produk,Pengiriman,Produksi,Produk Bermasalah,view')->group(function () {});
-    Route::middleware('check.access.any:Daftar Bahan Mentah,Stok Bahan Mentah,Pembelian,Produksi,Resep Bahan Mentah,Pengelolaan Bahan Mentah,Produk Bermasalah,view')->group(function () {});
-    Route::middleware('check.access.any:Armada,Pengiriman,view')->group(function () {});
-    Route::middleware('check.access.any:Pemasok,Pembelian,view')->group(function () {});
-    Route::middleware('check.access.any:Pengguna,Pengiriman,Pembelian,Produksi,Kas Operasional Admin,Kas Admin,Kas Operasional Gudang,Kas Gudang,Kas Operasional Armada,Kas Armada,Kas Operasional Sales,Kas Sales,Kas Operasional,view')->group(function () {});
-    Route::middleware('check.access:Pengiriman|view')->group(function () {});
-    Route::middleware('check.access.any:Kategori Kas,Kas Operasional Admin,Kas Admin,Kas Operasional Gudang,Kas Gudang,Kas Operasional Armada,Kas Armada,Kas Operasional Sales,Kas Sales,Kas Operasional,Kas,view')->group(function () {});
-    Route::middleware('check.access:Peran & Perizinan|view')->group(function () {});
-    Route::middleware('check.access.any:Bank Account,Hutang,view')->group(function () {});
-    Route::middleware('check.access:Pembelian|view')->group(function () {});
-    Route::middleware('check.access:Pengiriman|view')->group(function () {});
+    // Riwayat Stok Produk / Bahan Mentah modal (Stock_Product.js & Stock_Supplies.js) -- dulu
+    // salah tergabung ke grup 'Peran & Perizinan|view' sehingga staf QC & Gudang yang cuma
+    // punya akses 'Daftar Produk'/'Daftar Bahan Mentah' kena 403 saat buka histori stok
+    // (GitHub #68). Modul yang dicek tergantung request-nya (log_type: produk vs bahan mentah),
+    // jadi check.access middleware yang statis per-route tidak bisa mengekspresikan ini --
+    // GeneralController::getLog() sendiri yang memvalidasi lewat RoleAccess.
+    Route::get('/getLog', [GeneralController::class, 'getLog'])->name('getLog');
 
     Route::middleware('check.access:Kategori|view')->group(function () {
         Route::get('/category', [ProductController::class, 'Category'])->name('category');
@@ -494,7 +486,6 @@ Route::middleware(checkLogin::class)->group(function () {
         Route::get('/permission/{id}', [UserController::class, 'permission'])->name('permission');
         Route::get('/dashboardWidgets/{id}', [UserController::class, 'dashboardWidgets'])->name('dashboardWidgets');
         Route::get('/getPermission', [UserController::class, 'getPermission'])->name('getPermission');
-        Route::get('/getLog', [GeneralController::class, 'getLog'])->name('getLog');
     });
     Route::middleware('check.access:Peran & Perizinan|create')->group(function () {
         Route::post('/insertRole', [UserController::class, 'insertRole'])->name('insertRole');

--- a/tests/Regression/GetLogGatedByWrongModuleTest.php
+++ b/tests/Regression/GetLogGatedByWrongModuleTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Tests\Regression;
+
+use Tests\Support\ActingAsStaff;
+use Tests\TestCase;
+
+/**
+ * ✅ FIXED (2026-08-21): `GET /getLog` backs the "Riwayat Stok Produk"/"Riwayat Stok Bahan Mentah"
+ * history modal on the Stock Produk (`/stockProduct`) and Stock Bahan Mentah (`/stockSupplies`)
+ * pages (Stock_Product.js / Stock_Supplies.js). It was registered inside the
+ * `check.access:Peran & Perizinan|view` route group — an unrelated admin-only module ("Peran &
+ * Perizinan" = Roles & Permissions) — instead of being reachable by staff who actually have access
+ * to view stock data. QC & Gudang staff who could open those pages got a 403 the moment they
+ * clicked into a variant's stock history, with no explanatory message on the frontend
+ * (GitHub #68 — "Staf QC & Gudang tidak bisa akses history stok").
+ *
+ * Fix, round 1: moved `/getLog` out of the `Peran & Perizinan|view` group into the login-only
+ * utility area (same treatment as `/autocomplete*`), since no static `check.access:Module|ability`
+ * middleware string could express "either Stok Produk or Stok Bahan Mentah" without hitting the
+ * check.access.any first-module-only bug (see memory `pegasus-check-access-any-bug`).
+ *
+ * Fix, round 2 (per explicit product decision): the module actually required is `Daftar Produk`
+ * for product history (`log_type=1`) and `Daftar Bahan Mentah` for bahan mentah history
+ * (`log_type=2`) — not the Stok Produk/Stok Bahan Mentah page-view modules. Since the module needed
+ * depends on a *request parameter* (`log_type`), not a fixed route, no `check.access` middleware
+ * string can express it either — `GeneralController::getLog()` now validates inline via
+ * `RoleAccess::can()`, keyed off `log_type`, and aborts 403 for a missing/unrecognized `log_type`
+ * or a staff member lacking the corresponding module's `view` ability.
+ *
+ * See cdocs/testing/KNOWN_ISSUES.md.
+ */
+class GetLogGatedByWrongModuleTest extends TestCase
+{
+    use ActingAsStaff;
+
+    public function test_staff_with_daftar_produk_access_can_view_product_history(): void
+    {
+        $this->actingAsStaffWithOnlyPermission('Daftar Produk', ['view']);
+
+        $this->get('/getLog?log_type=1&log_item_id=1')->assertOk();
+    }
+
+    public function test_staff_with_daftar_produk_access_cannot_view_bahan_mentah_history(): void
+    {
+        $this->actingAsStaffWithOnlyPermission('Daftar Produk', ['view']);
+
+        $this->get('/getLog?log_type=2&log_item_id=1')->assertForbidden();
+    }
+
+    public function test_staff_with_daftar_bahan_mentah_access_can_view_bahan_mentah_history(): void
+    {
+        $this->actingAsStaffWithOnlyPermission('Daftar Bahan Mentah', ['view']);
+
+        $this->get('/getLog?log_type=2&log_item_id=1')->assertOk();
+    }
+
+    public function test_staff_with_daftar_bahan_mentah_access_cannot_view_product_history(): void
+    {
+        $this->actingAsStaffWithOnlyPermission('Daftar Bahan Mentah', ['view']);
+
+        $this->get('/getLog?log_type=1&log_item_id=1')->assertForbidden();
+    }
+
+    public function test_staff_with_only_stok_produk_page_access_cannot_view_product_history(): void
+    {
+        // Confirms the fix really keys off 'Daftar Produk', not 'Stok Produk' (the page itself) --
+        // a role granted only the stock-page module must still be denied.
+        $this->actingAsStaffWithOnlyPermission('Stok Produk', ['view']);
+
+        $this->get('/getLog?log_type=1&log_item_id=1')->assertForbidden();
+    }
+
+    public function test_staff_with_no_access_at_all_is_blocked(): void
+    {
+        $this->actingAsStaffWithNoAccess();
+
+        $this->get('/getLog?log_type=1&log_item_id=1')->assertForbidden();
+    }
+
+    public function test_missing_log_type_is_blocked_even_for_a_privileged_staff(): void
+    {
+        $this->actingAsStaffWithOnlyPermission('Daftar Produk', ['view']);
+
+        $this->get('/getLog?log_item_id=1')->assertForbidden();
+    }
+
+    public function test_guest_is_redirected_to_login(): void
+    {
+        $this->get('/getLog?log_type=1&log_item_id=1')->assertRedirect('/login');
+    }
+}

--- a/tests/Workflow/StockOpnameTouchedBackfillTest.php
+++ b/tests/Workflow/StockOpnameTouchedBackfillTest.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Tests\Workflow;
+
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+/**
+ * GitHub #53 follow-up, reported by the user after the PDF highlight fix shipped: reprinting an
+ * OLD Stock Opname (created before 2026-08-14) showed no highlight at all, even for rows with a
+ * genuine selisih. Root cause: stod_touched/stobd_touched (added by
+ * 2026_08_14_010000_add_touched_to_stock_opname_details_tables) were added with a blanket
+ * default(false) and never backfilled -- every pre-existing row is stuck "untouched", and the PDF
+ * (Backoffice/PDF/Opname.blade.php + OpnameBahan.blade.php) renders untouched exactly like an
+ * exact match: no color either way.
+ *
+ * Confirmed empirically against the live `pegasus` DB 2026-08-21: 227 stock_opname_details rows
+ * and 820 stock_opname_detail_bahans rows had stod_real/stobd_real != stod_system/stobd_system
+ * (proof of real human input -- CreateStockOpname.js/CreateStockOpnameSupplies.js always default
+ * real = system when the field is left blank) but were still touched=0.
+ *
+ * See database/migrations/2026_08_21_010000_backfill_stod_touched_from_real_vs_system.php for the
+ * one-directional backfill and why the real==system case (staff typed a matching value vs. left
+ * it blank) is deliberately NOT touched -- that distinction is unrecoverable for pre-existing rows.
+ */
+class StockOpnameTouchedBackfillTest extends TestCase
+{
+    private function runBackfill(): void
+    {
+        $migration = require database_path('migrations/2026_08_21_010000_backfill_stod_touched_from_real_vs_system.php');
+        $migration->up();
+    }
+
+    public function test_mismatched_legacy_row_gets_backfilled_to_touched(): void
+    {
+        $id = DB::table('stock_opname_details')->insertGetId([
+            'sto_id' => 1,
+            'product_id' => 1,
+            'product_variant_id' => 1,
+            'stod_system' => '210 pcs',
+            'stod_real' => '214 pcs',
+            'stod_selisih' => '4 pcs',
+            'stod_touched' => 0,
+            'status' => 1,
+        ]);
+
+        $this->runBackfill();
+
+        $this->assertSame(1, (int) DB::table('stock_opname_details')->where('stod_id', $id)->value('stod_touched'));
+    }
+
+    public function test_exact_match_legacy_row_stays_untouched_because_it_is_unrecoverably_ambiguous(): void
+    {
+        $id = DB::table('stock_opname_details')->insertGetId([
+            'sto_id' => 1,
+            'product_id' => 1,
+            'product_variant_id' => 1,
+            'stod_system' => '210 pcs',
+            'stod_real' => '210 pcs',
+            'stod_selisih' => '0 pcs',
+            'stod_touched' => 0,
+            'status' => 1,
+        ]);
+
+        $this->runBackfill();
+
+        $this->assertSame(0, (int) DB::table('stock_opname_details')->where('stod_id', $id)->value('stod_touched'));
+    }
+
+    public function test_already_touched_row_is_left_alone(): void
+    {
+        $id = DB::table('stock_opname_details')->insertGetId([
+            'sto_id' => 1,
+            'product_id' => 1,
+            'product_variant_id' => 1,
+            'stod_system' => '210 pcs',
+            'stod_real' => '214 pcs',
+            'stod_selisih' => '4 pcs',
+            'stod_touched' => 1,
+            'status' => 1,
+        ]);
+
+        $this->runBackfill();
+
+        $this->assertSame(1, (int) DB::table('stock_opname_details')->where('stod_id', $id)->value('stod_touched'));
+    }
+
+    public function test_bahan_mismatched_legacy_row_gets_backfilled_to_touched(): void
+    {
+        $id = DB::table('stock_opname_detail_bahans')->insertGetId([
+            'stob_id' => 1,
+            'supplies_id' => 1,
+            'stobd_system' => '210 kg',
+            'stobd_real' => '214 kg',
+            'stobd_selisih' => '4 kg',
+            'stobd_touched' => 0,
+            'status' => 1,
+        ]);
+
+        $this->runBackfill();
+
+        $this->assertSame(1, (int) DB::table('stock_opname_detail_bahans')->where('stobd_id', $id)->value('stobd_touched'));
+    }
+
+    public function test_bahan_exact_match_legacy_row_stays_untouched(): void
+    {
+        $id = DB::table('stock_opname_detail_bahans')->insertGetId([
+            'stob_id' => 1,
+            'supplies_id' => 1,
+            'stobd_system' => '210 kg',
+            'stobd_real' => '210 kg',
+            'stobd_selisih' => '0 kg',
+            'stobd_touched' => 0,
+            'status' => 1,
+        ]);
+
+        $this->runBackfill();
+
+        $this->assertSame(0, (int) DB::table('stock_opname_detail_bahans')->where('stobd_id', $id)->value('stobd_touched'));
+    }
+}


### PR DESCRIPTION
## Summary
Batch 10 of the fase1→fase2 merge — the 2 new commits `main` picked up since the last accounted point (`4e5f299`, Batch 9's last commit), found via `git cherry origin/fase2/main origin/main` after ruling out patch-id noise from the many earlier batches' conflict-resolved cherry-picks (their content differs from `main`'s originals, so `git cherry` isn't reliable for detecting them — used `git log 4e5f299..origin/main` instead).

- `3a2dacb` — GitHub #67: backfills `stod_touched`/`stobd_touched` on pre-existing Stock Opname rows (the earlier #53 PDF-highlight fix only ever set these going forward; old documents still showed no highlight even with a real `real != system` discrepancy). New migration + matching `database/sql/` patch + `tests/Workflow/StockOpnameTouchedBackfillTest.php`.
- `8a9ed99` — GitHub #68: `/getLog` (backs the Riwayat Stok Produk/Bahan Mentah history modal) was gated behind the unrelated `Peran & Perizinan|view` module, 403'ing QC/Gudang staff who only have `Daftar Produk`/`Daftar Bahan Mentah`. Moved to an inline `RoleAccess::can()` check in `GeneralController::getLog()` keyed off `log_type`, since no static `check.access` middleware can express a module that depends on a request param. Also removes ~15 pre-existing dead empty `check.access` route groups (verified zero-route, safe to delete regardless of route list changes) as part of the same PR upstream.

## Standing hold check
Neither commit touches `accProduction()`/`accDeleteProduction()` (`ProductionController.php` isn't in either commit's diff) — no hold needed.

## Conflict resolution
One real conflict in `routes/web.php`: HEAD (post-final-merge `fase2/main`) still carried the ~15 dead empty `check.access` route groups this same upstream commit removes — confirmed each is genuinely empty-bodied (`function () {}`, zero routes regardless of duplication) before deleting, then added the new `/getLog` route in their place. `GeneralController.php` auto-merged clean. Verified exactly one `/getLog` route registered afterward, gated only by `checkLogin` (module check happens inline), 464 total routes.

## Testing
Full suite (Smoke/Health/Workflow/Regression/DatabaseTransaction), same-directory same-DB-reseed comparison against `origin/fase2/main` tip to eliminate a worktree/cache-path artifact that was producing misleading run-to-run noise:
- This branch: 545 tests, 53 failures.
- `fase2/main` baseline (same dir, same fresh reseed): 532 tests, 53 failures.
- **Failure sets are byte-identical** — zero new regressions. The 13 new tests (`GetLogGatedByWrongModuleTest`, `StockOpnameTouchedBackfillTest`) all pass. The 53 pre-existing failures are unrelated, already-known issues on `fase2/main` (Production/Purchase-Order/Stock-Opname areas, tracked in `cdocs/testing/KNOWN_ISSUES.md`).
- Verified using the known workaround for GitHub #38 (`app/Models/PurchaseOrdersDetail.php` duplicate-class fatal, deliberately left unfixed) — untracked local removal only, never touched in either committed tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
