### PR TITLE
fix: amankan semua mutasi stok dengan transaksi — 7 entry point tanpa DB::transaction()

### DIFF
--- a/app/Http/Controllers/CustomerController.php
+++ b/app/Http/Controllers/CustomerController.php
@@ -16,6 +16,7 @@ use App\Models\SalesOrderDetail;
 use App\Models\Staff;
 use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 
 class CustomerController extends Controller
@@ -81,6 +82,18 @@ class CustomerController extends Controller
             return 'Sales order tidak ditemukan';
         }
 
+        // Ditambahkan (2026-08-24): dulu method ini TIDAK punya DB::transaction() sama sekali
+        // (dokumentasi di cdocs/testing/guides/DATABASE_TRANSACTION_GUIDE.md sempat salah menyebut
+        // file ini sudah transaksional -- baris yang dirujuknya ternyata query ProductRelation biasa).
+        // Ini yang paling berbahaya dari semua celah atomicity stok: TAHAP 1 di bawah MENGEMBALIKAN
+        // stok lama dulu, baru TAHAP 4 memotong stok baru. Kalau gagal di antara keduanya (stok
+        // kurang, baris stok hilang, error apa pun), stok lama terlanjur balik permanen tapi tidak
+        // pernah dipotong lagi -- stok hantu tercipta dari ketiadaan. Bahkan jalur "gagal" yang
+        // normal pun bocor: `if($valid == -1) return ...` di bawah keluar SETELAH TAHAP 1 menulis
+        // revert ke DB. Sekarang semuanya satu transaksi, jadi setiap keluar-gagal ikut ter-rollback.
+        DB::beginTransaction();
+        try {
+
         // Mutasi stok/log hanya jika SO sudah disetujui (ACC). Sebelum itu stok belum dipotong (accSO);
         // jika revert+potong dijalankan saat status 1/3, stok ikut berubah padahal belum konfirmasi.
         if ((int) ($soBefore->status ?? 0) !== 2) {
@@ -95,6 +108,7 @@ class CustomerController extends Controller
             }
             SalesOrderDetail::where('so_id', $so->so_id)->whereNotIn('sod_id', $list_id_detail)->update(['status' => 0]);
 
+            DB::commit();
             return 1;
         }
 
@@ -242,7 +256,9 @@ class CustomerController extends Controller
             }
         }
 
-        if($valid == -1) { return implode(", ", $p); }
+        // Rollback dulu sebelum keluar: TAHAP 1 sudah menulis revert stok lama ke DB, dan tanpa
+        // rollback revert itu ikut permanen padahal update-nya sendiri dibatalkan (stok hantu).
+        if($valid == -1) { DB::rollBack(); return implode(", ", $p); }
 
         // --- TAHAP 4: UPDATE DATA SO & POTONG STOK FINAL ---
         $so = (new SalesOrder())->updateSalesOrder($data);
@@ -278,7 +294,12 @@ class CustomerController extends Controller
 
         SalesOrderDetail::where('so_id', $so->so_id)->whereNotIn('sod_id', $list_id_detail)->update(['status' => 0]);
 
+        DB::commit();
         return 1;
+        } catch (\Throwable $e) {
+            DB::rollBack();
+            throw $e;
+        }
     }
 
     function deleteSalesOrder(Request $req){
@@ -536,6 +557,15 @@ class CustomerController extends Controller
         }
 
         // ─── Langkah 4: EKSEKUSI – semua produk lolos, baru simpan ke DB ─────────────
+        // Ditambahkan (2026-08-24): dulu seluruh fase eksekusi ini TIDAK transaksional. Langkah 1-3
+        // di atas murni simulasi in-memory ($virtualStock, tidak ada ->save()), jadi batas transaksi
+        // yang benar memang tepat di sini -- sama persis bentuknya dengan accProduction() yang
+        // pre-check dulu di luar, baru beginTransaction() untuk fase tulisnya. Tanpa ini, gagal di
+        // tengah loop (satu produk sudah ter-save, produk berikutnya error) meninggalkan stok
+        // terpotong sebagian sementara status SO tetap 1/menunggu -- user meng-ACC ulang dan produk
+        // yang tadi sudah terpotong kena potong DUA KALI. Status flip di akhir ikut masuk transaksi.
+        DB::beginTransaction();
+        try {
         foreach ($simulasiHasil as $hasil) {
             $virtualStock = $hasil['virtualStock'];
             $logSummary   = $hasil['logSummary'];
@@ -578,7 +608,12 @@ class CustomerController extends Controller
         }
 
         (new SalesOrder())->accSO($data);
+        DB::commit();
         return 1;
+        } catch (\Throwable $e) {
+            DB::rollBack();
+            throw $e;
+        }
     }
 
     function declineSO(Request $req){

--- a/app/Http/Controllers/StockController.php
+++ b/app/Http/Controllers/StockController.php
@@ -820,11 +820,23 @@ class StockController extends Controller
 
         // insert
         // if ($data['tipe_return'] == 1) $data['po_id'] = $po->po_id;
+        // Ditambahkan (2026-08-24): ProductIssues::insertProductIssues() dan
+        // ProductIssuesDetail::insertProductIssuesDetail() sama-sama memutasi ps_stock/ss_stock,
+        // dan dulu tidak ada transaksi -- gagal di tengah loop item meninggalkan header
+        // ProductIssues yang sudah jadi dengan sebagian detail + sebagian stok saja yang termutasi.
+        // Semua pre-check (stockCheck dkk) di atas murni baca, jadi tetap di luar transaksi.
+        DB::beginTransaction();
+        try {
         $t = (new ProductIssues())->insertProductIssues($data);
         foreach (json_decode($data['items'], true) as $key => $value) {
             $value['pi_id'] = $t->pi_id;
             // if (isset($t->ref_num)) $value['ref_num'] = $t->ref_num;
             (new ProductIssuesDetail())->insertProductIssuesDetail($value);
+        }
+        DB::commit();
+        } catch (\Throwable $e) {
+            DB::rollBack();
+            throw $e;
         }
     }
 
@@ -855,6 +867,14 @@ class StockController extends Controller
         //     $po = PurchaseOrder::find($inv->po_id);
         //     $data['po_id'] = $po->po_id;
         // }
