### PR TITLE
fix: cakupan konversi satuan — roll-up di semua jalur stok masuk + bug bongkar ketiga yang kelewatan

### DIFF
--- a/app/Http/Controllers/CustomerController.php
+++ b/app/Http/Controllers/CustomerController.php
@@ -16,6 +16,7 @@ use App\Models\SalesOrderDetail;
 use App\Models\Staff;
 use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
+use App\Support\UnitRollUp;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 
@@ -130,16 +131,54 @@ class CustomerController extends Controller
             $revertAgregat[$key]['qty'] += $oldDetail->sod_qty;
         }
 
+        // Baris (varian_satuan) yang MASIH ada di daftar produk baru. Untuk baris-baris ini, revert
+        // TAHAP 1 di bawah akan langsung dipotong lagi di TAHAP 4 dalam request yang sama, jadi
+        // menaikkan satuannya di sini cuma churn: naik satuan lalu langsung dibongkar lagi oleh
+        // TAHAP 3, plus sepasang log konversi bolak-balik yang menyesatkan. Baris yang DIHAPUS dari
+        // SO tidak punya pasangan pemotongan — revert-nya jadi kondisi akhir, jadi ITU yang perlu
+        // naik satuan supaya konsisten dengan jalur pengembalian stok lain (2026-08-25).
+        $masihDipakai = [];
+        foreach ($productsData as $val) {
+            if (isset($val['product_variant_id'], $val['unit_id'])) {
+                $masihDipakai[$val['product_variant_id'] . '_' . $val['unit_id']] = true;
+            }
+        }
+
         // Eksekusi Revert Real ke DB & Log (Sekali per Satuan)
