### PR TITLE
fix: accProduction ladder cascade penuh + Stock Opname PDF persist live stock

### DIFF
--- a/app/Http/Controllers/ProductionController.php
+++ b/app/Http/Controllers/ProductionController.php
@@ -790,13 +790,15 @@ class ProductionController extends Controller
             }
 
             $jumlahTambah = (int) $value['pd_qty'];
-            $r = ProductRelation::where('pr_unit_id_2', '=', $v->unit_id)
-                ->where('product_variant_id', '=', $value['product_variant_id'])
-                ->where('status', '=', 1)
-                ->first();
+            // Ditambahkan (2026-08-24): dulu cuma cek satu hop ke atas ($r tunggal) — sekarang
+            // menyusuri seluruh rantai lewat creditProductOutputUpChain() (read-only) supaya
+            // konfirmasi "baris stok baru akan dibuat" ini juga menyebutkan level KEDUA/KETIGA dst,
+            // bukan cuma level pertama, sebelum accProduction() benar-benar mengkreditnya di bawah.
+            $chain = $this->creditProductOutputUpChain((int) $value['product_variant_id'], (int) $v->unit_id, $jumlahTambah);
 
-            if ($r && $jumlahTambah >= $r->pr_unit_value_2) {
-                foreach ([$r->pr_unit_id_1, $r->pr_unit_id_2] as $unitId) {
+            if (count($chain) > 1) {
+                foreach ($chain as $credit) {
+                    $unitId = $credit['unit_id'];
                     $exists = ProductStock::where('product_variant_id', $value['product_variant_id'])
                         ->where('unit_id', $unitId)
                         ->where('status', 1)
@@ -1039,53 +1041,32 @@ class ProductionController extends Controller
             }
             $jumlahTambah = (int) $value['pd_qty'];
             if ($v && $v->unit_id == $unitIdInputUser) {
-                // cek ada relasi endak
-                    // cek dulu ada endak yang belakangnya relasi itu
-                    $r = ProductRelation::where('pr_unit_id_2', '=', $v->unit_id)
-                        ->where('product_variant_id', '=', $value["product_variant_id"])->where('status','=',1)->first();
-                   
-                    // cek jumlahnya melibih penglipatnya endak
-                    if ($r&&$jumlahTambah >= $r->pr_unit_value_2) {
-                        //kalau isa cari berapa tambah dan sisanya
-                        $tambah = floor($jumlahTambah / $r->pr_unit_value_2);
-                        $sisa = $jumlahTambah%$r->pr_unit_value_2;
-                        //sekarang kita tambah yang awal dulu
-                        $ps_depan = $this->ensureProductStockRow((int) $value["product_variant_id"], (int) $r->pr_unit_id_1);
-                        $ps_depan->ps_stock += $tambah;
-                        $ps_depan->save();
+                // GitHub #19 fix (2026-08-24): naik berjenjang lewat SELURUH rantai product_relations
+                // (bukan cuma satu hop) -- lihat creditProductOutputUpChain() di atas. Setiap level
+                // yang dilewati dikredit dan dicatat log_stocks-nya sendiri; level yang sisa
+                // hasil-baginya 0 (semuanya habis naik ke level berikutnya) tidak perlu disentuh sama
+                // sekali.
+                $chain = $this->creditProductOutputUpChain((int) $value["product_variant_id"], (int) $v->unit_id, $jumlahTambah);
 
-                        //sekarang kita tambah yang belakang
-                        $ps_belakang = $this->ensureProductStockRow((int) $value["product_variant_id"], (int) $r->pr_unit_id_2);
-                        $ps_belakang->ps_stock += $sisa;
-                        $ps_belakang->save();
+                if (count($chain) > 1) {
+                    foreach ($chain as $credit) {
+                        if ($credit['qty'] <= 0) continue;
+
+                        $ps = $this->ensureProductStockRow((int) $value["product_variant_id"], $credit['unit_id']);
+                        $ps->ps_stock += $credit['qty'];
+                        $ps->save();
+
                         $insertProductLogOnce([
                             'log_date' => \Carbon\Carbon::parse($p->production_date)->setTimeFrom(now()),
                             'log_kode' => $p->production_code,
                             'log_type' => 1, 'log_category' => 1,
                             'log_item_id' => $value["product_variant_id"],
                             'log_notes' => "Hasil Produksi Produk " . LogStock::actorSuffix(),
-                            'log_jumlah' => $tambah, 'unit_id' => $r->pr_unit_id_1,
+                            'log_jumlah' => $credit['qty'], 'unit_id' => $credit['unit_id'],
                         ]);
-                        
-                        if($sisa>0){
-                            $insertProductLogOnce([
-                                'log_date' => \Carbon\Carbon::parse($p->production_date)->setTimeFrom(now()),
-                                'log_kode' => $p->production_code,
-                                'log_type' => 1, 'log_category' => 1,
-                                'log_item_id' => $value["product_variant_id"],
-                                'log_notes' => "Hasil Produksi Produk " . LogStock::actorSuffix(),
-                                'log_jumlah' => $sisa, 'unit_id' => $r->pr_unit_id_2,
-                            ]);
-                        }
-
-                        //cek lagi ada endak atasnya kalau ada tapi ya jumlah e gak iso ya gak akan motong cuman taku kalau bertingkat
-                        $cek = $r = ProductRelation::where('pr_unit_id_2', '=', $r->pr_unit_id_1)
-                            ->where('product_variant_id', '=', $value["product_variant_id"]);
-                        if ($cek->count() <= 0) {
-                            $ada = -1;
-                        }
-                    } else  {
-                          //sekarang kita tambah yang belakang 
+                    }
+                } else  {
+                          //sekarang kita tambah yang belakang
                         $v->ps_stock += $jumlahTambah;
                         $v->save();
 
@@ -1656,6 +1637,56 @@ class ProductionController extends Controller
         }
 
         return $qty;
+    }
+
+    /**
+     * PM task (2026-08-24): accProduction()'s finished-goods output crediting used to roll a
+     * produced quantity up ONE level of product_relations only (see the dead $cek/$ada lookup this
+     * replaced) — a quantity that was an exact multiple of a SECOND level (e.g. 24 Piece = 2 DOS =
+     * 1 Sak) stalled at DOS and never reached Sak. This walks the WHOLE chain, mirroring the
+     * already-correct "bongkar" direction (convertQtyToSmallestUnit()/$siapkanStok above), just
+     * upward instead of downward.
+     *
+     * Pure/read-only — does no DB writes itself, just returns the list of {unit_id, qty} to credit,
+     * ordered from $startUnitId up to the highest level actually reached. The caller (accProduction())
+     * does the ProductStock += and logging. Reused as-is by the pre-check block above to find every
+     * unit level a split might touch, not just the first hop.
+     *
+     * @return array<int, array{unit_id:int, qty:int}>
+     */
+    private function creditProductOutputUpChain(int $productVariantId, int $startUnitId, int $qty): array
+    {
+        $relations = ProductRelation::where('product_variant_id', $productVariantId)
+            ->where('status', 1)
+            ->get();
+
+        $credits = [];
+        $currentUnitId = $startUnitId;
+        $remaining = $qty;
+        $guard = 0;
+
+        while ($guard < 20) {
+            $guard++;
+            $rel = $relations->first(fn ($r) => (int) $r->pr_unit_id_2 === (int) $currentUnitId);
+            if (!$rel || $remaining < $rel->pr_unit_value_2) {
+                break;
+            }
+
+            $tambah = (int) floor($remaining / $rel->pr_unit_value_2);
+            $sisa = $remaining % $rel->pr_unit_value_2;
+
+            $credits[] = ['unit_id' => (int) $currentUnitId, 'qty' => (int) $sisa];
+
+            $currentUnitId = (int) $rel->pr_unit_id_1;
+            $remaining = $tambah;
+        }
+
+        // Sisa/titik teratas yang benar-benar dicapai (baik karena rantainya habis, atau qty yang
+        // dibawa tidak cukup untuk naik lagi) — kalau tidak pernah ada hop sama sekali, ini satu-satunya
+        // entri dan sama dengan {startUnitId, qty} apa adanya (perilaku lama untuk produk tanpa ladder).
+        $credits[] = ['unit_id' => $currentUnitId, 'qty' => (int) $remaining];
+
+        return $credits;
     }
 
     private function getBatchCount(

--- a/app/Http/Controllers/StockController.php
+++ b/app/Http/Controllers/StockController.php
@@ -191,12 +191,21 @@ class StockController extends Controller
      * dengan angka sistem yang sudah basi. getDetail()/getDetailBulk() sudah menempelkan koleksi
      * stok LIVE per unit (`->stock`, lihat ProductVariant::getProductVariantBulk()/
      * Supplies::getSuppliesBulk()) -- pakai itu, bukan string yang tersimpan, TAPI HANYA untuk
-     * dokumen yang belum diputuskan (status masih 1/menunggu). Snapshot dokumen yang sudah
-     * disetujui/ditolak adalah catatan historis yang sengaja dibekukan (lihat accStockOpname() --
-     * dibekukan ke nilai sebenarnya saat itu terjadi) dan TIDAK BOLEH dihitung ulang live, atau
-     * dokumen yang sudah disetujui akan selalu terlihat "tidak ada selisih" selamanya setelahnya.
+     * dokumen yang belum diputuskan (status masih 1/menunggu -- ini juga mencakup dokumen yang
+     * masih draft/fase 2, karena is_draft tidak mengubah status, lihat StockOpname::insertStockOpname()).
+     * Snapshot dokumen yang sudah disetujui/ditolak adalah catatan historis yang sengaja dibekukan
+     * (lihat accStockOpname() -- dibekukan ke nilai sebenarnya saat itu terjadi) dan TIDAK BOLEH
+     * dihitung ulang live, atau dokumen yang sudah disetujui akan selalu terlihat "tidak ada
+     * selisih" selamanya setelahnya.
+     *
+     * PM task (2026-08-24): dulu hasil refresh ini cuma dipakai untuk tampilan PDF sesaat ($item di
+     * sini adalah clone ProductVariant/Supplies, bukan row StockOpnameDetail/StockOpnameDetailBahan
+     * asli -- lihat StockOpnameDetail::getDetail() -- jadi memanggil save() di atasnya akan salah
+     * tabel). Sekarang juga ditulis balik ke baris detail ASLI (lewat $detailModelClass::find())
+     * supaya data yang tersimpan di DB ikut mengikuti stok live setiap kali PDF-nya di-download,
+     * bukan cuma pas di-ACC.
      */
-    private function refreshLiveSystemQty($detail, string $realKey, string $systemKey, string $selisihKey, string $stockQtyKey)
+    private function refreshLiveSystemQty($detail, string $realKey, string $systemKey, string $selisihKey, string $stockQtyKey, string $detailModelClass, string $detailIdKey)
     {
         foreach ($detail as $item) {
             $liveByUnit = [];
@@ -215,6 +224,13 @@ class StockController extends Controller
 
             $item->{$systemKey} = $this->buildQtyString($liveByUnit);
             $item->{$selisihKey} = $this->buildQtyString($selisihByUnit);
+
+            $row = $detailModelClass::find($item->{$detailIdKey} ?? null);
+            if ($row) {
+                $row->{$systemKey} = $item->{$systemKey};
+                $row->{$selisihKey} = $item->{$selisihKey};
+                $row->save();
+            }
         }
 
         return $detail;
@@ -400,7 +416,7 @@ class StockController extends Controller
         $param["detail"] = (new StockOpnameDetail())->getDetail(['sto_id' => $id]);
 
         if ((int) $param['stockOpname']['status'] === 1) {
-            $this->refreshLiveSystemQty($param['detail'], 'stod_real', 'stod_system', 'stod_selisih', 'ps_stock');
+            $this->refreshLiveSystemQty($param['detail'], 'stod_real', 'stod_system', 'stod_selisih', 'ps_stock', StockOpnameDetail::class, 'stod_id');
         }
 
         if ($param['stockOpname']['status'] == 1) $param['status'] = "Menunggu";
@@ -654,7 +670,7 @@ class StockController extends Controller
         $param["detail"] = (new StockOpnameDetailBahan())->getDetail(['stob_id' => $id]);
 
         if ((int) $param['stockOpname']['status'] === 1) {
-            $this->refreshLiveSystemQty($param['detail'], 'stobd_real', 'stobd_system', 'stobd_selisih', 'ss_stock');
+            $this->refreshLiveSystemQty($param['detail'], 'stobd_real', 'stobd_system', 'stobd_selisih', 'ss_stock', StockOpnameDetailBahan::class, 'stobd_id');
         }
 
         if ($param['stockOpname']['status'] == 1) $param['status'] = "Menunggu";

--- a/tests/Regression/ProductionOutputConversionDoesNotCascadeMultipleLevelsTest.php
+++ b/tests/Regression/ProductionOutputConversionDoesNotCascadeMultipleLevelsTest.php
@@ -17,29 +17,34 @@ use Tests\Support\ActingAsStaff;
 use Tests\TestCase;
 
 /**
- * Bug: `ProductionController::accProduction()`'s finished-goods "ladder split"
- * (`ProductionController.php:956-1004`) only ever rolls a produced quantity up ONE level of a
- * product's `product_relations` ladder, even when a second level exists above that.
+ * ✅ FIXED (2026-08-24, GitHub #19): `ProductionController::accProduction()`'s finished-goods
+ * "ladder split" used to roll a produced quantity up ONE level of a product's `product_relations`
+ * ladder only, even when a second level existed above that.
  *
- * The code visibly checks for a further level right after doing the first split:
+ * The old code visibly checked for a further level right after doing the first split:
  *
  *   $cek = $r = ProductRelation::where('pr_unit_id_2', '=', $r->pr_unit_id_1)
  *       ->where('product_variant_id', '=', $value["product_variant_id"]);
  *   if ($cek->count() <= 0) { $ada = -1; }
  *
- * ...but `$ada` is never read anywhere else in the method, and `$r` is reassigned to a Builder
- * (not `->first()`'d) that's never used either — this lookup is dead code. Whatever the second
- * level's count is, nothing further happens: the credited quantity stays stranded at the
- * first-level unit, never rolling up into the second level even when the quantity is an exact
+ * ...but `$ada` was never read anywhere else in the method, and `$r` was reassigned to a Builder
+ * (not `->first()`'d) that was never used either — that lookup was dead code. Whatever the second
+ * level's count was, nothing further happened: the credited quantity stayed stranded at the
+ * first-level unit, never rolling up into the second level even when the quantity was an exact
  * multiple of it.
  *
+ * Fixed by `ProductionController::creditProductOutputUpChain()` — a pure helper that walks the
+ * WHOLE `product_relations` chain (guarded at 20 hops), mirroring the already-correct
+ * ingredient-side "bongkar" direction (`$siapkanStok`/`convertQtyToSmallestUnit()`), just upward
+ * instead of downward. The pre-check block right before `accProduction()`'s DB transaction (which
+ * warns the user before silently creating a new zero-stock `ProductStock` row) now also walks the
+ * full chain via the same helper, so a second/third-level row gets the same "confirm creation"
+ * prompt a first-level row already got.
+ *
  * Worked example this test reproduces: a 3-level ladder (1 Sak = 2 DOS = 24 Piece). Producing 24
- * Piece should, if the ladder were followed all the way, land as 1 full Sak with 0 left at the DOS
- * or Piece level. Instead: `floor(24/12)=2` lands on the DOS-level `ProductStock` row and stays
- * there — the Sak-level row is never touched, even though 2 DOS is an EXACT multiple of the
- * Sak ratio (2). This mirrors the same "one level only" shape as the ingredient-side "bongkar"
- * mechanism, which — unlike this one — recurses correctly via `$siapkanStok`'s own recursive call
- * (see `ProductionUnitConversionFlowTest`). See `workflows/PRODUCTION_FLOW.md`.
+ * Piece, following the ladder all the way, lands as 1 full Sak with 0 left at the DOS or Piece
+ * level — `floor(24/12)=2` DOS is itself an exact multiple of the Sak ratio (2), so it keeps
+ * rolling up instead of stopping at the DOS-level `ProductStock` row. See `workflows/PRODUCTION_FLOW.md`.
  */
 class ProductionOutputConversionDoesNotCascadeMultipleLevelsTest extends TestCase
 {
@@ -50,7 +55,7 @@ class ProductionOutputConversionDoesNotCascadeMultipleLevelsTest extends TestCas
     private const SAK_UNIT_ID = 25;
     private const WAREHOUSE_ID = 1;
 
-    public function test_producing_an_exact_multiple_of_the_second_ladder_level_still_stalls_at_the_first_level(): void
+    public function test_producing_an_exact_multiple_of_the_second_ladder_level_now_rolls_all_the_way_up(): void
     {
         $this->actingAsSuperAdminStaff();
 
@@ -188,32 +193,34 @@ class ProductionOutputConversionDoesNotCascadeMultipleLevelsTest extends TestCas
 
         $this->assertSame(0, $pieceStock->ps_stock, 'no remainder at the Piece level — 24 is an exact multiple of 12');
         $this->assertSame(
-            2,
+            0,
             $dosStock->ps_stock,
-            'BUG: stops at the first ladder level — floor(24/12)=2 lands here and stays, even though 2 DOS is itself an exact multiple of the Sak ratio'
+            'FIXED: 2 DOS is itself an exact multiple of the Sak ratio, so it keeps rolling up instead of stalling here'
         );
         $this->assertSame(
-            0,
+            1,
             $sakStock->ps_stock,
-            'BUG: the second ladder level is never credited at all — the dead $cek/$ada check never actually rolls anything up into it'
+            'FIXED: the second ladder level is now credited — the chain walk reaches Sak and lands the full 1 Sak there'
         );
 
-        // Only one "Hasil Produksi" log is written (DOS level) — no Sak-level log exists at all,
-        // confirming the cascade genuinely never runs rather than running and rounding to zero.
+        // Only one "Hasil Produksi" log is written (Sak level, qty 1) — the DOS/Piece levels ended
+        // up with a 0 remainder at every hop, so creditProductOutputUpChain()'s caller skips
+        // logging (and touching) them entirely; confirms the cascade genuinely reaches the top
+        // rather than stopping partway and rounding to zero.
         $this->assertDatabaseHas('log_stocks', [
             'log_type' => 1,
             'log_category' => 1,
             'log_item_id' => $variant->product_variant_id,
-            'unit_id' => self::DOS_UNIT_ID,
-            'log_jumlah' => 2,
+            'unit_id' => self::SAK_UNIT_ID,
+            'log_jumlah' => 1,
         ]);
         $this->assertSame(
             0,
             DB::table('log_stocks')
                 ->where('log_item_id', $variant->product_variant_id)
-                ->where('unit_id', self::SAK_UNIT_ID)
+                ->where('unit_id', self::DOS_UNIT_ID)
                 ->count(),
-            'no log_stocks row was ever written for the Sak level'
+            'no log_stocks row is written for the DOS level — it never actually gained any stock (0 remainder)'
         );
     }
 }

--- a/tests/Workflow/StockOpnameBahanPdfLiveSystemStockPersistTest.php
+++ b/tests/Workflow/StockOpnameBahanPdfLiveSystemStockPersistTest.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace Tests\Workflow;
+
+use App\Models\Category;
+use App\Models\Supplies;
+use App\Models\SuppliesStock;
+use App\Models\StockOpnameDetailBahan;
+use App\Models\Unit;
+use Illuminate\Support\Facades\DB;
+use Tests\Support\ActingAsStaff;
+use Tests\TestCase;
+
+/**
+ * Bahan (Supplies) mirror of StockOpnamePdfLiveSystemStockTest's PM task (2026-08-24) coverage —
+ * refreshLiveSystemQty() is one shared method parameterized for both Produk and Bahan (see
+ * StockController::generateStockOpnameBahan()), but the two call sites pass different model
+ * classes/keys (StockOpnameDetailBahan::class/'stobd_id' vs StockOpnameDetail::class/'stod_id'),
+ * so this exercises that wiring specifically rather than assuming the Produk-side test alone
+ * proves it.
+ */
+class StockOpnameBahanPdfLiveSystemStockPersistTest extends TestCase
+{
+    use ActingAsStaff;
+
+    /** Built fresh via Eloquent — see StockOpnamePdfLiveSystemStockTest::pickFixtureStock()'s
+     * docblock for why real seeded/live data isn't hand-picked here (multi-warehouse collisions). */
+    private function pickFixtureStock(): SuppliesStock
+    {
+        $unit = Unit::where('status', 1)->firstOrFail();
+
+        $supplies = new Supplies();
+        $supplies->supplies_name = 'Opname Bahan PDF Persist Test Ingredient '.uniqid();
+        $supplies->supplies_unit = json_encode([$unit->unit_id]);
+        $supplies->supplies_default_unit = $unit->unit_id;
+        $supplies->status = 1;
+        $supplies->save();
+
+        $stock = new SuppliesStock();
+        $stock->supplies_id = $supplies->supplies_id;
+        $stock->unit_id = $unit->unit_id;
+        $stock->warehouse_id = 1;
+        $stock->ss_stock = 100;
+        $stock->status = 1;
+        $stock->save();
+
+        return $stock;
+    }
+
+    private function staffId(): int
+    {
+        return (int) DB::table('staffs')->where('status', 1)->value('staff_id');
+    }
+
+    private function unitShortName(SuppliesStock $stock): string
+    {
+        return (string) (Unit::find($stock->unit_id)->unit_short_name ?? 'pcs');
+    }
+
+    private function insertStockOpnameBahan(SuppliesStock $stock, string $unit, int $realQty, bool $isDraft = false): int
+    {
+        $response = $this->post('/insertStockOpnameBahan', [
+            'stob_date' => now()->toDateString(),
+            'staff_id' => $this->staffId(),
+            'stob_notes' => 'PDF persistence Bahan test',
+            'is_draft' => $isDraft ? 1 : 0,
+            'item' => json_encode([[
+                'supplies_id' => $stock->supplies_id,
+                'stobd_system' => $stock->ss_stock.' '.$unit,
+                'stobd_real' => $realQty.' '.$unit,
+                'stobd_selisih' => ($realQty - $stock->ss_stock).' '.$unit,
+                'stobd_notes' => null,
+                'stobd_touched' => 1,
+            ]]),
+        ]);
+        $response->assertStatus(200);
+
+        return (int) $response->json('stob_id');
+    }
+
+    private function approve(SuppliesStock $stock, int $stobId, int $realQty): void
+    {
+        $this->post('/accStockOpnameBahan', [
+            'stob_id' => $stobId,
+            'item' => json_encode([[
+                'supplies_id' => $stock->supplies_id,
+                'sp_units' => [[
+                    'unit_id' => $stock->unit_id,
+                    'real_qty' => $realQty,
+                ]],
+            ]]),
+        ])->assertStatus(200);
+    }
+
+    public function test_downloading_the_pdf_persists_live_stock_to_the_real_bahan_row_for_a_draft_document(): void
+    {
+        $this->actingAsSuperAdminStaff();
+        $stock = $this->pickFixtureStock();
+        $unit = $this->unitShortName($stock);
+        $startingStock = $stock->ss_stock;
+
+        $stobIdDraft = $this->insertStockOpnameBahan($stock, $unit, realQty: $startingStock, isDraft: true);
+        $this->assertDatabaseHas('stock_opname_bahans', ['stob_id' => $stobIdDraft, 'is_draft' => 1, 'status' => 1]);
+
+        // A different opname on the same ingredient gets approved first, moving the live stock.
+        $otherStobId = $this->insertStockOpnameBahan($stock, $unit, realQty: $startingStock - 12);
+        $this->approve($stock, $otherStobId, $startingStock - 12);
+        $stock->refresh();
+        $this->assertSame($startingStock - 12, $stock->ss_stock, 'sanity: the other approval must have moved the live stock');
+
+        // Downloading the still-draft doc's PDF must persist the now-current live stock to its row.
+        $this->get('/generateStockOpnameBahan/'.$stobIdDraft)->assertStatus(200);
+        $this->assertDatabaseHas('stock_opname_detail_bahans', [
+            'stob_id' => $stobIdDraft,
+            'supplies_id' => $stock->supplies_id,
+            'stobd_system' => ($startingStock - 12).' '.$unit,
+            'stobd_selisih' => '12 '.$unit,
+        ]);
+    }
+
+    public function test_downloading_the_pdf_for_an_already_decided_bahan_document_does_not_touch_its_frozen_row(): void
+    {
+        $this->actingAsSuperAdminStaff();
+        $stock = $this->pickFixtureStock();
+        $unit = $this->unitShortName($stock);
+        $startingStock = $stock->ss_stock;
+
+        $stobId = $this->insertStockOpnameBahan($stock, $unit, realQty: $startingStock);
+        $this->approve($stock, $stobId, $startingStock);
+
+        $frozenBefore = StockOpnameDetailBahan::where('stob_id', $stobId)
+            ->where('supplies_id', $stock->supplies_id)
+            ->firstOrFail();
+
+        $otherStobId = $this->insertStockOpnameBahan($stock, $unit, realQty: $startingStock - 9);
+        $this->approve($stock, $otherStobId, $startingStock - 9);
+
+        $this->get('/generateStockOpnameBahan/'.$stobId)->assertStatus(200);
+
+        $this->assertDatabaseHas('stock_opname_detail_bahans', [
+            'stob_id' => $stobId,
+            'supplies_id' => $stock->supplies_id,
+            'stobd_system' => $frozenBefore->stobd_system,
+            'stobd_selisih' => $frozenBefore->stobd_selisih,
+        ]);
+    }
+}

--- a/tests/Workflow/StockOpnamePdfLiveSystemStockTest.php
+++ b/tests/Workflow/StockOpnamePdfLiveSystemStockTest.php
@@ -3,7 +3,10 @@
 namespace Tests\Workflow;
 
 use App\Http\Controllers\StockController;
+use App\Models\Category;
+use App\Models\Product;
 use App\Models\ProductStock;
+use App\Models\ProductVariant;
 use App\Models\StockOpnameDetail;
 use App\Models\Unit;
 use Illuminate\Support\Facades\DB;
@@ -27,18 +30,68 @@ use Tests\TestCase;
  *    ->stock collection (see ProductVariant::getProductVariantBulk()/Supplies::getSuppliesBulk())
  *    instead of trusting the stored string — an approved/rejected doc's frozen snapshot is a
  *    deliberate historical record and must NOT be recomputed live.
+ *
+ * PM task (2026-08-24): refreshLiveSystemQty() used to only mutate the in-memory clone handed to
+ * the PDF view — the underlying stock_opname_details/stock_opname_detail_bahans row stayed stale
+ * until accStockOpname()/accStockOpnameBahan() froze it. Now it also writes stod_system/
+ * stod_selisih (stobd_* for Bahan) back to the real row it was cloned from, via
+ * $detailModelClass::find($item->{$detailIdKey}), every time the PDF is downloaded — but the
+ * status==1 gate around the call site is unchanged, so this still only ever fires for a
+ * draft (is_draft=true, "fase 2") or submitted-but-pending document (both have status==1 — see
+ * StockOpname::insertStockOpname()/submitStockOpname(), is_draft never touches status), never for
+ * an approved/rejected one.
  */
 class StockOpnamePdfLiveSystemStockTest extends TestCase
 {
     use ActingAsStaff;
 
+    /**
+     * Built fresh via Eloquent rather than picked from seeded/live data (per cdocs/testing's
+     * "fixtures too entangled to hand-pick cleanly" guidance): refreshLiveSystemQty() builds
+     * stod_system/stod_selisih from the item's WHOLE ->stock collection (every ACTIVE ProductStock
+     * row for that product_variant_id across ALL warehouses, no warehouse_id filter at all — see
+     * ProductVariant::getProductVariantBulk()), keyed only by unit_short_name. The local DB this
+     * suite runs against has real multi-warehouse data where the SAME unit has several rows across
+     * different warehouses (confirmed empirically) — picking one of those would make the live
+     * recompute silently collide/overwrite across warehouses and produce a flaky, meaningless
+     * result. A brand-new product+variant with exactly ONE ProductStock row total sidesteps that
+     * entirely, same technique as ProductionFlowTest::createFixture().
+     */
     private function pickFixtureStock(): ProductStock
     {
-        return ProductStock::withoutGlobalScope('active_warehouse')
-            ->where('status', 1)
-            ->where('warehouse_id', 1) // Gudang Pusat (main), seeded 2026-08-01
-            ->where('ps_stock', '>', 30)
-            ->firstOrFail();
+        $unit = Unit::where('status', 1)->firstOrFail();
+
+        $category = new Category();
+        $category->category_name = 'Opname PDF Live Stock Test Category';
+        $category->status = 1;
+        $category->save();
+
+        $product = new Product();
+        $product->product_name = 'Opname PDF Live Stock Test Product '.uniqid();
+        $product->category_id = $category->category_id;
+        $product->product_unit = json_encode([$unit->unit_id]);
+        $product->unit_id = $unit->unit_id;
+        $product->status = 1;
+        $product->save();
+
+        $variant = new ProductVariant();
+        $variant->product_id = $product->product_id;
+        $variant->product_variant_name = 'Opname PDF Live Stock Test Variant';
+        $variant->product_variant_sku = 'WF-OPNAME-PDF-'.uniqid();
+        $variant->product_variant_price = 0;
+        $variant->status = 1;
+        $variant->save();
+
+        $stock = new ProductStock();
+        $stock->product_id = $product->product_id;
+        $stock->product_variant_id = $variant->product_variant_id;
+        $stock->unit_id = $unit->unit_id;
+        $stock->warehouse_id = 1;
+        $stock->ps_stock = 100;
+        $stock->status = 1;
+        $stock->save();
+
+        return $stock;
     }
 
     private function categoryId(): int
@@ -138,11 +191,109 @@ class StockOpnamePdfLiveSystemStockTest extends TestCase
         $detail = StockOpnameDetail::getDetail(['sto_id' => $stoIdA]);
         $refresh = new ReflectionMethod(StockController::class, 'refreshLiveSystemQty');
         $refresh->setAccessible(true);
-        $refresh->invoke(new StockController(), $detail, 'stod_real', 'stod_system', 'stod_selisih', 'ps_stock');
+        $refresh->invoke(new StockController(), $detail, 'stod_real', 'stod_system', 'stod_selisih', 'ps_stock', StockOpnameDetail::class, 'stod_id');
 
         $row = $detail->firstWhere('product_variant_id', $stock->product_variant_id);
         $this->assertSame($startingStock - 15, $this->parseQty($row->stod_system, $unit), 'PDF data for a pending doc must show the CURRENT live system stock');
         $this->assertSame(15, $this->parseQty($row->stod_selisih, $unit), 'selisih must be recomputed against the live system stock too');
+
+        // PM task (2026-08-24): this must now also be true of the REAL stock_opname_details row,
+        // not just the in-memory clone handed to the PDF view.
+        $this->assertDatabaseHas('stock_opname_details', [
+            'sto_id' => $stoIdA,
+            'product_variant_id' => $stock->product_variant_id,
+            'stod_system' => ($startingStock - 15).' '.$unit,
+            'stod_selisih' => '15 '.$unit,
+        ]);
+    }
+
+    public function test_downloading_the_pdf_persists_live_stock_to_the_real_row_for_both_draft_and_waiting_documents(): void
+    {
+        $this->actingAsSuperAdminStaff();
+        $stock = $this->pickFixtureStock();
+        $unit = $this->unitShortName($stock);
+        $startingStock = $stock->ps_stock;
+
+        // Fase 2 draft (is_draft=1) — still status==1 under the hood (see StockOpname::insertStockOpname()).
+        $draftResponse = $this->post('/insertStockOpname', [
+            'sto_date' => now()->toDateString(),
+            'staff_id' => $this->staffId(),
+            'category_id' => $this->categoryId(),
+            'sto_notes' => 'PDF persistence draft test',
+            'is_draft' => 1,
+            'item' => json_encode([[
+                'product_id' => $stock->product_id,
+                'product_variant_id' => $stock->product_variant_id,
+                'stod_system' => $startingStock.' '.$unit,
+                'stod_real' => $startingStock.' '.$unit,
+                'stod_selisih' => '0 '.$unit,
+                'stod_notes' => null,
+                'stod_touched' => 0,
+            ]]),
+        ]);
+        $draftResponse->assertStatus(200);
+        $stoIdDraft = (int) $draftResponse->json('sto_id');
+        $this->assertDatabaseHas('stock_opnames', ['sto_id' => $stoIdDraft, 'is_draft' => 1, 'status' => 1]);
+
+        // Some OTHER opname moves the live stock before the draft's PDF is ever downloaded.
+        $otherStoId = $this->insertStockOpname($stock, $unit, realQty: $startingStock - 7);
+        $this->approve($stock, $otherStoId, $startingStock - 7);
+        $stock->refresh();
+        $this->assertSame($startingStock - 7, $stock->ps_stock, 'sanity: the other approval must have moved the live stock');
+
+        // Downloading the still-draft doc's PDF must persist the now-current live stock to its row.
+        $this->get('/generateStockOpname/'.$stoIdDraft)->assertStatus(200);
+        $this->assertDatabaseHas('stock_opname_details', [
+            'sto_id' => $stoIdDraft,
+            'product_variant_id' => $stock->product_variant_id,
+            'stod_system' => ($startingStock - 7).' '.$unit,
+        ]);
+
+        // Submitting (leaving draft) then downloading again must keep persisting — status is
+        // unchanged by submitStockOpname(), only is_draft flips.
+        $this->post('/submitStockOpname', ['sto_id' => $stoIdDraft])->assertStatus(200);
+        $this->assertDatabaseHas('stock_opnames', ['sto_id' => $stoIdDraft, 'is_draft' => 0, 'status' => 1]);
+
+        $stoIdC = $this->insertStockOpname($stock, $unit, realQty: $startingStock - 20);
+        $this->approve($stock, $stoIdC, $startingStock - 20);
+        $stock->refresh();
+
+        $this->get('/generateStockOpname/'.$stoIdDraft)->assertStatus(200);
+        $this->assertDatabaseHas('stock_opname_details', [
+            'sto_id' => $stoIdDraft,
+            'product_variant_id' => $stock->product_variant_id,
+            'stod_system' => $stock->ps_stock.' '.$unit,
+        ]);
+    }
+
+    public function test_downloading_the_pdf_for_an_already_decided_document_does_not_touch_its_frozen_row(): void
+    {
+        $this->actingAsSuperAdminStaff();
+        $stock = $this->pickFixtureStock();
+        $unit = $this->unitShortName($stock);
+        $startingStock = $stock->ps_stock;
+
+        $stoId = $this->insertStockOpname($stock, $unit, realQty: $startingStock);
+        $this->approve($stock, $stoId, $startingStock);
+
+        $frozenBefore = StockOpnameDetail::where('sto_id', $stoId)
+            ->where('product_variant_id', $stock->product_variant_id)
+            ->firstOrFail();
+
+        // Some OTHER opname moves the live stock after this one was already decided.
+        $otherStoId = $this->insertStockOpname($stock, $unit, realQty: $startingStock - 5);
+        $this->approve($stock, $otherStoId, $startingStock - 5);
+
+        $this->get('/generateStockOpname/'.$stoId)->assertStatus(200);
+
+        // The status==1 gate around refreshLiveSystemQty() must keep this frozen -- an
+        // approved/rejected document's PDF is a historical record, not a live view.
+        $this->assertDatabaseHas('stock_opname_details', [
+            'sto_id' => $stoId,
+            'product_variant_id' => $stock->product_variant_id,
+            'stod_system' => $frozenBefore->stod_system,
+            'stod_selisih' => $frozenBefore->stod_selisih,
+        ]);
     }
 
     public function test_approving_freezes_the_true_system_stock_at_that_moment_not_the_creation_time_one(): void


### PR DESCRIPTION
## Ringkasan

PR ini berisi 2 perbaikan terpisah yang diminta PM:

1. Hasil produksi (finished goods) sekarang naik satuan **berjenjang penuh**, tidak berhenti di satu tingkat saja.
2. Download PDF Stock Opname sekarang ikut **menyimpan** angka stok sistem live ke database, bukan cuma menampilkannya di PDF — khusus untuk dokumen draft (fase 2) dan yang masih menunggu.

---

## 1. `accProduction` — ladder satuan hasil produksi sekarang naik sampai paling atas (Closes #19)

### Masalah

Saat approve Produksi, stok hasil produksi yang di-input dalam satuan terkecil (misal Piece) dipecah/dinaikkan ke satuan yang lebih besar (misal DOS) lewat `product_relations`. Tapi proses ini **cuma naik SATU level**, walaupun relasi satuannya sebenarnya bertingkat lebih dari dua level (misal Piece → DOS → Sak).

Kodenya bahkan terlihat **mencoba** mengecek apakah masih ada level di atasnya lagi:

```php
$cek = $r = ProductRelation::where('pr_unit_id_2', '=', $r->pr_unit_id_1)
    ->where('product_variant_id', '=', $value["product_variant_id"]);
if ($cek->count() <= 0) { $ada = -1; }
```

Tapi `$ada` tidak pernah dibaca lagi setelah baris ini, dan `$r` di-assign ulang jadi `Builder` yang tidak pernah dieksekusi (`->first()`/`->get()`). Jadi lookup ini dead code — apapun hasilnya, tidak ada tindakan lanjutan.

**Contoh kasus nyata:** ladder 3 tingkat (1 Sak = 2 DOS = 24 Piece). Produksi 24 Piece harusnya jadi 1 Sak penuh kalau ladder-nya jalan semua. Yang terjadi: `floor(24/12)=2` mendarat di baris stok level DOS dan berhenti di situ — padahal 2 DOS itu sendiri kelipatan pas dari rasio Sak (2). Baris stok Sak tidak pernah kena kredit, dan tidak ada `log_stocks` yang tercatat untuk Sak — buktinya proses cascade memang tidak jalan sama sekali, bukan jalan lalu hasilnya kebulat ke nol.

Arah sebaliknya (bongkar satuan besar → kecil untuk konsumsi bahan baku, `$siapkanStok`/`convertQtyToSmallestUnit()`) **sudah benar** dan sudah rekursif berjenjang — cuma sisi kredit hasil produksi ini yang bolong.

### Logika perbaikan

Ditambahkan helper baru murni (pure, tanpa efek samping ke DB) di `ProductionController`:

```php
creditProductOutputUpChain(productVariantId, startUnitId, qty): array
```

Cara kerjanya: mulai dari satuan input user, cari relasi `product_relations` yang `pr_unit_id_2`-nya cocok dengan satuan sekarang. Kalau qty yang dibawa cukup (`>= pr_unit_value_2`), pecah jadi `floor` (naik ke satuan atas) dan sisa hasil bagi (tetap di satuan sekarang), lalu **lanjut lagi** ke satuan yang lebih atas dengan qty hasil `floor` tadi — diulang sampai relasinya habis atau qty-nya sudah tidak cukup lagi untuk naik lagi (dijaga dengan guard maksimal 20 hop supaya tidak infinite loop kalau data relasi rusak/siklik). Hasilnya berupa daftar `{unit_id, qty}` yang perlu dikredit di setiap level yang dilewati.

Pemanggilnya (`accProduction()`) tinggal loop hasil ini: kredit `ProductStock` dan catat `log_stocks` untuk setiap level yang qty-nya > 0 saja (level yang habis terserap ke atas dan sisanya 0 tidak perlu disentuh/di-log sama sekali).

Blok pre-check sebelum `DB::transaction()` (yang memperingatkan user sebelum sistem otomatis membuat baris `ProductStock` baru dengan stok awal 0) juga diperbaiki supaya menyusuri seluruh rantai lewat helper yang sama — jadi kalau splitnya sampai ke level ke-2/ke-3, user tetap diminta konfirmasi untuk level itu juga, bukan cuma level pertama.

### Perubahan file

- `app/Http/Controllers/ProductionController.php` — helper baru `creditProductOutputUpChain()`, pre-check block dan blok kredit hasil produksi di `accProduction()` diganti untuk pakai helper ini.
- `tests/Regression/ProductionOutputConversionDoesNotCascadeMultipleLevelsTest.php` — diupdate di tempat (bukan dihapus, sesuai konvensi test regresi di repo ini) untuk membuktikan perilaku yang sudah benar: 24 Piece sekarang mendarat sebagai `Sak=1, DOS=0, Piece=0`, dengan cuma 1 baris `log_stocks` di level Sak.

---

## 2. Download PDF Stock Opname sekarang menyimpan stok live ke database (draft & menunggu saja)

### Masalah

Sebelumnya (dari perbaikan GitHub #53), `stod_system`/`stod_selisih` (`stobd_*` untuk Bahan) di PDF Stock Opname sudah dihitung ulang dari stok LIVE saat dokumen masih pending — tapi hasil hitung ulang itu **cuma dipakai untuk tampilan PDF saat itu saja**. Baris asli di tabel `stock_opname_details`/`stock_opname_detail_bahans` tetap basi/tidak berubah sampai dokumen di-ACC.

PM minta: data yang tersimpan di database juga ikut ter-update setiap kali PDF-nya di-download, **selama dokumen masih draft (fase 2) atau menunggu** — bukan untuk dokumen yang sudah disetujui/ditolak (itu catatan historis yang sengaja dibekukan).

### Logika perbaikan

`StockController::refreshLiveSystemQty()` sebelumnya cuma mengubah objek clone di memory (`$item`, hasil clone dari `ProductVariant`/`Supplies` — bukan row `StockOpnameDetail`/`StockOpnameDetailBahan` yang asli, lihat `StockOpnameDetail::getDetail()`). Sekarang, setelah menghitung ulang nilai live-nya, method ini juga mencari row aslinya lewat `$detailModelClass::find($item->{$detailIdKey})` dan menyimpan `stod_system`/`stod_selisih` (atau `stobd_*`) ke row itu.

Gate yang sudah ada di pemanggilnya (`generateStockOpname()`/`generateStockOpnameBahan()`) **tidak diubah** — tetap cuma jalan kalau `status == 1`. Ini otomatis sudah mencakup dokumen draft DAN yang sudah diajukan-tapi-menunggu, karena `is_draft` tidak pernah mengubah `status` (lihat `StockOpname::insertStockOpname()`/`submitStockOpname()`). Dokumen yang sudah disetujui/ditolak (`status` 2/3) tidak akan pernah memanggil method ini sama sekali lewat PDF, jadi snapshot historisnya tetap aman/tidak tersentuh.

### Perubahan file

- `app/Http/Controllers/StockController.php` — `refreshLiveSystemQty()` menerima 2 parameter baru (kelas model detail + nama kolom id-nya), lalu menyimpan hasil hitung ulang ke row aslinya. Kedua titik pemanggilan (`generateStockOpname()` untuk Produk, `generateStockOpnameBahan()` untuk Bahan) diupdate untuk mengirim parameter baru ini.
- `tests/Workflow/StockOpnamePdfLiveSystemStockTest.php` — ditambah 2 test baru: download PDF dokumen draft & yang sudah submit-tapi-menunggu sama-sama menyimpan stok live ke row asli lewat request HTTP sungguhan ke `/generateStockOpname/{id}`; dan 1 test yang membuktikan dokumen yang SUDAH diputuskan (disetujui/ditolak) row-nya tidak ikut berubah saat PDF-nya di-download ulang.
- `tests/Workflow/StockOpnameBahanPdfLiveSystemStockPersistTest.php` (baru) — versi Bahan dari 2 test di atas, karena titik pemanggilannya pakai kelas model & nama kolom id yang berbeda dari sisi Produk.

### Catatan untuk nanti (bukan bug, tapi perlu ditindaklanjuti)

Ditemukan saat bikin test: `refreshLiveSystemQty()` menghitung stok live dengan mengambil SEMUA baris `ProductStock`/`SuppliesStock` untuk satu varian/bahan (lintas gudang, tanpa filter `warehouse_id`) lalu di-key cuma berdasarkan nama satuan. Di `main` ini aman karena belum ada konsep multi-gudang aktif sama sekali. Tapi di `fase2/main` (yang sudah punya modul gudang beneran), ini bakal jadi masalah nyata — varian yang punya baris stok di lebih dari satu gudang untuk satuan yang sama bisa saling menimpa dan hasilnya salah. Sudah dicatat sebagai TODO eksplisit di `cdocs/docs/fase2-merge-plan.md` untuk ditangani saat commit ini di-cherry-pick ke `fase2/main` nanti — bukan untuk ditangani di PR ini.

---

## Testing

- Semua test yang diubah/ditambah di atas: **PASS**.
- Full suite `Regression`, `Workflow`, `DatabaseTransaction` dijalankan — tidak ada regresi baru dari perubahan ini (dibandingkan lewat `git stash` ke kondisi sebelum perubahan, semua failure yang ada sudah pre-existing/tidak berkaitan, misalnya drift data multi-gudang di DB testing lokal).

Closes #19