+        // Ditambahkan (2026-08-24): dulu tidak ada transaksi di sini sama sekali. Perhatikan
+        // urutannya -- updateProductIssues() di bawah SUDAH memutasi stok, baru setelah itu blok
+        // "Cek stock" menjalankan stockCheck() yang bisa `return -1`. Artinya jalur gagal yang
+        // normal pun meninggalkan mutasi stok yang terlanjur tersimpan. Sekarang seluruh method
+        // (write + cek + loop detail di bawah) satu transaksi, jadi setiap `return -1` ikut
+        // ter-rollback bersih.
+        DB::beginTransaction();
+        try {
         $pi = (new ProductIssues())->updateProductIssues($data);
 
         // Cek stock
@@ -867,7 +887,7 @@ class StockController extends Controller
                             $val['tipe_return'] = $data['tipe_return'];
                             $val['pid_qty'] = $value['pid_qty'];
                             $c = (new ProductIssuesDetail())->stockCheck($val);
-                            if ($c == -1) return -1;
+                            if ($c == -1) { DB::rollBack(); return -1; }
                         }
                     }
                     if ($data['tipe_return'] == 2) {
@@ -875,7 +895,7 @@ class StockController extends Controller
                             $val['tipe_return'] = $data['tipe_return'];
                             $val['pid_qty'] = $value['pid_qty'];
                             $c = (new ProductIssuesDetail())->stockCheck($val);
-                            if ($c == -1) return -1;
+                            if ($c == -1) { DB::rollBack(); return -1; }
                         }
                     }
                 }
@@ -1091,9 +1111,14 @@ class StockController extends Controller
                 ]);
             }
             array_push($id, $t);
-            
+
         }
         ProductIssuesDetail::where('pi_id', '=', $data["pi_id"])->whereNotIn("pid_id", $id)->update(["status" => 0]);
+        DB::commit();
+        } catch (\Throwable $e) {
+            DB::rollBack();
+            throw $e;
+        }
     }
 
     // UI-unreachable (confirmed 2026-08-02) — this route's delete trigger icon is commented out in
@@ -1107,6 +1132,16 @@ class StockController extends Controller
 
         $pi = ProductIssues::find($data['pi_id']);
         $w = ProductIssuesDetail::where('pi_id','=',$data["pi_id"])->where('status', '>=', 1)->get();
+
+        // Ditambahkan (2026-08-24): dulu tidak ada transaksi sama sekali. Transaksi sengaja dibuka
+        // di sini (sebelum percabangan tipe_return) supaya KEDUA cabang ikut terlindungi -- kalau
+        // dibuka di dalam blok tipe_return==2 saja, deleteProductIssues() + loop penghapusan detail
+        // di bawahnya (yang jalan untuk semua tipe) tetap tanpa proteksi. Fase 1-3 di bawah murni
+        // simulasi in-memory, jadi ikut masuk transaksi pun tidak menambah biaya tulis.
+        // Jalur gagal yang paling berbahaya: `$del == -1` ("Invoice sudah terbayar") keluar SETELAH
+        // Fase 4 menulis semua perubahan stok ke DB.
+        DB::beginTransaction();
+        try {
 
         if ($pi->tipe_return == 2) {
             // ─── Fase 1: Agregasi ───────────────────────────────────────────
@@ -1255,6 +1290,7 @@ class StockController extends Controller
 
             // ─── Fase 3: Validasi ────────────────────────────────────────────
             if (count($kurang) > 0) {
+                DB::rollBack();
                 return [
                     "status"  => -1,
                     "header"  => "Gagal menghapus",
@@ -1302,6 +1338,9 @@ class StockController extends Controller
 
         $del = (new ProductIssues())->deleteProductIssues($data);
         if ($del == -1) {
+            // Rollback dulu: Fase 4 di atas sudah menulis seluruh perubahan stok ke DB, dan tanpa
+            // ini perubahan itu tetap permanen padahal penghapusannya sendiri dibatalkan.
+            DB::rollBack();
             return response()->json([
                 "status"  => 0,
                 "header"  => "Gagal Delete",
@@ -1364,6 +1403,11 @@ class StockController extends Controller
                 'log_jumlah'   => $value['pid_qty'],
                 'unit_id'      => $value['unit_id'],
             ]);
+        }
+        DB::commit();
+        } catch (\Throwable $e) {
+            DB::rollBack();
+            throw $e;
         }
     }
 

--- a/app/Http/Controllers/SupplierController.php
+++ b/app/Http/Controllers/SupplierController.php
@@ -564,6 +564,14 @@ class SupplierController extends Controller
                 "message" => "Pengajuan sudah diterma/ditolak oleh " . $staff
             ]);
         }
+        // Ditambahkan (2026-08-24): dulu penerimaan barang ini TIDAK transaksional sama sekali,
+        // padahal insertPoDeliveryDetail() di dalam loop menambah ss_stock per item. Gagal di tengah
+        // (item ke-3 dari 5 error) meninggalkan stok bahan bertambah sebagian, PurchaseOrderDelivery
+        // header sudah terlanjur dibuat, invoice belum, dan po->status masih 1 -- user meng-ACC ulang
+        // lalu item yang tadi sudah masuk ditambahkan LAGI. Guard status di atas sengaja tetap di
+        // luar transaksi (murni baca, sama seperti accProduction()/accStockOpname()).
+        DB::beginTransaction();
+        try {
         $pod_id = (new PurchaseOrderDelivery())->insertPoDelivery(["po_id"=>$data["po_id"],"pdo_receiver"=>"Auto Generated","status"=>2]);
 
         foreach ($data['items'] as $key => $value) {
@@ -594,7 +602,12 @@ class SupplierController extends Controller
         $po->status = 2; // Lunas
         $po->acc_by = session()->get('user') ? session()->get('user')->staff_id : null;
         $po->save();
+        DB::commit();
         return $due;
+        } catch (\Throwable $e) {
+            DB::rollBack();
+            throw $e;
+        }
     }
 
     function tolakPO(Request $req) {
@@ -721,10 +734,14 @@ class SupplierController extends Controller
                 ->where('unit_id', $value['unit_id'])
                 ->where('status', 1)
                 ->first();
-            
-            if (($ss->ss_stock - $value['rsd_qty'] < 0)){
+
+            // Ditambahkan (2026-08-24): dulu langsung $ss->ss_stock tanpa null-check -- baris stok
+            // yang tidak ada (kombinasi supplies_id + unit_id yang tidak match) meledak jadi
+            // "Attempt to read property on null" di tengah pre-check. Diperlakukan sama dengan stok
+            // tidak mencukupi, karena memang tidak ada stok yang bisa diretur.
+            if (!$ss || ($ss->ss_stock - $value['rsd_qty'] < 0)){
                 $svr = SuppliesVariant::find($value['supplies_variant_id']);
-                array_push($kurang, $svr->supplies_variant_name);
+                array_push($kurang, $svr->supplies_variant_name ?? ('id '.$value['supplies_variant_id']));
             }
         }
         if (count($bermasalah) > 0) {
@@ -740,6 +757,14 @@ class SupplierController extends Controller
             ];
         }
 