-        foreach ($revertAgregat as $rev) {
+        foreach ($revertAgregat as $revKey => $rev) {
             $sOld = ProductStock::where("product_variant_id", $rev['pvr_id'])
                 ->where("unit_id", $rev['unit_id'])
                 ->where("status", 1)
                 ->first();
-            
+
             if($sOld) {
                 $sOld->ps_stock += $rev['qty'];
                 $sOld->save();
+
+                // Baris dihapus dari SO → revert ini final, naikkan satuannya berjenjang.
+                if (!isset($masihDipakai[$revKey])) {
+                    $rollUp = UnitRollUp::planProduct((int) $rev['pvr_id'], (int) $rev['unit_id'], (int) $rev['qty']);
+                    $naikLevel = array_slice($rollUp, 1);
+
+                    if ($naikLevel !== []) {
+                        // Turunkan lagi yang sudah terlanjur ditambahkan flat di atas, lalu
+                        // distribusikan sesuai rencana roll-up.
+                        $sOld->ps_stock -= $rev['qty'];
+                        $sOld->ps_stock += (int) $rollUp[0]['qty'];
+                        $sOld->save();
+
+                        foreach ($naikLevel as $credit) {
+                            if ($credit['qty'] <= 0) continue;
+                            $row = ProductStock::where('product_variant_id', $rev['pvr_id'])
+                                ->where('unit_id', $credit['unit_id'])
+                                ->where('status', 1)
+                                ->first();
+                            if (!$row) continue;
+                            $row->ps_stock += $credit['qty'];
+                            $row->save();
+                        }
+                    }
+                }
 
                 (new LogStock())->insertLog([                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                
                     'log_date' => now(), 
@@ -196,20 +235,50 @@ class CustomerController extends Controller
 
                 if ($keyTarget === null) { $valid = -1; continue; }
 
-                $siapkanStok = function($targetKey, $units) use (&$virtualStock, &$logSummary, &$siapkanStok, $variantId) {
-                    if (!isset($units[$targetKey + 1])) return false; 
-                    $stokSekarang = $units[$targetKey];
-                    $stokAtas = $units[$targetKey + 1];
+                // Diperbaiki (2026-08-25): dulu unit di atasnya diambil lewat POSISI ARRAY
+                // ($units[$targetKey + 1]) pada koleksi yang diurutkan `ps_id DESC` -- padahal ps_id
+                // itu urutan pembuatan baris stok, sama sekali tidak ada hubungannya dengan urutan
+                // hierarki satuan. Relasi yang benar sudah di-query ($sr), tapi hasilnya
+                // ($sr->pr_unit_id_1) TIDAK pernah dipakai untuk menentukan baris mana yang dipotong
+                // -- jadi kalau urutan ps_id kebetulan tidak sama dengan urutan ladder, stok dipotong
+                // dari satuan YANG SALAH dengan rasio milik satuan lain (korupsi stok, bukan cuma
+                // gagal). Ini bug yang PERSIS sama dengan yang sudah diperbaiki 2026-08-05 di
+                // ProductIssuesDetail::stockCheck() (dua closure-nya) dan 2026-08-06 di
+                // StockController::deleteProductIssue() -- lihat
+                // tests/Regression/ReturnSuppliesBongkarFailsOnStockRowInsertionOrderTest.php.
+                // Sales Order kelewatan di sapuan itu. Sekarang pola-nya disamakan: cari relasi
+                // dulu, baru cari index baris stok yang unit_id-nya cocok dengan pr_unit_id_1.
+                $siapkanStok = function($targetKey, $units, $depth = 0) use (&$virtualStock, &$logSummary, &$siapkanStok, $variantId) {
+                    // Depth guard, sama seperti StockController::deleteProductIssue() -- $keyAtas
+                    // dicari lewat lookup relasi, jadi rantai yang sirkular bisa rekursi selamanya.
+                    if ($depth >= 20) return false;
 
-                    if ($virtualStock[$stokAtas->ps_id]['current'] <= 0) {
-                        if (!$siapkanStok($targetKey + 1, $units)) return false;
-                    }
+                    $stokSekarang = $units[$targetKey];
 
                     $sr = ProductRelation::where('product_variant_id', $variantId)
                         ->where('pr_unit_id_2', $stokSekarang->unit_id)
                         ->where('status', 1)->first();
 
-                    if ($sr && $virtualStock[$stokAtas->ps_id]['current'] > 0) {
+                    if (!$sr) return false;
+
+                    // Cari index baris stok milik unit atas berdasarkan RELASI, bukan posisi array.
+                    $keyAtas = null;
+                    foreach ($units as $idx => $stok) {
+                        if ((int) $stok->unit_id === (int) $sr->pr_unit_id_1) {
+                            $keyAtas = $idx;
+                            break;
+                        }
+                    }
+
+                    if ($keyAtas === null) return false;
+
+                    $stokAtas = $units[$keyAtas];
+
+                    if ($virtualStock[$stokAtas->ps_id]['current'] <= 0) {
+                        if (!$siapkanStok($keyAtas, $units, $depth + 1)) return false;
+                    }
+
+                    if ($virtualStock[$stokAtas->ps_id]['current'] > 0) {
                         $virtualStock[$stokAtas->ps_id]['current'] -= 1;
                         $hasilBongkar = (float)$sr['pr_unit_value_2'];
                         $virtualStock[$stokSekarang->ps_id]['current'] += $hasilBongkar;

--- a/app/Http/Controllers/SupplierController.php
+++ b/app/Http/Controllers/SupplierController.php
@@ -21,6 +21,7 @@ use App\Models\Supplies;
 use App\Models\SuppliesStock;
 use App\Models\SuppliesVariant;
 use Barryvdh\DomPDF\Facade\Pdf;
+use App\Support\UnitRollUp;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Session;
@@ -610,6 +611,102 @@ class SupplierController extends Controller
         }
     }
 
+    /**
+     * Apakah TOTAL stok satu bahan (dijumlahkan lintas seluruh ladder satuan, dikonversi ke
+     * satuan-terkecil-setara) cukup untuk memenuhi $qty pada $unitId?
+     *
+     * Dipakai tolakPO() sebagai pengganti "cek stok di satuan yang dipesan saja" — sejak
+     * penerimaan PO menaikkan satuan (UnitRollUp), stok bisa berada di satuan yang lebih besar.
+     */
+    private function suppliesLadderHasEnough(int $suppliesId, int $unitId, int $qty): bool
+    {
+        $chain = UnitRollUp::suppliesChain($suppliesId);
+
+        // Faktor konversi tiap satuan ke satuan target ($unitId). Satuan target = 1.
+        $faktor = [$unitId => 1];
+        $current = $unitId;
+        $hops = 0;
+        while ($hops < 20) {
+            $hops++;
+            $rel = null;
+            foreach ($chain as $link) {
+                if ($link['small'] === $current) { $rel = $link; break; }
+            }
+            if ($rel === null || $rel['ratio'] <= 0) break;
+            $faktor[$rel['big']] = $faktor[$current] * $rel['ratio'];
+            $current = $rel['big'];
+        }
+
+        $total = 0;
+        $rows = SuppliesStock::where('supplies_id', $suppliesId)->where('status', 1)->get();
+        foreach ($rows as $row) {
+            $u = (int) $row->unit_id;
+            if (isset($faktor[$u])) {
+                $total += ((int) $row->ss_stock) * $faktor[$u];
+            }
+        }
+
+        return $total >= $qty;
+    }
+
+    /**
+     * Pecah satuan yang lebih besar turun ke $unitId sampai baris stok $unitId cukup untuk $qty.
+     * Menyimpan langsung ke DB dan mencatat log konversinya (pola sama dengan bongkar di
+     * ProductIssuesDetail::stockCheck(): satuan atas keluar/cat 2, satuan bawah masuk/cat 1).
+     *
+     * Unit atas dicari lewat RELASI (su_id_1), bukan posisi array — pelajaran dari
+     * ReturnSuppliesBongkarFailsOnStockRowInsertionOrderTest.
+     */
+    private function bongkarSuppliesUntilEnough(int $suppliesId, int $unitId, int $qty, $sv, &$p): void
+    {
+        $chain = UnitRollUp::suppliesChain($suppliesId);
+        $safety = 0;
+
+        while ($safety < 500) {
+            $safety++;
+
+            $target = SuppliesStock::where('supplies_id', $suppliesId)
+                ->where('unit_id', $unitId)->where('status', 1)->first();
+            if (! $target || $target->ss_stock >= $qty) {
+                return; // sudah cukup (atau tidak ada baris sama sekali — biarkan guard di atas yang bicara)
+            }
+
+            // Cari satuan tepat di atas $unitId lewat relasi.
+            $rel = null;
+            foreach ($chain as $link) {
+                if ($link['small'] === $unitId) { $rel = $link; break; }
+            }
+            if ($rel === null || $rel['ratio'] <= 0) return;
+
+            $atas = SuppliesStock::where('supplies_id', $suppliesId)
+                ->where('unit_id', $rel['big'])->where('status', 1)->first();
+
+            // Satuan atas kosong → coba isi dulu dari satuan di atasnya lagi (rekursif satu tingkat).
+            if (! $atas || $atas->ss_stock <= 0) {
+                if ($atas === null) return;
+                $this->bongkarSuppliesUntilEnough($suppliesId, (int) $rel['big'], 1, $sv, $p);
+                $atas->refresh();
+                if ($atas->ss_stock <= 0) return;
+            }
+
+            $atas->ss_stock -= 1;
+            $atas->save();
+            $target->ss_stock += $rel['ratio'];
+            $target->save();
+
+            (new LogStock())->insertLog([
+                'log_date' => now(), 'log_kode' => '-', 'log_type' => 2, 'log_category' => 2,
+                'log_item_id' => $suppliesId, 'log_notes' => 'Konversi unit (Bongkar) pembatalan PO',
+                'log_jumlah' => 1, 'unit_id' => (int) $rel['big'],
+            ]);
+            (new LogStock())->insertLog([
+                'log_date' => now(), 'log_kode' => '-', 'log_type' => 2, 'log_category' => 1,
+                'log_item_id' => $suppliesId, 'log_notes' => 'Konversi unit (Hasil) pembatalan PO',
+                'log_jumlah' => (int) $rel['ratio'], 'unit_id' => $unitId,
+            ]);
+        }
+    }
+
     function tolakPO(Request $req) {
         $data = $req->all();
         $p = PurchaseOrder::find($data["po_id"]);
@@ -630,6 +727,13 @@ class SupplierController extends Controller
                 $details = PurchaseOrderDetail::where('po_id', '=', $data["po_id"])->get();
                 $kurang = [];
 
+                // Diperbaiki (2026-08-25): dulu ini cuma melihat stok di satuan yang DIPESAN dan
+                // menolak pembatalan kalau satuan itu saja tidak cukup. Sejak penerimaan barang PO
+                // menaikkan satuan berjenjang (lihat PurchaseOrderDeliveryDetail::insertPoDeliveryDetail()),
+                // stok hasil penerimaan bisa saja sudah tidak berada di satuan yang dipesan lagi --
+                // 24 Piece yang diterima jadi 2 DOS. Tanpa perubahan ini, membatalkan PO yang sudah
+                // di-ACC akan SELALU gagal "Stok bahan tidak mencukupi" untuk bahan yang punya ladder.
+                // Sekarang yang dibandingkan adalah TOTAL stok dalam satuan terkecil-setara.
                 foreach ($details as $value) {
                     $sv = SuppliesVariant::find($value->supplies_variant_id);
                     if (!$sv) {
@@ -638,12 +742,7 @@ class SupplierController extends Controller
                         continue;
                     }
 
-                    $s = SuppliesStock::where("supplies_id", "=", $sv->supplies_id)
-                        ->where("unit_id", "=", $value->unit_id)
-                        ->where("status", "=", 1)
-                        ->first();
-
-                    if (!$s || ($s->ss_stock - $value->pod_qty) < 0) {
+                    if (!$this->suppliesLadderHasEnough((int) $sv->supplies_id, (int) $value->unit_id, (int) $value->pod_qty)) {
                         $name = trim(($value->pod_nama ?? '') . ' ' . ($value->pod_variant ?? ''));
                         if ($name === '' && $sv) {
                             $name = $sv->supplies_variant_name ?? 'Bahan';
@@ -662,6 +761,11 @@ class SupplierController extends Controller
 
                 foreach ($details as $value) {
                     $sv = SuppliesVariant::find($value->supplies_variant_id);
+
+                    // Bongkar satuan besar dulu kalau satuan yang dipesan tidak cukup sendirian
+                    // (lihat komentar di blok validasi di atas). Kalau sudah cukup, ini no-op.
+                    $this->bongkarSuppliesUntilEnough((int) $sv->supplies_id, (int) $value->unit_id, (int) $value->pod_qty, $sv, $p);
+
                     $s = SuppliesStock::where("supplies_id", "=", $sv->supplies_id)
                         ->where("unit_id", "=", $value->unit_id)
                         ->where("status", "=", 1)

--- a/app/Models/ProductIssuesDetail.php
+++ b/app/Models/ProductIssuesDetail.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Support\UnitRollUp;
 use Illuminate\Database\Eloquent\Model;
 
 class ProductIssuesDetail extends Model
@@ -167,9 +168,59 @@ class ProductIssuesDetail extends Model
         
         if($pi->tipe_return == 1){
             $m = SuppliesVariant::find($t->item_id);
-            $s = SuppliesStock::where('supplies_id',$m->supplies_id)->where('unit_id',$t->unit_id)->first();
-            $s->ss_stock += $t->pid_qty;
+            // Ditambahkan (2026-08-25): dulu pengembalian stok ini flat (`ss_stock += pid_qty`)
+            // tanpa konversi satuan sama sekali -- 24 Piece yang dikembalikan tetap menumpuk sebagai
+            // 24 Piece walaupun 1 DOS = 12 Piece. Sekarang dinaikkan berjenjang lewat UnitRollUp,
+            // konsisten dengan hasil produksi (accProduction). UnitRollUp hanya menaikkan ke satuan
+            // yang SUDAH punya baris stok aktif, jadi tidak ada baris stok baru yang dibuat diam-diam.
+            $rollUp = UnitRollUp::planSupplies((int) $m->supplies_id, (int) $t->unit_id, (int) $t->pid_qty);
+            $base = $rollUp[0];           // selalu satuan asal
+            $naikLevel = array_slice($rollUp, 1); // level-level di atasnya (kosong kalau tidak naik)
+
+            // Baris stok satuan asal SENGAJA tidak di-null-guard: kalau kombinasi supplies_id +
+            // unit_id tidak ketemu, itu unit_id yang salah dan harus meledak seperti perilaku lama,
+            // bukan gagal senyap (stok tidak pernah kembali tanpa ada yang tahu).
+            $s = SuppliesStock::where('supplies_id',$m->supplies_id)->where('unit_id',$base['unit_id'])->first();
+            $s->ss_stock += $base['qty'];
             $s->save();
+
+            // Level di atasnya dijamin punya baris stok aktif — UnitRollUp hanya menaikkan ke
+            // satuan yang sudah punya baris (lihat allowedSuppliesUnitIds()).
+            foreach ($naikLevel as $credit) {
+                if ($credit['qty'] <= 0) continue;
+
+                $row = SuppliesStock::where('supplies_id', $m->supplies_id)
+                    ->where('unit_id', $credit['unit_id'])
+                    ->where('status', 1)
+                    ->first();
+                if (!$row) continue;
+
+                $row->ss_stock += $credit['qty'];
+                $row->save();
+            }
+
+            // Catat jejak konversinya kalau memang naik satuan, supaya ledger tidak menunjukkan
+            // stok "pindah" satuan tanpa penjelasan. Pola log-nya sama dengan bongkar di
+            // stockCheck(): satuan asal keluar (cat 2), satuan hasil masuk (cat 1). Caller tetap
+            // menulis log utamanya sendiri.
+            if ($naikLevel !== []) {
+                $naik = (int) $t->pid_qty - (int) $base['qty'];
+                if ($naik > 0) {
+                    (new LogStock())->insertLog([
+                        'log_date' => now(), 'log_kode' => '-', 'log_type' => 2, 'log_category' => 2,
+                        'log_item_id' => $m->supplies_id, 'log_notes' => 'Konversi unit (Naik satuan)',
+                        'log_jumlah' => $naik, 'unit_id' => (int) $t->unit_id,
+                    ]);
+                }
+                foreach ($naikLevel as $credit) {
+                    if ($credit['qty'] <= 0) continue;
+                    (new LogStock())->insertLog([
+                        'log_date' => now(), 'log_kode' => '-', 'log_type' => 2, 'log_category' => 1,
+                        'log_item_id' => $m->supplies_id, 'log_notes' => 'Konversi unit (Hasil naik satuan)',
+                        'log_jumlah' => $credit['qty'], 'unit_id' => $credit['unit_id'],
+                    ]);
+                }
+            }
 
             // Cek dari retur pembelian, apakah ada barang yang dibeli dari invoice ini
             if ($pi['ref_num'] != 0){

--- a/app/Models/PurchaseOrderDeliveryDetail.php
+++ b/app/Models/PurchaseOrderDeliveryDetail.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Support\UnitRollUp;
 use Illuminate\Database\Eloquent\Model;
 
 class PurchaseOrderDeliveryDetail extends Model
@@ -47,13 +48,52 @@ class PurchaseOrderDeliveryDetail extends Model
         $t->status = $data["status"]??1;
         $t->save();
         if(isset($data["statusPO"])&&$data["statusPO"]==2){
-            $s = SuppliesVariant::find($data["supplies_variant_id"]);
-            $s = SuppliesStock::where("supplies_id", "=", $s->supplies_id)
-                ->where("unit_id", "=", $data["unit_id"])
+            $sv = SuppliesVariant::find($data["supplies_variant_id"]);
+
+            // Ditambahkan (2026-08-25): penerimaan barang PO dulu flat (`ss_stock += pdod_qty`)
+            // tanpa konversi satuan -- 24 Piece yang dibeli tetap 24 Piece walaupun 1 DOS = 12 Piece,
+            // padahal 24 Piece hasil PRODUKSI sudah naik jadi 2 DOS sejak GitHub #19. Barang fisik
+            // yang sama jadi terepresentasi beda tergantung cara masuknya. Sekarang dinaikkan
+            // berjenjang lewat UnitRollUp, yang hanya menaikkan ke satuan yang SUDAH punya baris
+            // stok aktif (tidak membuat baris baru diam-diam).
+            //
+            // PENTING: tolakPO() -- pembatalan PO yang sudah di-ACC -- ikut disesuaikan di
+            // SupplierController supaya bisa membongkar satuan besar saat mengembalikan stok.
+            // Tanpa itu, roll-up di sini membuat pembatalan PO selalu gagal "Stok bahan tidak
+            // mencukupi", karena stoknya sudah tidak lagi berada di satuan yang dipesan.
+            $rollUp = UnitRollUp::planSupplies(
+                (int) $sv->supplies_id,
+                (int) $data["unit_id"],
+                (int) $data["pdod_qty"]
+            );
+
+            // Entry ke-0 selalu satuan asal. Baris stoknya SENGAJA tidak di-null-guard: kalau
+            // kombinasi supplies_id + unit_id tidak ketemu, itu unit_id yang salah dan harus
+            // meledak seperti perilaku sebelumnya supaya transaksi accPO() rollback -- bukan
+            // di-skip diam-diam, yang berarti "barang diterima tapi stok tidak pernah bertambah"
+            // tanpa ada yang tahu (antipattern yang sudah pernah diperbaiki di accProduction()).
+            $base = array_shift($rollUp);
+            $s = SuppliesStock::where("supplies_id", "=", $sv->supplies_id)
+                ->where("unit_id", "=", $base['unit_id'])
                 ->where("status", "=", 1)
                 ->first();
-            $s->ss_stock += $data["pdod_qty"];
+            $s->ss_stock += $base['qty'];
             $s->save();
+
+            // Level di atasnya dijamin punya baris stok aktif — UnitRollUp hanya menaikkan ke
+            // satuan yang sudah punya baris (lihat allowedSuppliesUnitIds()).
+            foreach ($rollUp as $credit) {
+                if ($credit['qty'] <= 0) continue;
+
+                $row = SuppliesStock::where("supplies_id", "=", $sv->supplies_id)
+                    ->where("unit_id", "=", $credit['unit_id'])
+                    ->where("status", "=", 1)
+                    ->first();
+                if (!$row) continue;
+
+                $row->ss_stock += $credit['qty'];
+                $row->save();
+            }
         }
         return $t->pdod_id;
     }

--- a/app/Support/UnitRollUp.php
+++ b/app/Support/UnitRollUp.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace App\Support;
+
+use App\Models\ProductRelation;
+use App\Models\ProductStock;
+use App\Models\SuppliesRelation;
+use App\Models\SuppliesStock;
+
+/**
+ * Roll a quantity UP a product's / raw material's unit ladder — the "naik satuan" direction
+ * (small -> big, e.g. 24 Piece -> 2 DOS -> 1 Sak).
+ *
+ * Why this exists (2026-08-25): an audit of every `ps_stock`/`ss_stock` write site found that the
+ * roll-up direction existed in exactly ONE place — `ProductionController::accProduction()`'s
+ * finished-goods crediting (added for GitHub #19). Every other stock-IN path did a flat
+ * `$row->ps_stock += $qty` with no conversion at all: Purchase Order goods receipt
+ * (`PurchaseOrderDeliveryDetail::insertPoDeliveryDetail()`), stock restores
+ * (`ProductIssuesDetail::deleteProductIssuesDetail()`), and Sales Order's edit-time revert
+ * (`CustomerController::updateSalesOrder()` TAHAP 1). The same physical goods therefore ended up
+ * represented differently depending on how they entered the system — 24 Piece stayed 24 Piece when
+ * purchased, but became 1 Sak when produced.
+ *
+ * The opposite direction ("bongkar", big -> small, used when a consuming unit is short) is NOT
+ * here: it is need-driven — it only makes sense against a specific target quantity to satisfy —
+ * so it stays at each consumption site. See `ProductIssuesDetail::stockCheck()` and
+ * `StockController::deleteProductIssue()` for the canonical relation-lookup implementations of it.
+ *
+ * Design notes:
+ * - `plan*()` is PURE: it performs no DB writes and returns the credit plan as an ordered list of
+ *   `{unit_id, qty}`, lowest unit first. The caller applies it and writes its own `log_stocks`
+ *   rows, because the log note/code differs per flow.
+ * - `$allowedUnitIds` is the caller's policy hook for "may I credit this unit?". Production passes
+ *   every unit in the ladder because it provisions missing `ProductStock` rows on demand (behind a
+ *   user confirmation). Every other caller passes only units that ALREADY have an active stock
+ *   row, via `allowedProductUnitIds()`/`allowedSuppliesUnitIds()` below — so a roll-up never
+ *   silently creates a stock row the user never asked for. Rolling stops at the first disallowed
+ *   unit and the remainder simply stays at the level below it, which is always a valid state.
+ * - Guarded at 20 hops, same as the ladder walkers in ProductionController, so a circular or
+ *   corrupt relation chain can't loop forever.
+ */
+class UnitRollUp
+{
+    private const MAX_HOPS = 20;
+
+    /**
+     * @param  array<int, array{small: int, big: int, ratio: int}>  $chain
+     * @param  array<int, int>  $allowedUnitIds
+     * @return array<int, array{unit_id: int, qty: int}>
+     */
+    public static function plan(array $chain, int $startUnitId, int $qty, array $allowedUnitIds): array
+    {
+        $credits = [];
+        $currentUnitId = $startUnitId;
+        $remaining = $qty;
+        $allowed = array_flip(array_map('intval', $allowedUnitIds));
+        $hops = 0;
+
+        while ($hops < self::MAX_HOPS) {
+            $hops++;
+
+            $rel = null;
+            foreach ($chain as $link) {
+                if ($link['small'] === $currentUnitId) {
+                    $rel = $link;
+                    break;
+                }
+            }
+
+            // Chain ended, quantity no longer fills a whole bigger unit, ratio is nonsense, or the
+            // caller won't let us credit the next unit up — stop and leave the rest where it is.
+            if ($rel === null
+                || $rel['ratio'] <= 0
+                || $remaining < $rel['ratio']
+                || ! isset($allowed[$rel['big']])
+            ) {
+                break;
+            }
+
+            $credits[] = ['unit_id' => $currentUnitId, 'qty' => (int) ($remaining % $rel['ratio'])];
+
+            $currentUnitId = $rel['big'];
+            $remaining = (int) floor($remaining / $rel['ratio']);
+        }
+
+        $credits[] = ['unit_id' => $currentUnitId, 'qty' => (int) $remaining];
+
+        return $credits;
+    }
+
+    /** @return array<int, array{small: int, big: int, ratio: int}> */
+    public static function productChain(int $productVariantId): array
+    {
+        return ProductRelation::where('product_variant_id', $productVariantId)
+            ->where('status', 1)
+            ->get()
+            ->map(fn ($r) => [
+                'small' => (int) $r->pr_unit_id_2,
+                'big' => (int) $r->pr_unit_id_1,
+                'ratio' => (int) $r->pr_unit_value_2,
+            ])
+            ->all();
+    }
+
+    /** @return array<int, array{small: int, big: int, ratio: int}> */
+    public static function suppliesChain(int $suppliesId): array
+    {
+        return SuppliesRelation::where('supplies_id', $suppliesId)
+            ->where('status', 1)
+            ->get()
+            ->map(fn ($r) => [
+                'small' => (int) $r->su_id_2,
+                'big' => (int) $r->su_id_1,
+                'ratio' => (int) $r->sr_value_2,
+            ])
+            ->all();
+    }
+
+    /** Units that already have an active ProductStock row — the default crediting policy. */
+    public static function allowedProductUnitIds(int $productVariantId): array
+    {
+        return ProductStock::where('product_variant_id', $productVariantId)
+            ->where('status', 1)
+            ->pluck('unit_id')
+            ->map(fn ($u) => (int) $u)
+            ->all();
+    }
+
+    /** Units that already have an active SuppliesStock row — the default crediting policy. */
+    public static function allowedSuppliesUnitIds(int $suppliesId): array
+    {
+        return SuppliesStock::where('supplies_id', $suppliesId)
+            ->where('status', 1)
+            ->pluck('unit_id')
+            ->map(fn ($u) => (int) $u)
+            ->all();
+    }
+
+    /**
+     * Convenience wrapper: plan a product roll-up restricted to units that already have stock rows.
+     *
+     * @return array<int, array{unit_id: int, qty: int}>
+     */
+    public static function planProduct(int $productVariantId, int $startUnitId, int $qty): array
+    {
+        return self::plan(
+            self::productChain($productVariantId),
+            $startUnitId,
+            $qty,
+            self::allowedProductUnitIds($productVariantId)
+        );
+    }
+
+    /**
+     * Convenience wrapper: plan a supplies roll-up restricted to units that already have stock rows.
+     *
+     * @return array<int, array{unit_id: int, qty: int}>
+     */
+    public static function planSupplies(int $suppliesId, int $startUnitId, int $qty): array
+    {
+        return self::plan(
+            self::suppliesChain($suppliesId),
+            $startUnitId,
+            $qty,
+            self::allowedSuppliesUnitIds($suppliesId)
+        );
+    }
+}

--- a/tests/Regression/SalesOrderUpdateBongkarFailsOnStockRowInsertionOrderTest.php
+++ b/tests/Regression/SalesOrderUpdateBongkarFailsOnStockRowInsertionOrderTest.php
@@ -1,0 +1,177 @@
+<?php
+
+namespace Tests\Regression;
+
+use App\Models\Category;
+use App\Models\Product;
+use App\Models\ProductRelation;
+use App\Models\ProductStock;
+use App\Models\ProductVariant;
+use App\Models\SalesOrder;
+use App\Models\SalesOrderDetail;
+use Illuminate\Support\Facades\DB;
+use Tests\Support\ActingAsStaff;
+use Tests\TestCase;
+
+/**
+ * ✅ FIXED (2026-08-25): third and last instance of the "bongkar resolves the larger unit by ARRAY
+ * POSITION instead of by relation" bug.
+ *
+ * The same bug shape was found and fixed twice before — 2026-08-05 in
+ * `ProductIssuesDetail::stockCheck()`'s two closures (see
+ * `ReturnSuppliesBongkarFailsOnStockRowInsertionOrderTest`) and 2026-08-06 in
+ * `StockController::deleteProductIssue()`, whose fixed version even carries the comment "cari unit
+ * atas via relasi, tidak bergantung index". `CustomerController::updateSalesOrder()` was missed by
+ * both passes and kept using `$units[$targetKey + 1]` on a collection ordered by `ps_id DESC`.
+ *
+ * Why that is worse here than in the earlier two: this closure DOES query the correct relation
+ * (`$sr`, matching `pr_unit_id_2` to the current unit) but then never uses `$sr->pr_unit_id_1` to
+ * decide which row to decrement. It decrements whichever row sat at `$targetKey + 1` while
+ * crediting the current unit at `$sr->pr_unit_value_2`. So when `ps_id` order happened not to match
+ * the ladder order, it did not merely fail to find stock — it broke down the WRONG unit at ANOTHER
+ * unit's ratio, silently corrupting both rows.
+ *
+ * This test pins the plain 2-level case with the smaller unit's `ProductStock` row created FIRST
+ * (the reproducing order — equally plausible in real provisioning). Before the fix,
+ * `$targetKey + 1` ran off the end of the array and bongkar returned false immediately, so the
+ * edit was rejected as "insufficient stock" even though combined physical stock was ample.
+ */
+class SalesOrderUpdateBongkarFailsOnStockRowInsertionOrderTest extends TestCase
+{
+    use ActingAsStaff;
+
+    private const PIECE = 9;
+    private const DOS = 7;
+
+    public function test_editing_an_approved_so_bongkars_correctly_when_the_smaller_units_row_was_created_first(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $category = new Category();
+        $category->category_name = 'SO Bongkar Order Regression Category';
+        $category->status = 1;
+        $category->save();
+
+        $product = new Product();
+        $product->product_name = 'SO Bongkar Order Regression Product '.uniqid();
+        $product->category_id = $category->category_id;
+        $product->product_unit = json_encode([self::PIECE, self::DOS]);
+        $product->unit_id = self::PIECE;
+        $product->status = 1;
+        $product->save();
+
+        $variant = new ProductVariant();
+        $variant->product_id = $product->product_id;
+        $variant->product_variant_name = 'SO Bongkar Order Regression Variant';
+        $variant->product_variant_sku = 'REG-SOBONGKAR-'.uniqid();
+        $variant->product_variant_price = 1000;
+        $variant->status = 1;
+        $variant->save();
+
+        $relation = new ProductRelation();
+        $relation->product_variant_id = $variant->product_variant_id;
+        $relation->pr_unit_id_1 = self::DOS;   // larger unit
+        $relation->pr_unit_id_2 = self::PIECE; // smaller unit
+        $relation->pr_unit_value_1 = 1;
+        $relation->pr_unit_value_2 = 12;       // 1 DOS = 12 Piece
+        $relation->pr_default = 0;
+        $relation->status = 1;
+        $relation->save();
+
+        // Smaller unit's row created FIRST (lower ps_id) — the reproducing order. With
+        // `orderBy('ps_id','desc')` this lands the Piece row at the LAST index, so the old
+        // `$targetKey + 1` ran off the end of the array and never found the DOS row.
+        $pieceStock = new ProductStock();
+        $pieceStock->product_id = $product->product_id;
+        $pieceStock->product_variant_id = $variant->product_variant_id;
+        $pieceStock->unit_id = self::PIECE;
+        $pieceStock->warehouse_id = 1;
+        $pieceStock->ps_stock = 5; // not enough alone
+        $pieceStock->status = 1;
+        $pieceStock->save();
+
+        $dosStock = new ProductStock();
+        $dosStock->product_id = $product->product_id;
+        $dosStock->product_variant_id = $variant->product_variant_id;
+        $dosStock->unit_id = self::DOS;
+        $dosStock->warehouse_id = 1;
+        $dosStock->ps_stock = 4; // 4 DOS = 48 Piece — ample combined with the 5 Piece
+        $dosStock->status = 1;
+        $dosStock->save();
+
+        // An already-approved SO for 5 Piece (matching what was deducted from the Piece row).
+        $so = new SalesOrder();
+        $so->so_number = 'SO-REG-BONGKAR-'.uniqid();
+        $so->so_customer = (int) DB::table('customers')->where('status', 1)->value('customer_id');
+        $so->so_date = now()->toDateString();
+        $so->so_total = 5 * 1000;
+        $so->so_ppn = 0;
+        $so->so_discount = 0;
+        $so->so_cost = 0;
+        $so->so_img = json_encode([]);
+        $so->so_invoice_no = 'INV-REG-BONGKAR-'.uniqid();
+        $so->status = 2;
+        $so->save();
+
+        $sod = new SalesOrderDetail();
+        $sod->so_id = $so->so_id;
+        $sod->product_variant_id = $variant->product_variant_id;
+        $sod->sod_nama = 'SO Bongkar Order Regression Product';
+        $sod->sod_variant = $variant->product_variant_name;
+        $sod->sod_sku = $variant->product_variant_sku;
+        $sod->unit_id = self::PIECE;
+        $sod->sod_harga = 1000;
+        $sod->sod_qty = 5;
+        $sod->sod_subtotal = 5 * 1000;
+        $sod->status = 1;
+        $sod->save();
+
+        // Edit up to 20 Piece. Revert puts back 5 (Piece row -> 10), still short of 20, so bongkar
+        // must break open DOS rows to cover it.
+        $newQty = 20;
+        $response = $this->post('/updateSalesOrder', [
+            'so_id' => $so->so_id,
+            'so_number' => $so->so_number,
+            'so_invoice_no' => $so->so_invoice_no,
+            'so_customer' => $so->so_customer,
+            'so_date' => now()->toDateString(),
+            'so_total' => $newQty * 1000,
+            'so_img' => json_encode([]),
+            'products' => json_encode([[
+                'sod_id' => $sod->sod_id,
+                'product_variant_id' => $variant->product_variant_id,
+                'product_name' => 'SO Bongkar Order Regression Product',
+                'pr_name' => 'SO Bongkar Order Regression Product',
+                'product_variant_name' => $variant->product_variant_name,
+                'product_variant_sku' => $variant->product_variant_sku,
+                'unit_id' => self::PIECE,
+                'product_variant_price' => 1000,
+                'so_qty' => $newQty,
+                'so_subtotal' => $newQty * 1000,
+            ]]),
+        ]);
+
+        $response->assertStatus(200);
+        $this->assertSame(
+            '1',
+            trim($response->getContent()),
+            'BUG WOULD BE: rejected as insufficient stock because bongkar never found the DOS row'
+        );
+
+        $pieceStock->refresh();
+        $dosStock->refresh();
+
+        // Revert 5 -> Piece 10. Need 20, so one DOS is broken open: DOS 4 -> 3, Piece 10 + 12 = 22.
+        // Then deduct the new 20: Piece 22 - 20 = 2.
+        $this->assertSame(3, $dosStock->ps_stock, 'exactly one DOS must be broken open, from the DOS row itself');
+        $this->assertSame(2, $pieceStock->ps_stock, 'Piece = 5 (revert) + 5 (existing) + 12 (bongkar) - 20 (new qty)');
+
+        // Total physical stock is conserved: started 4 DOS + 5 Piece = 53 Piece-equivalent,
+        // with 5 already consumed by the original SO. After editing to 20: 53 - 20 + 5 = 38.
+        $this->assertSame(
+            38,
+            ($dosStock->ps_stock * 12) + $pieceStock->ps_stock,
+            'no stock may be created or destroyed by the bongkar itself'
+        );
+    }
+}

--- a/tests/Unit/UnitRollUpTest.php
+++ b/tests/Unit/UnitRollUpTest.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Support\UnitRollUp;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Pure-logic tests for `UnitRollUp::plan()` — no DB, so this lives in tests/Unit (the chain and
+ * the allowed-unit list are both passed in explicitly, which is exactly why plan() takes them as
+ * arrays rather than querying).
+ *
+ * Ladder used throughout: 1 Sak = 2 DOS, 1 DOS = 12 Piece (so 1 Sak = 24 Piece).
+ */
+class UnitRollUpTest extends TestCase
+{
+    private const PIECE = 9;
+    private const DOS = 7;
+    private const SAK = 25;
+
+    /** @return array<int, array{small:int, big:int, ratio:int}> */
+    private function ladder(): array
+    {
+        return [
+            ['small' => self::PIECE, 'big' => self::DOS, 'ratio' => 12],
+            ['small' => self::DOS, 'big' => self::SAK, 'ratio' => 2],
+        ];
+    }
+
+    private function allUnits(): array
+    {
+        return [self::PIECE, self::DOS, self::SAK];
+    }
+
+    public function test_an_exact_multiple_rolls_all_the_way_to_the_top(): void
+    {
+        // 24 Piece = 2 DOS = 1 Sak exactly, nothing left behind at any level.
+        $plan = UnitRollUp::plan($this->ladder(), self::PIECE, 24, $this->allUnits());
+
+        $this->assertSame([
+            ['unit_id' => self::PIECE, 'qty' => 0],
+            ['unit_id' => self::DOS, 'qty' => 0],
+            ['unit_id' => self::SAK, 'qty' => 1],
+        ], $plan);
+    }
+
+    public function test_remainders_are_left_at_each_level(): void
+    {
+        // 31 Piece = 2 DOS + 7 Piece; 2 DOS = 1 Sak + 0 DOS.
+        $plan = UnitRollUp::plan($this->ladder(), self::PIECE, 31, $this->allUnits());
+
+        $this->assertSame([
+            ['unit_id' => self::PIECE, 'qty' => 7],
+            ['unit_id' => self::DOS, 'qty' => 0],
+            ['unit_id' => self::SAK, 'qty' => 1],
+        ], $plan);
+    }
+
+    public function test_a_quantity_below_the_first_ratio_stays_put(): void
+    {
+        $plan = UnitRollUp::plan($this->ladder(), self::PIECE, 11, $this->allUnits());
+
+        $this->assertSame([['unit_id' => self::PIECE, 'qty' => 11]], $plan);
+    }
+
+    public function test_rolling_can_start_partway_up_the_ladder(): void
+    {
+        // Receiving in DOS: 5 DOS = 2 Sak + 1 DOS. Piece is never involved.
+        $plan = UnitRollUp::plan($this->ladder(), self::DOS, 5, $this->allUnits());
+
+        $this->assertSame([
+            ['unit_id' => self::DOS, 'qty' => 1],
+            ['unit_id' => self::SAK, 'qty' => 2],
+        ], $plan);
+    }
+
+    public function test_rolling_stops_at_a_unit_the_caller_disallows(): void
+    {
+        // Sak has no stock row → not in the allowed list. 24 Piece becomes 2 DOS and stops there
+        // rather than silently provisioning a Sak row nobody asked for.
+        $plan = UnitRollUp::plan($this->ladder(), self::PIECE, 24, [self::PIECE, self::DOS]);
+
+        $this->assertSame([
+            ['unit_id' => self::PIECE, 'qty' => 0],
+            ['unit_id' => self::DOS, 'qty' => 2],
+        ], $plan);
+    }
+
+    public function test_a_missing_intermediate_unit_blocks_the_whole_roll_up(): void
+    {
+        // DOS row missing: Piece cannot skip straight to Sak (the ratio is defined per hop), so
+        // everything stays at Piece. Leaving it flat is the only correct outcome here.
+        $plan = UnitRollUp::plan($this->ladder(), self::PIECE, 24, [self::PIECE, self::SAK]);
+
+        $this->assertSame([['unit_id' => self::PIECE, 'qty' => 24]], $plan);
+    }
+
+    public function test_a_product_with_no_ladder_at_all_is_left_untouched(): void
+    {
+        $plan = UnitRollUp::plan([], self::PIECE, 500, [self::PIECE]);
+
+        $this->assertSame([['unit_id' => self::PIECE, 'qty' => 500]], $plan);
+    }
+
+    public function test_a_zero_or_negative_ratio_does_not_divide_by_zero(): void
+    {
+        $broken = [['small' => self::PIECE, 'big' => self::DOS, 'ratio' => 0]];
+
+        $plan = UnitRollUp::plan($broken, self::PIECE, 24, $this->allUnits());
+
+        $this->assertSame([['unit_id' => self::PIECE, 'qty' => 24]], $plan);
+    }
+
+    public function test_a_circular_chain_terminates_instead_of_looping_forever(): void
+    {
+        // Corrupt data: A -> B -> A. The 20-hop guard must stop this.
+        $circular = [
+            ['small' => self::PIECE, 'big' => self::DOS, 'ratio' => 2],
+            ['small' => self::DOS, 'big' => self::PIECE, 'ratio' => 2],
+        ];
+
+        $plan = UnitRollUp::plan($circular, self::PIECE, 1048576, $this->allUnits());
+
+        // Exactly one entry per hop, plus the final resting level — bounded, not infinite.
+        $this->assertLessThanOrEqual(21, count($plan));
+    }
+
+    public function test_the_planned_quantities_conserve_the_original_amount(): void
+    {
+        // Whatever the split, converting every planned level back down to Piece must equal the
+        // input — the property that actually matters for "no stock lost".
+        $plan = UnitRollUp::plan($this->ladder(), self::PIECE, 100, $this->allUnits());
+
+        $pieceEquivalent = [self::PIECE => 1, self::DOS => 12, self::SAK => 24];
+        $total = 0;
+        foreach ($plan as $credit) {
+            $total += $credit['qty'] * $pieceEquivalent[$credit['unit_id']];
+        }
+
+        $this->assertSame(100, $total);
+    }
+}

--- a/tests/Workflow/PurchaseOrderReceiptRollUpFlowTest.php
+++ b/tests/Workflow/PurchaseOrderReceiptRollUpFlowTest.php
@@ -1,0 +1,183 @@
+<?php
+
+namespace Tests\Workflow;
+
+use App\Models\PurchaseOrder;
+use App\Models\Supplier;
+use App\Models\Supplies;
+use App\Models\SuppliesRelation;
+use App\Models\SuppliesStock;
+use App\Models\SuppliesVariant;
+use Tests\Support\ActingAsStaff;
+use Tests\TestCase;
+
+/**
+ * Added 2026-08-25 with the unit-conversion coverage sweep.
+ *
+ * Before: `PurchaseOrderDeliveryDetail::insertPoDeliveryDetail()` — the live goods-receipt path
+ * used by `accPO()` — credited stock with a flat `$s->ss_stock += $qty` and no unit conversion at
+ * all. Receiving 24 Piece left 24 Piece sitting at the Piece level, even though 1 DOS = 12 Piece
+ * and the very same 24 Piece coming out of PRODUCTION had rolled up to 2 DOS since GitHub #19. The
+ * same physical goods were represented differently purely based on how they entered.
+ *
+ * After: receipt rolls up through the ladder via `App\Support\UnitRollUp`.
+ *
+ * The second test is the important one. Rolling up on receipt is NOT safe on its own: `tolakPO()`
+ * (rejecting an already-approved PO) used to look only at the ORDERED unit's stock row and refuse
+ * with "Stok bahan tidak mencukupi" if that one row was short. Once receipt rolls up, the received
+ * stock is no longer in the ordered unit, so rejecting any laddered PO would have failed 100% of
+ * the time. `tolakPO()` therefore now measures the whole ladder in smallest-unit-equivalent and
+ * breaks bigger units back down before deducting. These two changes must ship together.
+ */
+class PurchaseOrderReceiptRollUpFlowTest extends TestCase
+{
+    use ActingAsStaff;
+
+    private const PIECE = 9;
+    private const DOS = 7;
+
+    /** @return array{0: Supplies, 1: SuppliesVariant, 2: SuppliesStock, 3: SuppliesStock, 4: Supplier} */
+    private function createFixture(): array
+    {
+        $supplier = Supplier::where('status', 1)->whereNotNull('bank_id')->firstOrFail();
+
+        $supplies = new Supplies();
+        $supplies->supplies_name = 'PO RollUp Ingredient '.uniqid();
+        $supplies->supplies_unit = json_encode([self::PIECE, self::DOS]);
+        $supplies->supplies_default_unit = self::PIECE;
+        $supplies->status = 1;
+        $supplies->save();
+
+        $variant = new SuppliesVariant();
+        $variant->supplies_id = $supplies->supplies_id;
+        $variant->supplier_id = $supplier->supplier_id;
+        $variant->supplies_variant_name = 'PO RollUp Variant';
+        $variant->supplies_variant_sku = 'WF-POROLL-'.uniqid();
+        $variant->supplies_variant_price = 1000;
+        $variant->supplies_variant_barcode = 'WF-POROLL-BC-'.uniqid();
+        $variant->supplies_variant_stock = 0;
+        $variant->status = 1;
+        $variant->save();
+
+        $relation = new SuppliesRelation();
+        $relation->supplies_id = $supplies->supplies_id;
+        $relation->su_id_1 = self::DOS;   // bigger
+        $relation->su_id_2 = self::PIECE; // smaller
+        $relation->sr_value_1 = 1;
+        $relation->sr_value_2 = 12;       // 1 DOS = 12 Piece
+        $relation->status = 1;
+        $relation->save();
+
+        $pieceStock = new SuppliesStock();
+        $pieceStock->supplies_id = $supplies->supplies_id;
+        $pieceStock->unit_id = self::PIECE;
+        $pieceStock->warehouse_id = 1;
+        $pieceStock->ss_stock = 0;
+        $pieceStock->status = 1;
+        $pieceStock->save();
+
+        $dosStock = new SuppliesStock();
+        $dosStock->supplies_id = $supplies->supplies_id;
+        $dosStock->unit_id = self::DOS;
+        $dosStock->warehouse_id = 1;
+        $dosStock->ss_stock = 0;
+        $dosStock->status = 1;
+        $dosStock->save();
+
+        return [$supplies, $variant, $pieceStock, $dosStock, $supplier];
+    }
+
+    private function createAndApprovePo(SuppliesVariant $variant, Supplier $supplier, int $qty): int
+    {
+        $poId = (int) $this->post('/insertPurchaseOrder', [
+            'po_supplier' => $supplier->supplier_id,
+            'po_date' => now()->toDateString(),
+            'po_total' => $qty * 1000,
+            'jenis_discount' => 1,
+            'po_desc' => 'PO roll-up flow test',
+            'po_img' => json_encode([]),
+            'po_detail' => json_encode([[
+                'supplies_variant_id' => $variant->supplies_variant_id,
+                'supplies_name' => 'PO RollUp Ingredient',
+                'supplies_variant_name' => $variant->supplies_variant_name,
+                'supplies_variant_sku' => $variant->supplies_variant_sku,
+                'qty' => $qty,
+                'supplies_variant_price' => 1000,
+                'unit_id_select' => self::PIECE,
+            ]]),
+        ])->json();
+
+        $this->post('/accPO', [
+            'data' => [
+                'po_id' => $poId,
+                'po_supplier' => $supplier->supplier_id,
+                'items' => [[
+                    'supplies_variant_id' => $variant->supplies_variant_id,
+                    'unit_id' => self::PIECE,
+                    'pod_sku' => $variant->supplies_variant_sku,
+                    'pod_qty' => $qty,
+                ]],
+            ],
+        ])->assertStatus(200);
+
+        return $poId;
+    }
+
+    public function test_receiving_goods_rolls_the_quantity_up_the_unit_ladder(): void
+    {
+        $this->actingAsSuperAdminStaff();
+        [, $variant, $pieceStock, $dosStock, $supplier] = $this->createFixture();
+
+        // 26 Piece = 2 DOS + 2 Piece.
+        $this->createAndApprovePo($variant, $supplier, 26);
+
+        $pieceStock->refresh();
+        $dosStock->refresh();
+
+        $this->assertSame(2, $dosStock->ss_stock, 'received qty must roll up into whole DOS');
+        $this->assertSame(2, $pieceStock->ss_stock, 'the remainder stays at the Piece level');
+
+        // Conservation: nothing invented, nothing lost.
+        $this->assertSame(
+            26,
+            ($dosStock->ss_stock * 12) + $pieceStock->ss_stock,
+            'total Piece-equivalent must equal exactly what was received'
+        );
+    }
+
+    public function test_an_approved_po_can_still_be_rejected_after_its_receipt_rolled_up(): void
+    {
+        $this->actingAsSuperAdminStaff();
+        [, $variant, $pieceStock, $dosStock, $supplier] = $this->createFixture();
+
+        // 24 Piece rolls up to exactly 2 DOS, leaving ZERO at the ordered (Piece) unit — the case
+        // that would have made the old tolakPO() refuse outright.
+        $poId = $this->createAndApprovePo($variant, $supplier, 24);
+
+        $pieceStock->refresh();
+        $dosStock->refresh();
+        $this->assertSame(2, $dosStock->ss_stock);
+        $this->assertSame(0, $pieceStock->ss_stock, 'precondition: nothing left at the ordered unit');
+
+        $response = $this->post('/tolakPO', ['po_id' => $poId]);
+        $response->assertStatus(200);
+        $this->assertStringNotContainsString(
+            'tidak mencukupi',
+            $response->getContent(),
+            'BUG WOULD BE: rejection refused because the ordered unit reads 0 after the roll-up'
+        );
+
+        $pieceStock->refresh();
+        $dosStock->refresh();
+
+        // Everything received is fully backed out: one DOS is broken open to cover the 24 Piece.
+        $this->assertSame(
+            0,
+            ($dosStock->ss_stock * 12) + $pieceStock->ss_stock,
+            'rejecting the PO must remove exactly what it added, across the whole ladder'
+        );
+
+        $po = PurchaseOrder::find($poId);
+        $this->assertSame(-1, (int) $po->status, 'the PO ends up rejected');
+    }
+}

--- a/tests/Workflow/SalesOrderUpdateRollUpFlowTest.php
+++ b/tests/Workflow/SalesOrderUpdateRollUpFlowTest.php
@@ -1,0 +1,201 @@
+<?php
+
+namespace Tests\Workflow;
+
+use App\Models\Category;
+use App\Models\Product;
+use App\Models\ProductRelation;
+use App\Models\ProductStock;
+use App\Models\ProductVariant;
+use App\Models\SalesOrder;
+use App\Models\SalesOrderDetail;
+use Illuminate\Support\Facades\DB;
+use Tests\Support\ActingAsStaff;
+use Tests\TestCase;
+
+/**
+ * Added 2026-08-25 with the unit-conversion coverage sweep.
+ *
+ * `updateSalesOrder()`'s TAHAP 1 gives back the stock of the SO's CURRENT lines before TAHAP 4
+ * deducts the new ones. Whether that give-back should roll up the unit ladder depends entirely on
+ * whether the line survives the edit:
+ *
+ * - Line still on the SO → TAHAP 4 deducts it again in the same request, and TAHAP 3's bongkar
+ *   would immediately break any roll-up back down. Rolling up there is pure churn plus a pair of
+ *   contradictory conversion log rows written a second apart, so it is deliberately NOT done.
+ * - Line REMOVED from the SO → nothing deducts it again. The give-back is the final state, exactly
+ *   like any other stock restore, so it rolls up — consistent with PO receipt
+ *   (`insertPoDeliveryDetail`) and supplier-return cancellation (`deleteProductIssuesDetail`).
+ *
+ * Both halves are asserted here so the distinction can't be "simplified" away later without a
+ * failing test explaining why it exists.
+ */
+class SalesOrderUpdateRollUpFlowTest extends TestCase
+{
+    use ActingAsStaff;
+
+    private const PIECE = 9;
+    private const DOS = 7;
+
+    /** @return array{0: ProductStock, 1: ProductStock, 2: ProductVariant} */
+    private function createFixture(int $pieceStart, int $dosStart): array
+    {
+        $category = new Category();
+        $category->category_name = 'SO RollUp Category';
+        $category->status = 1;
+        $category->save();
+
+        $product = new Product();
+        $product->product_name = 'SO RollUp Product '.uniqid();
+        $product->category_id = $category->category_id;
+        $product->product_unit = json_encode([self::PIECE, self::DOS]);
+        $product->unit_id = self::PIECE;
+        $product->status = 1;
+        $product->save();
+
+        $variant = new ProductVariant();
+        $variant->product_id = $product->product_id;
+        $variant->product_variant_name = 'SO RollUp Variant';
+        $variant->product_variant_sku = 'WF-SOROLL-'.uniqid();
+        $variant->product_variant_price = 1000;
+        $variant->status = 1;
+        $variant->save();
+
+        $relation = new ProductRelation();
+        $relation->product_variant_id = $variant->product_variant_id;
+        $relation->pr_unit_id_1 = self::DOS;
+        $relation->pr_unit_id_2 = self::PIECE;
+        $relation->pr_unit_value_1 = 1;
+        $relation->pr_unit_value_2 = 12; // 1 DOS = 12 Piece
+        $relation->pr_default = 0;
+        $relation->status = 1;
+        $relation->save();
+
+        $pieceStock = new ProductStock();
+        $pieceStock->product_id = $product->product_id;
+        $pieceStock->product_variant_id = $variant->product_variant_id;
+        $pieceStock->unit_id = self::PIECE;
+        $pieceStock->warehouse_id = 1;
+        $pieceStock->ps_stock = $pieceStart;
+        $pieceStock->status = 1;
+        $pieceStock->save();
+
+        $dosStock = new ProductStock();
+        $dosStock->product_id = $product->product_id;
+        $dosStock->product_variant_id = $variant->product_variant_id;
+        $dosStock->unit_id = self::DOS;
+        $dosStock->warehouse_id = 1;
+        $dosStock->ps_stock = $dosStart;
+        $dosStock->status = 1;
+        $dosStock->save();
+
+        return [$pieceStock, $dosStock, $variant];
+    }
+
+    private function createApprovedSo(ProductVariant $variant, int $qty): SalesOrder
+    {
+        $so = new SalesOrder();
+        $so->so_number = 'SO-WFROLL-'.uniqid();
+        $so->so_customer = (int) DB::table('customers')->where('status', 1)->value('customer_id');
+        $so->so_date = now()->toDateString();
+        $so->so_total = $qty * 1000;
+        $so->so_ppn = 0;
+        $so->so_discount = 0;
+        $so->so_cost = 0;
+        $so->so_img = json_encode([]);
+        $so->so_invoice_no = 'INV-WFROLL-'.uniqid();
+        $so->status = 2;
+        $so->save();
+
+        $sod = new SalesOrderDetail();
+        $sod->so_id = $so->so_id;
+        $sod->product_variant_id = $variant->product_variant_id;
+        $sod->sod_nama = 'SO RollUp Product';
+        $sod->sod_variant = $variant->product_variant_name;
+        $sod->sod_sku = $variant->product_variant_sku;
+        $sod->unit_id = self::PIECE;
+        $sod->sod_harga = 1000;
+        $sod->sod_qty = $qty;
+        $sod->sod_subtotal = $qty * 1000;
+        $sod->status = 1;
+        $sod->save();
+
+        return $so;
+    }
+
+    public function test_removing_a_line_rolls_its_returned_stock_up_the_ladder(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        // Start with 0 Piece / 0 DOS on hand; the SO has consumed 24 Piece.
+        [$pieceStock, $dosStock, $variant] = $this->createFixture(0, 0);
+        $so = $this->createApprovedSo($variant, 24);
+
+        // Edit the SO down to an empty product list — the line is removed entirely.
+        $response = $this->post('/updateSalesOrder', [
+            'so_id' => $so->so_id,
+            'so_number' => $so->so_number,
+            'so_invoice_no' => $so->so_invoice_no,
+            'so_customer' => $so->so_customer,
+            'so_date' => now()->toDateString(),
+            'so_total' => 0,
+            'so_img' => json_encode([]),
+            'products' => json_encode([]),
+        ]);
+        $response->assertStatus(200);
+
+        $pieceStock->refresh();
+        $dosStock->refresh();
+
+        // 24 returned Piece = exactly 2 DOS, nothing left at the Piece level.
+        $this->assertSame(2, $dosStock->ps_stock, 'the returned qty must roll up into whole DOS');
+        $this->assertSame(0, $pieceStock->ps_stock, 'no remainder at the Piece level');
+        $this->assertSame(
+            24,
+            ($dosStock->ps_stock * 12) + $pieceStock->ps_stock,
+            'nothing may be created or lost by the roll-up'
+        );
+    }
+
+    public function test_a_line_that_survives_the_edit_is_not_rolled_up_and_back_down(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        // 0 Piece / 3 DOS on hand; SO consumed 24 Piece.
+        [$pieceStock, $dosStock, $variant] = $this->createFixture(0, 3);
+        $so = $this->createApprovedSo($variant, 24);
+        $sodId = SalesOrderDetail::where('so_id', $so->so_id)->value('sod_id');
+
+        // Same line kept, quantity reduced to 6 Piece.
+        $response = $this->post('/updateSalesOrder', [
+            'so_id' => $so->so_id,
+            'so_number' => $so->so_number,
+            'so_invoice_no' => $so->so_invoice_no,
+            'so_customer' => $so->so_customer,
+            'so_date' => now()->toDateString(),
+            'so_total' => 6 * 1000,
+            'so_img' => json_encode([]),
+            'products' => json_encode([[
+                'sod_id' => $sodId,
+                'product_variant_id' => $variant->product_variant_id,
+                'product_name' => 'SO RollUp Product',
+                'pr_name' => 'SO RollUp Product',
+                'product_variant_name' => $variant->product_variant_name,
+                'product_variant_sku' => $variant->product_variant_sku,
+                'unit_id' => self::PIECE,
+                'product_variant_price' => 1000,
+                'so_qty' => 6,
+                'so_subtotal' => 6 * 1000,
+            ]]),
+        ]);
+        $response->assertStatus(200);
+
+        $pieceStock->refresh();
+        $dosStock->refresh();
+
+        // Revert 24 Piece (0 -> 24), deduct the new 6 -> 18 Piece. DOS untouched at 3: the
+        // surviving line was NOT rolled up, so no DOS was created and none broken back down.
+        $this->assertSame(3, $dosStock->ps_stock, 'a surviving line must not churn the DOS level');
+        $this->assertSame(18, $pieceStock->ps_stock, '24 returned minus the new 6 stays at Piece');
+    }
+}


### PR DESCRIPTION
> **Catatan:** PR #74 (atomicity transaksi) sudah ter-merge, dan PR ini sudah di-rebase ke `main` di atasnya — jadi ini berdiri sendiri, tidak perlu menunggu apa pun lagi.

## Ringkasan

Menjawab pertanyaan: **"apakah ada mutasi stok yang tidak memicu konversi satuan berjenjang?"**

Ditelusuri SEMUA lokasi penulisan `ps_stock`/`ss_stock`, lalu dicek satu per satu apakah konversi satuannya jalan. Hasilnya: dua arah konversi kondisinya jauh berbeda.

---

## Arah 1 — Bongkar (satuan besar → kecil), saat stok KELUAR

Sudah tertangani di hampir semua tempat (bahan produksi, `stockCheck()`, `deleteProductIssue()`) — semuanya mencari satuan atas lewat **lookup relasi**.

**Kecuali satu: `CustomerController::updateSalesOrder()`.**

Ini instance **KETIGA** dari bug yang sudah pernah diperbaiki dua kali:
- 2026-08-05 di `ProductIssuesDetail::stockCheck()` (dua closure-nya)
- 2026-08-06 di `StockController::deleteProductIssue()` — versi yang sudah benar bahkan diberi komentar *"cari unit atas via relasi, tidak bergantung index"*

Sales Order kelewatan di dua sapuan itu, dan masih memakai:

```php
$stokAtas = $units[$targetKey + 1];   // koleksi diurutkan ps_id DESC
```

`ps_id` itu urutan pembuatan baris stok — **tidak ada hubungannya** dengan urutan hierarki satuan.

**Yang membuat versi ini lebih parah dari dua sebelumnya:** kodenya SUDAH meng-query relasi yang benar (`$sr`), tapi hasilnya (`$sr->pr_unit_id_1`) **tidak pernah dipakai** untuk menentukan baris mana yang dipotong. Jadi kalau urutan `ps_id` kebetulan tidak sama dengan urutan ladder, sistem memotong stok dari **satuan yang SALAH** dengan **rasio milik satuan lain** — korupsi stok di dua baris sekaligus, bukan sekadar gagal.

Sekarang polanya disamakan: cari relasi dulu, baru cari index baris stok yang `unit_id`-nya cocok dengan `pr_unit_id_1`, plus depth guard 20 hop.

---

## Arah 2 — Naik satuan / roll-up (satuan kecil → besar), saat stok MASUK

Ternyata cuma ada di **SATU tempat**: crediting hasil produksi di `accProduction()` (dari GitHub #19). Semua jalur stok-masuk lain flat `+=` tanpa konversi sama sekali.

Akibatnya: **24 Piece yang DIBELI tetap jadi 24 Piece, tapi 24 Piece hasil PRODUKSI naik jadi 2 DOS.** Barang fisik yang sama, representasinya beda tergantung cara masuknya.

### Helper baru: `app/Support/UnitRollUp`

Planner murni (tanpa efek samping DB) yang mengembalikan daftar terurut `{unit_id, qty}`, dijaga maksimal 20 hop.

Keputusan desain penting: **hanya menaikkan ke satuan yang SUDAH punya baris stok aktif.** Jadi roll-up tidak pernah diam-diam membuat baris stok baru yang tidak diminta siapa pun. Kalau satuan berikutnya belum punya baris, proses berhenti dan sisanya tetap di level bawahnya — kondisi yang selalu valid.

Bongkar **sengaja TIDAK dimasukkan** ke class ini: arah itu sifatnya *need-driven* (cuma bermakna terhadap target qty tertentu), jadi tetap di masing-masing lokasi konsumsi.

### Roll-up ditambahkan ke:

| Lokasi | Keterangan |
|---|---|
| `PurchaseOrderDeliveryDetail::insertPoDeliveryDetail()` | Penerimaan barang PO |
| `ProductIssuesDetail::deleteProductIssuesDetail()` | Pembatalan retur / pengembalian stok |
| `CustomerController::updateSalesOrder()` TAHAP 1 | **Hanya untuk baris yang DIHAPUS dari SO** |

**Kenapa TAHAP 1 dibedakan:** baris yang masih ada di SO akan langsung dipotong lagi oleh TAHAP 4 di request yang sama. Menaikkan satuannya di situ cuma churn — naik satuan lalu langsung dibongkar lagi oleh TAHAP 3, plus sepasang log konversi yang saling bertentangan berjarak sedetik. Baris yang dihapus tidak punya pasangan pemotongan, jadi revert-nya kondisi akhir dan memang perlu naik satuan.

Kedua sisi ini di-assert di test supaya pembedaannya tidak "dirapikan" orang lain nanti tanpa sadar.

---

## ⚠️ Perubahan wajib yang menyertai: `tolakPO()`

**Roll-up di penerimaan PO TIDAK aman kalau berdiri sendiri.**

`tolakPO()` (membatalkan PO yang sudah di-ACC) dulu hanya mengecek dan memotong baris stok di **satuan yang dipesan**. Begitu penerimaan menaikkan satuan, baris itu bisa terbaca 0 — sehingga **setiap pembatalan PO untuk bahan yang punya ladder akan SELALU gagal** dengan "Stok bahan tidak mencukupi".

Jadi `tolakPO()` sekarang:
- `suppliesLadderHasEnough()` — mengukur total stok seluruh ladder dalam satuan-terkecil-setara
- `bongkarSuppliesUntilEnough()` — membongkar satuan besar turun dulu sebelum memotong (mencari satuan atas lewat relasi, bukan posisi array)

**Kedua sisi diverifikasi terpisah** dengan me-revert satu per satu:

| Yang di-revert | Hasil |
|---|---|
| Hanya fix `tolakPO` (roll-up tetap aktif) | ❌ `{"status":-1,"message":"Stok bahan tidak mencukupi..."}` — regresi terbukti nyata |
| Hanya roll-up | ❌ `0` DOS (harusnya `2`) — roll-up terbukti bekerja |

---

## Perilaku yang SENGAJA dipertahankan

Di kedua lokasi roll-up, baris stok untuk **satuan asal** tetap di-lookup **tanpa null-guard**, persis seperti sebelumnya. Kalau `unit_id`-nya salah, harus tetap meledak (dan sekarang ikut rollback berkat PR #74) — **bukan** di-skip diam-diam.

Draft awal saya sempat memberi guard `continue` di situ, yang mengubah "barang diterima" jadi "stok tidak pernah bertambah, tanpa error sama sekali" — antipattern gagal-senyap yang persis sudah pernah diperbaiki di `accProduction()`. Ketahuan karena `PurchaseOrderApprovalAtomicityTest` berubah dari 500 jadi 200, lalu dikembalikan.

---

## Yang TIDAK diubah

- **Aksi APPROVE Stock Opname** (`accStockOpname`/`accStockOpnameBahan`) menulis angka absolut per satuan, jadi konversi satuan tidak berlaku di langkah itu.

  ⚠️ **Klarifikasi (kalimat ini sebelumnya ambigu):** ini BUKAN berarti dokumen opname kebal terhadap pergerakan stok. Dokumen yang masih draft/menunggu TETAP ikut berubah — `stod_system` dan `stod_selisih` dihitung ulang dari stok live setiap kali PDF-nya di-download (dan sejak PR #73 juga ikut disimpan ke DB). Yang dibekukan hanya `stod_real`, yaitu hasil hitung fisik staf. Lihat bagian di bawah.

- **`ProductionPendingStockRestorer`** sudah benar: ia membalik stok dengan me-replay entri `log_stocks` termasuk baris konversinya. Ini justru satu-satunya komponen yang sudah memakai pendekatan "pakai riwayat perubahan stok" yang sempat Anda singgung.

---

## Tambahan: gerbang "opname basi" + runbook rollback roll-up

Menelusuri skenario konkret dari review (stok 12 DOS + 10 PCS → opname dihitung 11 DOS + 6 PCS, masih menunggu → lalu masuk +20 PCS), diukur langsung hasilnya:

| | DOS | PCS | setara PCS |
|---|---|---|---|
| Stok awal | 12 | 10 | 154 |
| Hasil hitung staf (`stod_real`, dibekukan) | 11 | 6 | 138 |
| Stok setelah +20 PCS (roll-up) | 13 | 18 | 174 |
| `stod_system` setelah PDF di-download | 13 | 18 | 174 |
| `stod_selisih` setelah PDF di-download | −2 | −12 | −36 |

Jadi refresh-nya bekerja benar. **Tapi ini membuka masalah lain:** approve dokumen itu menimpa stok dengan hasil hitung lama (11 DOS / 6 PCS), sehingga **20 PCS yang sah masuk setelah penghitungan hilang diam-diam**. Refresh live cuma membuatnya kelihatan (selisih membengkak dari −16 ke −36), tidak mencegahnya.

**Perbaikan:** `accStockOpname()`/`accStockOpnameBahan()` sekarang membalas `{status: -3}` dengan menyebut item yang stoknya bergerak, dan baru lanjut kalau dikirim ulang dengan `confirm_stale=1` — pola konfirmasi yang sama dengan `confirm_create_stock` di `accProduction()`. Opname yang tidak ada pergerakan sama sekali tetap approve **satu langkah** seperti sebelumnya (di-assert eksplisit).

Deteksinya sengaja memakai `log_stocks`, bukan membandingkan `stod_system` dengan stok live — karena `stod_system` ikut ter-refresh setiap PDF di-download, jadi perbandingan itu bisa "sembuh sendiri" hanya gara-gara dokumennya dibuka, padahal hitungan fisiknya tetap basi.

**Runbook rollback roll-up global** (permintaan PM): ditulis sebagai block comment besar di atas `app/Support/UnitRollUp.php` (ikut ter-commit, karena `cdocs/` masuk gitignore) + di memory project. Isinya: 4 lokasi yang harus dibalikkan, penegasan bahwa `tolakPO()` WAJIB dibalikkan berpasangan dengan penerimaan PO, daftar hal yang JANGAN ikut dibalikkan, dan catatan risikonya (roll-up mengubah pembagian satuan tanpa tindakan fisik → gudang yang membiarkan barang lepasan akan terus melihat selisih DOS/PCS palsu di setiap opname).

---

## Testing

**Test baru:**
- `tests/Unit/UnitRollUpTest.php` — 10 test: sisa pembagian per level, satuan perantara yang tidak punya baris stok, rasio 0/negatif, rantai relasi sirkular, dan **property test konservasi** (total setara-satuan-terkecil harus selalu sama dengan input).
- `tests/Regression/SalesOrderUpdateBongkarFailsOnStockRowInsertionOrderTest.php` — mengikuti penamaan dua test bug sejenis yang sudah ada.
- `tests/Workflow/PurchaseOrderReceiptRollUpFlowTest.php` — 2 test, termasuk kopling `tolakPO`.
- `tests/Workflow/SalesOrderUpdateRollUpFlowTest.php` — 2 test: baris dihapus (naik satuan) DAN baris bertahan (tidak boleh churn).
- `tests/Workflow/StockOpnameStaleCountGuardTest.php` — 3 test: diblokir untuk konfirmasi, konfirmasi tetap menimpa, dan opname tanpa pergerakan tetap approve satu langkah.

Semua test baru diverifikasi benar-benar menangkap bug-nya dengan me-revert fix-nya lalu memastikan test GAGAL.

**Perbandingan dengan branch induk (#74), dijalankan di direktori yang sama:**

| Suite | Induk (#74) | Branch ini |
|---|---|---|
| Unit | 1 test | **11 test, OK** |
| DatabaseTransaction | 18 test, OK | **18 test, OK** |
| Regression | 74 test, 1 failure | 75 test, 1 failure |
| Workflow | 107 test, 1 error, 12 failure | 114 test, 1 error, 12 failure |
| Smoke | 120 test, 12 failure | **identik** |

**Nol regresi baru** — failure yang tersisa semuanya pre-existing (drift data multi-gudang di DB testing lokal).