+        // Ditambahkan (2026-08-24): mulai dari sini semuanya menulis ke DB (po_total, ProductIssues,
+        // ReturnSupplies, lalu pengurangan ss_stock per item di loop bawah) dan dulu TIDAK ada
+        // transaksi sama sekali. Paling parah: `return -1` di dalam loop bawah (stok tidak cukup)
+        // keluar begitu saja padahal po_total sudah dikurangi, ProductIssues/ReturnSupplies sudah
+        // dibuat, dan item-item sebelumnya sudah dipotong stoknya -- dan itu jalur bisnis normal,
+        // bukan cuma skenario crash. Semua pre-check yang murni baca tetap di luar transaksi.
+        DB::beginTransaction();
+        try {
         $po->po_total -= $total;
         $po->save();
 
@@ -775,12 +800,15 @@ class SupplierController extends Controller
             $s = SuppliesStock::where('supplies_id','=',$value['supplies_id'])->where('unit_id','=',$value["unit_id"])->where('status', 1)->first();
 
             // pengurangan qty stok
+            // Ditambahkan (2026-08-24): null-check eksplisit untuk $s -- dulu `$s->ss_stock ?? 0`
+            // aman saat MEMBACA, tapi `$s->ss_stock = ...` di bawah tetap meledak kalau $s null
+            // (mis. rsd_qty = 0 sehingga cek di bawah lolos). Sekarang rollback + pesan jelas.
             $stocks = $s->ss_stock ?? 0;
-            if ($stocks - $value["rsd_qty"] >= 0) {
-                $stocks -= $value["rsd_qty"];
-            } else {
+            if (!$s || $stocks - $value["rsd_qty"] < 0) {
+                DB::rollBack();
                 return -1;
             }
+            $stocks -= $value["rsd_qty"];
 
             $s->ss_stock = $stocks;
             $s->save();
@@ -803,9 +831,14 @@ class SupplierController extends Controller
             $value['pid_id'] = $pid_id;
             (new ReturnSuppliesDetail())->insertReturnSuppliesDetail($value);
         }
-        
 
+
+        DB::commit();
         return 1;
+        } catch (\Throwable $e) {
+            DB::rollBack();
+            throw $e;
+        }
     }
 
     function updateReturnSupplies(Request $req){
@@ -825,6 +858,12 @@ class SupplierController extends Controller
             $total += ($value['rsd_price'] * $value['rsd_qty']);
         }
 
+        // Ditambahkan (2026-08-24): kebalikan dari insertReturnSupplies() di atas -- method ini
+        // MENGEMBALIKAN stok bahan (lewat deleteProductIssuesDetail() di loop bawah) sekaligus
+        // mengembalikan po_total. Dulu tanpa transaksi: gagal di tengah meninggalkan po_total sudah
+        // bertambah tapi stok baru sebagian yang dikembalikan, atau sebaliknya.
+        DB::beginTransaction();
+        try {
         $po = PurchaseOrder::find($data['po_id']);
         $po->po_total += $total;
         $po->save();
@@ -865,6 +904,11 @@ class SupplierController extends Controller
             (new ReturnSuppliesDetail())->deleteReturnSuppliesDetail($value);
         }
 
+        DB::commit();
         return 1;
+        } catch (\Throwable $e) {
+            DB::rollBack();
+            throw $e;
+        }
     }
 }

--- a/tests/DatabaseTransaction/PurchaseOrderApprovalAtomicityTest.php
+++ b/tests/DatabaseTransaction/PurchaseOrderApprovalAtomicityTest.php
@@ -13,24 +13,32 @@ use Tests\TestCase;
 
 /**
  * Extends the Phase 3 pilot (tests/Workflow/PurchaseOrderFlowTest.php,
- * cdocs/testing/workflows/PURCHASE_ORDER_FLOW.md). `accPO` has no
- * DB::transaction() (unlike `tolakPO` — see guides/DATABASE_TRANSACTION_GUIDE.md),
- * so this documents exactly how far a mid-loop failure gets before it stops,
- * rather than assuming the whole request either fully applies or fully
- * doesn't.
+ * cdocs/testing/workflows/PURCHASE_ORDER_FLOW.md).
  *
  * Trigger: PurchaseOrderDeliveryDetail::insertPoDeliveryDetail() saves the
  * delivery-detail row FIRST, then looks up SuppliesStock by
  * supplies_id+unit_id — if that lookup misses (e.g. a bad unit_id), it calls
  * `$s->ss_stock += ...` on null and throws, uncaught, all the way up through
- * accPO. A second, valid line item processed earlier in the same request
- * has already been fully committed by that point.
+ * accPO.
+ *
+ * ✅ FIXED 2026-08-24: this test used to DOCUMENT the partial-commit bug — a
+ * valid line item processed earlier in the same request kept its stock
+ * increment, its log_stocks row, and its delivery-detail row permanently,
+ * while the PO itself stayed pending, so re-approving double-credited that
+ * item. `accPO()` now wraps its whole write phase (delivery header + per-item
+ * loop + invoice + status flip) in DB::beginTransaction()/commit with a
+ * rollBack on throw, mirroring accProduction()/accStockOpname(). The
+ * assertions below are flipped accordingly: nothing survives the failure.
+ *
+ * The uncaught 500 itself is unchanged and still asserted — this fix is about
+ * atomicity, not about converting the underlying null-lookup crash into a
+ * clean business-rule response.
  */
 class PurchaseOrderApprovalAtomicityTest extends TestCase
 {
     use ActingAsStaff;
 
-    public function test_a_mid_loop_failure_leaves_earlier_items_partially_committed(): void
+    public function test_a_mid_loop_failure_now_rolls_back_every_earlier_item(): void
     {
         $this->actingAsSuperAdminStaff();
 
@@ -96,30 +104,30 @@ class PurchaseOrderApprovalAtomicityTest extends TestCase
             ],
         ]);
 
-        // Documents current behavior: an uncaught error, not a clean
-        // {status:-1, message:...} business-rule response.
+        // Still an uncaught error, not a clean {status:-1, message:...} business-rule
+        // response — unchanged by the atomicity fix.
         $response->assertStatus(500);
 
-        // Item A (processed first) is fully, permanently committed.
+        // FIXED: item A (processed first) is rolled back completely.
         $stockA->refresh();
         $this->assertSame(
-            $startingStockA + $qty,
+            $startingStockA,
             $stockA->ss_stock,
-            'the first, valid line item keeps its stock increment despite the later failure'
+            'the first, valid line item must NOT keep its stock increment once a later item fails'
         );
         $this->assertSame(
-            $logCountBefore + 1,
+            $logCountBefore,
             DB::table('log_stocks')->count(),
-            'the first line item still gets its log_stocks entry'
+            'no log_stocks entry survives the rollback either'
         );
-        $this->assertDatabaseHas('purchase_delivery_orders_details', [
+        $this->assertDatabaseMissing('purchase_delivery_orders_details', [
             'pdod_qty' => $qty,
             'supplies_variant_id' => $variantA->supplies_variant_id,
         ]);
 
-        // Item B's delivery-detail row is created (save() runs before the
-        // stock lookup) but its stock is never touched and no log is written.
-        $this->assertDatabaseHas('purchase_delivery_orders_details', [
+        // Item B's delivery-detail row (save() runs before the stock lookup that
+        // throws) is rolled back too, rather than being left orphaned.
+        $this->assertDatabaseMissing('purchase_delivery_orders_details', [
             'supplies_variant_id' => $variantB->supplies_variant_id,
             'pdod_qty' => $qty,
         ]);

--- a/tests/DatabaseTransaction/ReturnSuppliesInsertAtomicityTest.php
+++ b/tests/DatabaseTransaction/ReturnSuppliesInsertAtomicityTest.php
@@ -1,0 +1,199 @@
+<?php
+
+namespace Tests\DatabaseTransaction;
+
+use App\Models\ProductIssues;
+use App\Models\PurchaseOrder;
+use App\Models\ReturnSupplies;
+use App\Models\Supplier;
+use App\Models\Supplies;
+use App\Models\SuppliesStock;
+use App\Models\SuppliesVariant;
+use App\Models\Unit;
+use Illuminate\Support\Facades\DB;
+use Tests\Support\ActingAsStaff;
+use Tests\TestCase;
+
+/**
+ * ✅ FIXED (2026-08-24): `SupplierController::insertReturnSupplies()` had no `DB::transaction()`,
+ * and — like `updateSalesOrder()` — its worst exit was a *normal business path*, not a crash.
+ *
+ * The reachable trigger is a genuine logic gap, not a contrived one: the pre-check loop validates
+ * each return line INDEPENDENTLY against the full current stock (`$ss->ss_stock - $value['rsd_qty']
+ * < 0`), while the write loop deducts CUMULATIVELY. Two lines for the same supplies + unit that
+ * each individually fit, but together exceed stock, therefore sail through the pre-check and only
+ * blow up partway through the writes — at which point `return -1` used to exit with the PO total
+ * already reduced, the ProductIssues + ReturnSupplies headers already created, and the FIRST
+ * line's stock already deducted and logged. All permanent.
+ *
+ * That left the books doubly wrong: supplier stock reduced for a return that was reported back to
+ * the caller as failed (`-1`), plus an orphaned ProductIssues/ReturnSupplies pair referencing it.
+ *
+ * The fix wraps everything from the first write (`$po->po_total -= $total`) onward in one
+ * transaction, with `rollBack()` on that `-1` path and on any throw. The cumulative-vs-independent
+ * pre-check discrepancy itself is left as-is (unchanged behavior, still returns -1) — this test
+ * pins the atomicity, not a redesign of the validation.
+ *
+ * Fixtures built fresh via Eloquent — see memory `pegasus-testing-db-multiwarehouse-drift`.
+ */
+class ReturnSuppliesInsertAtomicityTest extends TestCase
+{
+    use ActingAsStaff;
+
+    private const STARTING_STOCK = 10;
+    private const QTY_PER_LINE = 6; // 6 <= 10 individually, but 6 + 6 = 12 > 10 cumulatively
+
+    /** @return array{0: SuppliesStock, 1: SuppliesVariant, 2: PurchaseOrder} */
+    private function createFixture(): array
+    {
+        $unit = Unit::where('status', 1)->firstOrFail();
+        $supplier = Supplier::where('status', 1)->whereNotNull('bank_id')->firstOrFail();
+
+        $supplies = new Supplies();
+        $supplies->supplies_name = 'Return Atomicity Ingredient '.uniqid();
+        $supplies->supplies_unit = json_encode([$unit->unit_id]);
+        $supplies->supplies_default_unit = $unit->unit_id;
+        $supplies->status = 1;
+        $supplies->save();
+
+        $variant = new SuppliesVariant();
+        $variant->supplies_id = $supplies->supplies_id;
+        $variant->supplier_id = $supplier->supplier_id;
+        $variant->supplies_variant_name = 'Return Atomicity Variant';
+        $variant->supplies_variant_sku = 'DBTX-RET-'.uniqid();
+        $variant->supplies_variant_price = 1000;
+        $variant->supplies_variant_barcode = 'DBTX-BC-'.uniqid();
+        $variant->supplies_variant_stock = 0;
+        $variant->status = 1;
+        $variant->save();
+
+        // Exactly ONE stock row and no supplies_relations, so stockCheck() has no bongkar
+        // ladder to fall back on — keeps the scenario purely about cumulative deduction.
+        $stock = new SuppliesStock();
+        $stock->supplies_id = $supplies->supplies_id;
+        $stock->unit_id = $unit->unit_id;
+        $stock->warehouse_id = 1;
+        $stock->ss_stock = self::STARTING_STOCK;
+        $stock->status = 1;
+        $stock->save();
+
+        $po = new PurchaseOrder();
+        $po->po_number = 'PO-DBTX-RET-'.uniqid();
+        $po->po_supplier = $supplier->supplier_id;
+        $po->po_date = now()->toDateString();
+        $po->po_img = json_encode([]);
+        $po->po_total = 1000000;
+        $po->status = 2;
+        $po->save();
+
+        return [$stock, $variant, $po];
+    }
+
+    public function test_a_cumulative_shortfall_mid_loop_rolls_back_every_earlier_write(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        [$stock, $variant, $po] = $this->createFixture();
+
+        $startingStock = $stock->ss_stock;
+        $startingPoTotal = $po->po_total;
+        $logCountBefore = DB::table('log_stocks')->count();
+        $piCountBefore = ProductIssues::count();
+        $rsCountBefore = ReturnSupplies::count();
+
+        $line = [
+            'supplies_id' => $stock->supplies_id,
+            'supplies_variant_id' => $variant->supplies_variant_id,
+            'supplies_variant_name' => $variant->supplies_variant_name,
+            'unit_id' => $stock->unit_id,
+            'rsd_qty' => self::QTY_PER_LINE,
+            'rsd_price' => 1000,
+        ];
+
+        $response = $this->post('/insertReturnSupplies', [
+            'po_id' => $po->po_id,
+            'rs_date' => now()->toDateString(),
+            'rs_notes' => 'Return supplies atomicity test',
+            'rs_total' => self::QTY_PER_LINE * 2 * 1000,
+            'returs' => json_encode([$line, $line]), // same supplies+unit twice
+        ]);
+
+        $response->assertStatus(200);
+        $this->assertSame(
+            '-1',
+            trim($response->getContent()),
+            'the second line still fails with the existing -1 response (behavior unchanged)'
+        );
+
+        // THE FIX: none of the first line's writes may survive.
+        $stock->refresh();
+        $this->assertSame(
+            $startingStock,
+            $stock->ss_stock,
+            'BUG WOULD BE: stock reduced by the first line only, for a return reported as failed'
+        );
+
+        $po->refresh();
+        $this->assertSame(
+            $startingPoTotal,
+            (int) $po->po_total,
+            'the PO total reduction must roll back with everything else'
+        );
+
+        $this->assertSame(
+            $logCountBefore,
+            DB::table('log_stocks')->count(),
+            'no log_stocks row may survive'
+        );
+        $this->assertSame(
+            $piCountBefore,
+            ProductIssues::count(),
+            'no orphaned ProductIssues header may survive'
+        );
+        $this->assertSame(
+            $rsCountBefore,
+            ReturnSupplies::count(),
+            'no orphaned ReturnSupplies header may survive'
+        );
+    }
+
+    public function test_a_return_that_fits_still_commits_normally(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        [$stock, $variant, $po] = $this->createFixture();
+        $startingStock = $stock->ss_stock;
+        $qty = 4; // 4 + 4 = 8 <= 10, so both lines fit cumulatively
+
+        $line = [
+            'supplies_id' => $stock->supplies_id,
+            'supplies_variant_id' => $variant->supplies_variant_id,
+            'supplies_variant_name' => $variant->supplies_variant_name,
+            'unit_id' => $stock->unit_id,
+            'rsd_qty' => $qty,
+            'rsd_price' => 1000,
+        ];
+
+        $response = $this->post('/insertReturnSupplies', [
+            'po_id' => $po->po_id,
+            'rs_date' => now()->toDateString(),
+            'rs_notes' => 'Return supplies atomicity happy path',
+            'rs_total' => $qty * 2 * 1000,
+            'returs' => json_encode([$line, $line]),
+        ]);
+        $response->assertStatus(200);
+
+        // Proves the transaction COMMITS rather than swallowing valid work.
+        $stock->refresh();
+        $this->assertSame(
+            $startingStock - ($qty * 2),
+            $stock->ss_stock,
+            'a return that fits must still deduct both lines and commit'
+        );
+        $this->assertSame(
+            1,
+            ReturnSupplies::where('po_id', $po->po_id)->where('status', 1)->count(),
+            'the ReturnSupplies header is created and kept'
+        );
+    }
+}

--- a/tests/DatabaseTransaction/SalesOrderUpdateAtomicityTest.php
+++ b/tests/DatabaseTransaction/SalesOrderUpdateAtomicityTest.php
@@ -1,0 +1,236 @@
+<?php
+
+namespace Tests\DatabaseTransaction;
+
+use App\Models\Category;
+use App\Models\Product;
+use App\Models\ProductStock;
+use App\Models\ProductVariant;
+use App\Models\SalesOrder;
+use App\Models\SalesOrderDetail;
+use App\Models\Unit;
+use Illuminate\Support\Facades\DB;
+use Tests\Support\ActingAsStaff;
+use Tests\TestCase;
+
+/**
+ * ✅ FIXED (2026-08-24): `CustomerController::updateSalesOrder()` had NO `DB::transaction()` at
+ * all — and this was the single most dangerous of the stock-atomicity gaps, because it creates
+ * stock out of nothing rather than merely losing some.
+ *
+ * Note the method's shape: for an already-approved SO (`status == 2`) it first REVERTS the old
+ * stock (TAHAP 1 — `$sOld->ps_stock += $rev['qty']`, saved immediately), and only much later
+ * deducts the new quantities (TAHAP 4). Between those two phases sits TAHAP 3's stock-sufficiency
+ * validation, whose failure path is a plain `return implode(", ", $p);`. So the *normal business
+ * path* of "you tried to edit an approved SO up to a quantity we don't have" used to leave the
+ * TAHAP 1 revert permanently committed with no matching deduction — phantom stock, every time,
+ * no crash required.
+ *
+ * Worth stressing that this was never hypothetical: it needs no exception, no race, no bad data —
+ * just a user editing an approved SO and asking for more than is in stock, which the UI actively
+ * invites. Every such rejected edit silently inflated stock by the original order quantity.
+ *
+ * The fix wraps the whole method in `DB::beginTransaction()`/`commit()` with `rollBack()` on both
+ * the validation-failure exit and any throw, mirroring `accProduction()`/`accStockOpname()`.
+ *
+ * Both the testing guide (`cdocs/testing/guides/DATABASE_TRANSACTION_GUIDE.md:8`) and
+ * `tests/Workflow/SalesOrderFlowTest.php`'s docblock previously asserted the opposite — that this
+ * flow "wraps its stock mutation in a real DB::transaction() end to end" — which is likely why the
+ * gap went unprioritised for so long. Both have been corrected.
+ *
+ * Fixtures are built fresh via Eloquent rather than picked from seeded data, per
+ * `cdocs/testing/` guidance and memory `pegasus-testing-db-multiwarehouse-drift`: the shared
+ * `pegasus_testing` DB currently holds real multi-warehouse rows that make hand-picked stock
+ * fixtures behave unpredictably here.
+ */
+class SalesOrderUpdateAtomicityTest extends TestCase
+{
+    use ActingAsStaff;
+
+    private const STARTING_STOCK = 90;
+    private const ORDERED_QTY = 10;
+
+    /** @return array{0: ProductStock, 1: ProductVariant} */
+    private function createFixture(): array
+    {
+        $unit = Unit::where('status', 1)->firstOrFail();
+
+        $category = new Category();
+        $category->category_name = 'SO Update Atomicity Category';
+        $category->status = 1;
+        $category->save();
+
+        $product = new Product();
+        $product->product_name = 'SO Update Atomicity Product '.uniqid();
+        $product->category_id = $category->category_id;
+        $product->product_unit = json_encode([$unit->unit_id]);
+        $product->unit_id = $unit->unit_id;
+        $product->status = 1;
+        $product->save();
+
+        $variant = new ProductVariant();
+        $variant->product_id = $product->product_id;
+        $variant->product_variant_name = 'SO Update Atomicity Variant';
+        $variant->product_variant_sku = 'DBTX-SOUPD-'.uniqid();
+        $variant->product_variant_price = 1000;
+        $variant->status = 1;
+        $variant->save();
+
+        // Exactly ONE stock row, already reflecting a deducted/approved SO:
+        // 100 on hand originally, minus the ORDERED_QTY this SO consumed.
+        $stock = new ProductStock();
+        $stock->product_id = $product->product_id;
+        $stock->product_variant_id = $variant->product_variant_id;
+        $stock->unit_id = $unit->unit_id;
+        $stock->warehouse_id = 1;
+        $stock->ps_stock = self::STARTING_STOCK;
+        $stock->status = 1;
+        $stock->save();
+
+        return [$stock, $variant];
+    }
+
+    private function createApprovedSalesOrder(ProductVariant $variant, ProductStock $stock): SalesOrder
+    {
+        $so = new SalesOrder();
+        $so->so_number = 'SO-DBTX-'.uniqid();
+        $so->so_customer = (int) DB::table('customers')->where('status', 1)->value('customer_id');
+        $so->so_date = now()->toDateString();
+        $so->so_total = self::ORDERED_QTY * 1000;
+        $so->so_ppn = 0;
+        $so->so_discount = 0;
+        $so->so_cost = 0;
+        $so->so_img = json_encode([]);
+        $so->so_invoice_no = 'INV-DBTX-'.uniqid();
+        $so->status = 2; // already approved — this is what enables the revert-then-deduct path
+        $so->save();
+
+        $sod = new SalesOrderDetail();
+        $sod->so_id = $so->so_id;
+        $sod->product_variant_id = $variant->product_variant_id;
+        $sod->sod_nama = 'SO Update Atomicity Product';
+        $sod->sod_variant = $variant->product_variant_name;
+        $sod->sod_sku = $variant->product_variant_sku;
+        $sod->unit_id = $stock->unit_id;
+        $sod->sod_harga = 1000;
+        $sod->sod_qty = self::ORDERED_QTY;
+        $sod->sod_subtotal = self::ORDERED_QTY * 1000;
+        $sod->status = 1;
+        $sod->save();
+
+        return $so;
+    }
+
+    public function test_a_rejected_edit_of_an_approved_so_no_longer_leaves_phantom_stock_behind(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        [$stock, $variant] = $this->createFixture();
+        $so = $this->createApprovedSalesOrder($variant, $stock);
+        $logCountBefore = DB::table('log_stocks')->count();
+
+        // Ask for far more than exists. TAHAP 1 reverts the original 10 (stock 90 -> 100),
+        // TAHAP 3 then finds 100 < 99999 and bails out via `return implode(", ", $p)`.
+        $response = $this->post('/updateSalesOrder', [
+            'so_id' => $so->so_id,
+            'so_number' => $so->so_number,
+            'so_customer' => $so->so_customer,
+            'so_date' => now()->toDateString(),
+            'so_total' => 99999 * 1000,
+            'so_img' => json_encode([]),
+            'products' => json_encode([[
+                'sod_id' => SalesOrderDetail::where('so_id', $so->so_id)->value('sod_id'),
+                'product_variant_id' => $variant->product_variant_id,
+                'product_name' => 'SO Update Atomicity Product',
+                'pr_name' => 'SO Update Atomicity Product',
+                'product_variant_name' => $variant->product_variant_name,
+                'product_variant_sku' => $variant->product_variant_sku,
+                'unit_id' => $stock->unit_id,
+                'product_variant_price' => 1000,
+                'so_qty' => 99999,
+                'so_subtotal' => 99999 * 1000,
+            ]]),
+        ]);
+
+        // The edit is rejected with the "insufficient stock" product-name string (unchanged
+        // behavior — this fix is about atomicity, not the response shape).
+        $response->assertStatus(200);
+        $this->assertStringContainsString(
+            'SO Update Atomicity Product',
+            $response->getContent(),
+            'the rejected edit still reports which product was short'
+        );
+
+        // THE FIX: TAHAP 1's revert must not survive the rejected edit.
+        $stock->refresh();
+        $this->assertSame(
+            self::STARTING_STOCK,
+            $stock->ps_stock,
+            'BUG WOULD BE: stock left at 100 (the TAHAP 1 revert committed with no matching deduction) — '
+            .'phantom stock created out of nothing by a merely-rejected edit'
+        );
+
+        // The revert also wrote a log_stocks row before bailing; that must roll back too,
+        // otherwise the ledger claims a restock that never happened.
+        $this->assertSame(
+            $logCountBefore,
+            DB::table('log_stocks')->count(),
+            'no log_stocks row may survive a rejected edit'
+        );
+
+        // And the order itself is untouched — still approved, still the original quantity.
+        $so->refresh();
+        $this->assertSame(2, (int) $so->status, 'the SO stays approved');
+        $this->assertDatabaseHas('sales_order_details', [
+            'so_id' => $so->so_id,
+            'product_variant_id' => $variant->product_variant_id,
+            'sod_qty' => self::ORDERED_QTY,
+        ]);
+    }
+
+    public function test_a_valid_edit_of_an_approved_so_still_commits_normally(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        [$stock, $variant] = $this->createFixture();
+        $so = $this->createApprovedSalesOrder($variant, $stock);
+        $newQty = 25;
+
+        $response = $this->post('/updateSalesOrder', [
+            'so_id' => $so->so_id,
+            'so_number' => $so->so_number,
+            'so_invoice_no' => $so->so_invoice_no,
+            'so_customer' => $so->so_customer,
+            'so_date' => now()->toDateString(),
+            'so_total' => $newQty * 1000,
+            'so_img' => json_encode([]),
+            'products' => json_encode([[
+                'sod_id' => SalesOrderDetail::where('so_id', $so->so_id)->value('sod_id'),
+                'product_variant_id' => $variant->product_variant_id,
+                'product_name' => 'SO Update Atomicity Product',
+                'pr_name' => 'SO Update Atomicity Product',
+                'product_variant_name' => $variant->product_variant_name,
+                'product_variant_sku' => $variant->product_variant_sku,
+                'unit_id' => $stock->unit_id,
+                'product_variant_price' => 1000,
+                'so_qty' => $newQty,
+                'so_subtotal' => $newQty * 1000,
+            ]]),
+        ]);
+        $response->assertStatus(200);
+
+        // Proves the added transaction COMMITS rather than silently swallowing valid work:
+        // 90 + 10 (revert) - 25 (new deduction) = 75.
+        $stock->refresh();
+        $this->assertSame(
+            self::STARTING_STOCK + self::ORDERED_QTY - $newQty,
+            $stock->ps_stock,
+            'a valid edit must still revert the old qty and deduct the new one, and commit both'
+        );
+        $this->assertDatabaseHas('sales_order_details', [
+            'so_id' => $so->so_id,
+            'product_variant_id' => $variant->product_variant_id,
+            'sod_qty' => $newQty,
+        ]);
+    }
+}

--- a/tests/Workflow/SalesOrderFlowTest.php
+++ b/tests/Workflow/SalesOrderFlowTest.php
@@ -10,9 +10,15 @@ use Tests\TestCase;
 
 /**
  * See cdocs/testing/workflows/SALES_ORDER_FLOW.md for the fully-traced flow this asserts against.
- * Unlike Purchase Order, this flow wraps its stock mutation in a real DB::transaction() end to
- * end — the pilot deliberately picks a plain, non-retail, non-unit-converted line item to keep
- * scope to Insert -> Approve -> Reject, matching the Purchase Order pilot's shape.
+ * The pilot deliberately picks a plain, non-retail, non-unit-converted line item to keep scope to
+ * Insert -> Approve -> Reject, matching the Purchase Order pilot's shape.
+ *
+ * Corrected 2026-08-24: this docblock used to claim "unlike Purchase Order, this flow wraps its
+ * stock mutation in a real DB::transaction() end to end". That was false — `CustomerController`
+ * had no transactions at all, and the same false claim in
+ * `cdocs/testing/guides/DATABASE_TRANSACTION_GUIDE.md` is likely why the gap went unprioritised.
+ * `accSO()`/`updateSalesOrder()` are now genuinely transactional; atomicity itself is asserted in
+ * `tests/DatabaseTransaction/SalesOrderUpdateAtomicityTest.php`, not here.
  */
 class SalesOrderFlowTest extends TestCase
 {


### PR DESCRIPTION
## Ringkasan

Menutup **7 titik masuk (entry point) yang memutasi stok tapi sama sekali tidak punya `DB::transaction()`**. Dua di antaranya merusak data stok lewat **alur bisnis normal** — bukan cuma kalau ada crash, race condition, atau data aneh.

Sweep dilakukan dengan menelusuri SEMUA lokasi penulisan `ps_stock`/`ss_stock` (baik assignment langsung maupun lewat method model), lalu dicek satu per satu apakah terbungkus transaksi.

---

## Kenapa ini bisa lolos selama ini

Dokumentasi internal kita **salah**. `cdocs/testing/guides/DATABASE_TRANSACTION_GUIDE.md` menyatakan `CustomerController.php` (Sales Order) sudah pakai `DB::transaction()` "di baris ~196, ~295".

Ternyata baris 196 itu query `ProductRelation` biasa, dan baris 295 itu signature function `accSO()`. File itu **nol** transaksi. Docblock di `tests/Workflow/SalesOrderFlowTest.php` juga mengulang klaim yang sama ("wraps its stock mutation in a real DB::transaction() end to end").

Karena dokumennya bilang sudah aman, celah ini tidak pernah masuk prioritas. Kedua dokumen sudah dikoreksi, dan tabel di guide sekarang diverifikasi ulang baris per baris + diberi peringatan supaya di-grep dulu sebelum dipercaya.

---

## 2 bug paling berbahaya (alur bisnis normal, bukan skenario crash)

### 1. `updateSalesOrder()` — stok hantu tercipta dari ketiadaan

Perhatikan urutan method ini untuk SO yang **sudah di-ACC** (`status == 2`):

- **TAHAP 1** — kembalikan dulu stok lama: `$sOld->ps_stock += $rev['qty']`, langsung `save()`.
- **TAHAP 3** — validasi kecukupan stok. Kalau kurang: `return implode(", ", $p);`
- **TAHAP 4** — baru potong stok sesuai qty baru.

Karena TAHAP 3 berada **di antara** revert dan pemotongan, maka setiap kali user mengedit SO yang sudah di-ACC dengan qty melebihi stok, editnya ditolak — **tapi revert dari TAHAP 1 terlanjur tersimpan permanen dan tidak pernah dipotong lagi**.

Artinya: setiap edit yang ditolak diam-diam **menambah stok** sebesar qty order aslinya. Tidak perlu error, tidak perlu race — cukup user salah input qty, yang justru dipancing oleh UI-nya sendiri.

### 2. `insertReturnSupplies()` — stok berkurang padahal retur dilaporkan gagal

Pre-check memvalidasi tiap baris retur **secara independen** terhadap stok penuh:

```php
if (($ss->ss_stock - $value['rsd_qty'] < 0)) { ... }
```

Tapi loop penulisan mengurangi stok secara **kumulatif**. Jadi 2 baris retur untuk bahan + satuan yang sama, yang masing-masing muat tapi totalnya melebihi stok, akan lolos pre-check lalu baru gagal di tengah proses tulis lewat `return -1`.

Saat itu terjadi, yang sudah terlanjur tersimpan permanen: `po_total` sudah dikurangi, header `ProductIssues` + `ReturnSupplies` sudah dibuat, dan stok baris pertama sudah dipotong beserta log-nya. Padahal ke pemanggil dilaporkan **gagal (`-1`)**.

---

## Daftar lengkap yang diperbaiki

| Entry point | Dampak kalau gagal di tengah |
|---|---|
| `CustomerController::updateSalesOrder()` | **Terparah** — stok hantu tercipta (lihat di atas) |
| `SupplierController::insertReturnSupplies()` | Stok terpotong + header orphan, padahal dilaporkan gagal |
| `CustomerController::accSO()` | Stok terpotong sebagian, status SO tetap 1 → ACC ulang memotong DUA KALI |
| `SupplierController::accPO()` | `ss_stock` bertambah sebagian + header delivery orphan, PO tetap pending → ACC ulang menambah DUA KALI |
| `SupplierController::deleteReturnSupplies()` | Pengembalian stok sebagian + `po_total` terlanjur bertambah |
| `StockController::updateProductIssue()` | Memutasi stok **sebelum** `stockCheck()`-nya jalan, jadi `return -1` meninggalkan mutasi yang terlanjur tersimpan |
| `StockController::insertProductIssue()` / `deleteProductIssue()` | Detail + stok tersimpan sebagian; exit "Invoice sudah terbayar" di `deleteProductIssue` terjadi SETELAH Fase 4 menulis semua perubahan stok |

---

## Logika perbaikan

Semua mengikuti pola yang **sudah ada** di `accProduction()`/`accStockOpname()`, bukan pola baru:

```php
// pre-check yang murni BACA tetap di luar transaksi
DB::beginTransaction();
try {
    // ... semua fase tulis ...
    DB::commit();
    return 1;
} catch (\Throwable $e) {
    DB::rollBack();
    throw $e;
}
```

Prinsip penempatan batas transaksi:

- **Pre-check read-only tetap di luar** — guard status, validasi kecukupan stok yang belum menulis apa pun. Sama seperti `accProduction()` yang pre-check dulu baru `beginTransaction()`.
- **Setiap exit jalur bisnis di dalam transaksi wajib `DB::rollBack()` dulu** sebelum return — ini yang menutup bug "stok hantu" dan "retur gagal tapi stok kepotong", karena keduanya keluar lewat `return` biasa, bukan lewat exception.
- **Flip status ikut masuk transaksi**, supaya tidak ada kondisi "stok sudah berubah tapi status belum" yang memancing ACC ganda.
- Untuk `deleteProductIssue()`, transaksi sengaja dibuka **sebelum** percabangan `tipe_return`, karena `deleteProductIssues()` + loop penghapusan detail di bawahnya jalan untuk semua tipe — kalau dibuka di dalam blok `tipe_return == 2` saja, cabang lainnya tetap tanpa proteksi.

### Null-guard tambahan (masih dalam scope)

`insertReturnSupplies()` mengakses `$ss->ss_stock` tanpa null-check di pre-check (crash "Attempt to read property on null" untuk kombinasi bahan + satuan yang tidak ada), dan meng-assign `$s->ss_stock` ke baris yang mungkin null di loop tulis. Keduanya sudah diberi guard.

---

## Yang SENGAJA tidak disentuh

`insertPoDelivery` / `updatePoDelivery` / `accPoDelivery` / `declinePoDelivery` juga tidak punya transaksi, **tapi tidak diperbaiki** — keempatnya bagian dari workflow manual PO Delivery yang sudah dideprecate lewat keputusan product owner 2026-08-04 ("do not fix, do not test, do not re-investigate").

Dicatat di `KNOWN_ISSUES.md` supaya terekam sebagai keputusan sadar, bukan kelewatan.

---

## Yang belum ditangani (keputusan scope)

**Race condition TOCTOU masih terbuka.** Dua proses ACC bersamaan masih bisa sama-sama membaca stok yang sama lalu keduanya lanjut. Menutup ini butuh `lockForUpdate()` pada baris stok (pola yang sudah dipakai di hardening CashGudang) dan menyentuh pola query di jalur yang ramai, jadi sengaja dikeluarkan dari sweep ini.

---

## Testing

**Test baru:**
- `tests/DatabaseTransaction/SalesOrderUpdateAtomicityTest.php` (2 test)
- `tests/DatabaseTransaction/ReturnSuppliesInsertAtomicityTest.php` (2 test)

Masing-masing memasangkan assertion rollback **dengan** assertion happy-path, supaya terbukti transaksinya benar-benar `commit` untuk pekerjaan yang valid — bukan cuma menelan semuanya.

**Kedua test diverifikasi benar-benar menangkap bug-nya** dengan cara `git stash` fix controller-nya lalu memastikan test-nya GAGAL tanpa fix:
- Sales Order: stok 100 (harusnya 90) → stok hantu terbukti
- Return Supplies: stok 4 (harusnya 10) → potongan baris pertama terbukti tertinggal

`PurchaseOrderApprovalAtomicityTest` sebelumnya adalah characterization test yang sengaja meng-assert perilaku partial-commit yang LAMA. Sesuai konvensi repo (test regresi tidak pernah dihapus), test itu di-flip di tempat untuk meng-assert perilaku yang sudah benar.

**Perbandingan dengan baseline `main`** (dijalankan di direktori yang sama, sesuai catatan metodologi di `fase2-merge-plan.md`):

| Suite | Baseline `main` | Branch ini |
|---|---|---|
| Workflow | 103 test, 1 error, 13 failure | **identik** |
| Smoke | 120 test, 12 failure | **identik** |
| Regression | 74 test, 1 failure | **identik** |
| DatabaseTransaction | 14 test, OK | **18 test, OK** (+4 test baru) |

**Nol regresi baru.** Failure yang tersisa semuanya pre-existing (drift data multi-gudang di DB testing lokal, sudah tercatat sebelumnya).

Fixture di test baru dibangun fresh lewat Eloquent, bukan mengambil data seed — karena DB `pegasus_testing` lokal saat ini punya baris multi-gudang nyata yang bikin fixture hasil pilih-tangan jadi tidak deterministik.
