### PR TITLE
chore: koleksi REST Client (.http) untuk External API v1

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -82,5 +82,6 @@ PMO_API_KEY=
 # mis. hasil `php artisan tinker >>> Str::random(40)`) sebelum dipakai di
 # production. Kosongkan/hapus baris ini dan endpoint akan menolak semua request.
 # Lihat cdocs/docs/deploy-shared-hosting.md.
-DEPLOY_TOKEN="Str::random(40)"
 DEPLOY_TOKEN=Y4g6xvuzYqMegKfrEIitJtpZgqJVs0KfTg9zCtvV
+
+EXTERNAL_API_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -44,8 +44,7 @@ routes.zip
 vendor.zip
 routes.zip
 vendor.zip
-/postman
-/.postman
+
 /cdocs
 /docs/sop-*.md
 

--- a/http/.env.example
+++ b/http/.env.example
@@ -1,0 +1,3 @@
+# Copy this file to http/.env (already gitignored) and fill in a real key.
+# Get a key from Backoffice > Aplikasi Eksternal > detail app > tambah kunci.
+EXTERNAL_API_KEY=ext_test_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx

--- a/http/README.md
+++ b/http/README.md
@@ -1,0 +1,49 @@
+# Calling the API from VS Code (no Postman)
+
+This is the extension the "call REST directly from VS Code" demos use:
+**REST Client** by Huawei (`humao.rest-client`). It reads plain-text
+`.http` files committed to the repo and puts a clickable "Send Request"
+link above every request — everything stays local and in git, no account,
+no cloud sync, no external service in the middle.
+
+## Setup
+
+1. Install the extension:
+   ```
+   code --install-extension humao.rest-client
+   ```
+2. Copy the key template and fill in a real key:
+   ```
+   cp http/.env.example http/.env
+   ```
+   Get a key from Backoffice > Aplikasi Eksternal > (pick an app) > tambah
+   kunci. `http/.env` matches the repo's root `.env` gitignore pattern, so
+   it never gets committed.
+3. Open [external-api-v1.http](external-api-v1.http), click "Send Request"
+   above any request. Response shows in a split pane (status, headers,
+   timing, formatted JSON body).
+
+If your local host isn't `pegasus.test`, edit `@baseUrl` at the top of the
+`.http` file.
+
+## Adding more requests
+
+- Separate requests with a line of `###`.
+- Reuse `{{baseUrl}}` / `{{apiKey}}` (defined at the top of the file) —
+  don't hardcode the host or key again.
+- To chain requests (e.g. use one response's value in the next call), name
+  a request with `# @name someName` above it and reference
+  `{{someName.response.body.$.data.id}}` later in the file.
+
+## Where the endpoint contracts live
+
+This file is for manual testing, not documentation — field names, error
+codes, and business rules for each endpoint are documented in:
+- `cdocs/integrations/202607282149-external-api-v1/` (specs/design docs)
+- `config('externalapi.docs')` (source of truth also rendered as the
+  in-app API docs pages)
+- The controller docblocks under `app/Http/Controllers/ExternalApi/V1/`
+
+For automated coverage, see the PHPUnit tests under `tests/` instead (see
+the `pegasus-testing` skill) — this collection is for poking at the API by
+hand.

--- a/http/README.md
+++ b/http/README.md
@@ -35,13 +35,20 @@ If your local host isn't `pegasus.test`, edit `@baseUrl` at the top of the
   a request with `# @name someName` above it and reference
   `{{someName.response.body.$.data.id}}` later in the file.
 
-## Where the endpoint contracts live
+## Where the examples come from
 
-This file is for manual testing, not documentation — field names, error
-codes, and business rules for each endpoint are documented in:
+Every request body in `external-api-v1.http` is copied from that
+endpoint's own `requestExample()` in its doc class under
+`app/ExternalApi/Docs/Endpoints/V1/` — the same example shown on the
+in-app API Documentation page, not invented separately. If a doc class's
+example changes, re-sync the matching request here rather than guessing.
+
+For full field-by-field docs (types, required/optional, error codes,
+notes) see:
+- The in-app API Documentation page itself, or `config('externalapi.docs')`
+  (registers which doc class backs which endpoint)
+- `app/ExternalApi/Docs/Endpoints/V1/` (one class per endpoint)
 - `cdocs/integrations/202607282149-external-api-v1/` (specs/design docs)
-- `config('externalapi.docs')` (source of truth also rendered as the
-  in-app API docs pages)
 - The controller docblocks under `app/Http/Controllers/ExternalApi/V1/`
 
 For automated coverage, see the PHPUnit tests under `tests/` instead (see

--- a/http/external-api-v1.http
+++ b/http/external-api-v1.http
@@ -11,11 +11,16 @@
 #      with a real key (Backoffice > Aplikasi Eksternal > tambah kunci).
 #      http/.env is gitignored (matches the root ".env" pattern) — never
 #      commit a real key.
-#   3. Adjust @baseUrl below if your local host differs from pegasus.test.
+#   3. Adjust @baseUrl below if it doesn't match the environment you're
+#      pointing at.
 #
-# See http/README.md for more detail. Full endpoint contracts (fields,
-# error codes) live in cdocs/integrations/202607282149-external-api-v1/
-# and config('externalapi.docs').
+# Every request body below is copied from that endpoint's own
+# requestExample()/responseExample() in app/ExternalApi/Docs/Endpoints/V1/
+# — the exact same examples shown on the in-app API Documentation page —
+# not invented separately. If a doc class changes, re-sync this file from
+# it rather than guessing. Full field-by-field docs (types, required/
+# optional, error codes, notes) live there and in
+# cdocs/integrations/202607282149-external-api-v1/.
 
 @baseUrl = https://pegasus.okejob.id/api/external/v1
 @apiKey = {{$dotenv EXTERNAL_API_KEY}}
@@ -26,20 +31,32 @@
 ##############################################################################
 
 ### List units
+# Query params (all optional): page, per_page (default 20, max 100),
+# sort ("kunci:arah" comma-separated — id, ref_unit_id, unit_name,
+# unit_short_name, created_at, updated_at), search (matches unit_name OR
+# unit_short_name). Same shape on every "list" endpoint in this file.
 GET {{baseUrl}}/master/units
 X-API-Key: {{apiKey}}
 
-### Create unit (ref_unit_id = id satuan di sistem PMO)
+### List units — paginated/sorted/searched example
+# Same page/per_page/sort/search pattern works on every list endpoint below;
+# not repeated for each one after this.
+GET {{baseUrl}}/master/units?page=1&per_page=20&sort=unit_name:asc&search=kg
+X-API-Key: {{apiKey}}
+
+### Create unit (ref_unit_id = id satuan di sistem PMO; not upsert — rejects an already-used ref_unit_id)
 POST {{baseUrl}}/master/units
 X-API-Key: {{apiKey}}
 Content-Type: application/json
 
 {
-  "ref_unit_id": 1001
+  "ref_unit_id": 1042,
+  "unit_name": "Kilogram",
+  "unit_short_name": "kg"
 }
 
-### Update unit profile (path param = ref_unit_id, PMO's id — not Pegasus unit_id)
-PUT {{baseUrl}}/master/units/1001
+### Update unit profile (path param = ref_unit_id, PMO's id — not Pegasus unit_id; full replace, both fields required)
+PUT {{baseUrl}}/master/units/1042
 X-API-Key: {{apiKey}}
 Content-Type: application/json
 
@@ -48,18 +65,19 @@ Content-Type: application/json
   "unit_short_name": "kg"
 }
 
-### Delete unit
-DELETE {{baseUrl}}/master/units/1001
+### Delete unit (soft delete; ref_unit_id stays attached to the old row, can't be reused via POST)
+DELETE {{baseUrl}}/master/units/1042
 X-API-Key: {{apiKey}}
 
-### Connect existing units in bulk (id = Pegasus internal unit_id)
+### Connect existing units in bulk (connections[].id = Pegasus internal unit_id, NOT ref_unit_id — see GET /master/units)
 PATCH {{baseUrl}}/master/units/connect
 X-API-Key: {{apiKey}}
 Content-Type: application/json
 
 {
   "connections": [
-    { "id": 7, "ref_unit_id": 1001 }
+    { "id": 1, "ref_unit_id": 1042 },
+    { "id": 2, "ref_unit_id": 1043 }
   ]
 }
 
@@ -76,35 +94,39 @@ X-API-Key: {{apiKey}}
 GET {{baseUrl}}/master/warehouses
 X-API-Key: {{apiKey}}
 
-### Create warehouse (tipe_id upserts warehouse_types — see controller notes)
+### Create warehouse (tipe_id/tipe_nama upsert warehouse_types — renames the type for EVERY warehouse using that tipe_id, not just this one)
 POST {{baseUrl}}/master/warehouses
 X-API-Key: {{apiKey}}
 Content-Type: application/json
 
 {
-  "nama": "Gudang Pusat",
+  "nama": "Gudang Surabaya Pusat",
   "tipe_nama": "Gudang Utama",
   "tipe_id": 1,
-  "alamat": "Jl. Contoh No. 1, Jakarta"
+  "alamat": "Jl. Raya Darmo No. 25, Surabaya"
 }
 
-### Update warehouse (path param = gudang_id, Pegasus internal id)
-PUT {{baseUrl}}/master/warehouses/1
+### Update warehouse (path param = gudang_id, Pegasus internal id; full replace, all 4 fields required)
+PUT {{baseUrl}}/master/warehouses/101
 X-API-Key: {{apiKey}}
 Content-Type: application/json
 
 {
-  "nama": "Gudang Pusat (Renov)",
+  "nama": "Gudang Surabaya Pusat",
   "tipe_nama": "Gudang Utama",
   "tipe_id": 1,
-  "alamat": "Jl. Contoh No. 1, Jakarta"
+  "alamat": "Jl. Raya Darmo No. 25, Surabaya"
 }
 
-### Delete warehouse
-DELETE {{baseUrl}}/master/warehouses/1
+### Delete warehouse (rejected with WAREHOUSE_HAS_STOCK if it still holds stock, unless force=1)
+DELETE {{baseUrl}}/master/warehouses/101
 X-API-Key: {{apiKey}}
 
-### Warehouse types (read-only)
+### Delete warehouse — force past existing stock
+DELETE {{baseUrl}}/master/warehouses/101?force=1
+X-API-Key: {{apiKey}}
+
+### Warehouse types (read-only, standalone export — not meant to be matched to warehouses' tipe_id)
 GET {{baseUrl}}/master/warehouse_types
 X-API-Key: {{apiKey}}
 
@@ -117,39 +139,44 @@ X-API-Key: {{apiKey}}
 GET {{baseUrl}}/master/sales
 X-API-Key: {{apiKey}}
 
-### Create sales (staff_id = Pegasus internal staff to expose externally)
+### Create sales (staff_id = caller's own id, NOT a Pegasus id; not upsert — rejects an already-used staff_id)
 POST {{baseUrl}}/master/sales
 X-API-Key: {{apiKey}}
 Content-Type: application/json
 
 {
-  "staff_id": 3
+  "staff_id": 2,
+  "nama_depan": "Willian",
+  "nama_belakang": "Hartanto",
+  "email": "wilha.h@gmail.com",
+  "alamat": "Jl. Sudirman Block A No. 12"
 }
 
-### Update sales profile (path param = staff_id, i.e. external_ref_id)
-PUT {{baseUrl}}/master/sales/3
+### Update sales profile (path param = staff_id, i.e. caller's own external_ref_id; full replace — only nama_depan required)
+PUT {{baseUrl}}/master/sales/2
 X-API-Key: {{apiKey}}
 Content-Type: application/json
 
 {
-  "nama_depan": "Budi",
-  "nama_belakang": "Santoso",
-  "email": "budi@example.com",
-  "alamat": "Jl. Sales No. 2"
+  "nama_depan": "Willian",
+  "nama_belakang": "Hartanto",
+  "email": "wilha.h@gmail.com",
+  "alamat": "Jl. Sudirman Block A No. 12"
 }
 
-### Delete sales
-DELETE {{baseUrl}}/master/sales/3
+### Delete sales (soft delete; only ever touches staff with the Sales role)
+DELETE {{baseUrl}}/master/sales/2
 X-API-Key: {{apiKey}}
 
-### Connect existing sales in bulk
+### Connect existing sales in bulk (connections[].staff_id = Pegasus internal staff id, map_staff_id = caller's own id — opposite direction from PUT/DELETE above)
 PATCH {{baseUrl}}/master/sales/connect
 X-API-Key: {{apiKey}}
 Content-Type: application/json
 
 {
   "connections": [
-    { "staff_id": 3, "map_staff_id": "SALES-003" }
+    { "staff_id": 20, "map_staff_id": "SLS-002" },
+    { "staff_id": 21, "map_staff_id": "SLS-003" }
   ]
 }
 
@@ -158,68 +185,73 @@ Content-Type: application/json
 # Pembayaran Kas                                                   API-005
 ##############################################################################
 
-### Create cash payment (idempotent by ref_payment_id; payment_type 1=armada, 2=sales)
+### Create cash payment (idempotent by ref_payment_id; payment_type 1=Armada [armada_id required], 2=Sales [staff_id required]; every item must share the same type)
 POST {{baseUrl}}/payments/cash
 X-API-Key: {{apiKey}}
 Content-Type: application/json
 
 {
-  "ref_payment_id": "PAY-0001",
-  "payment_type": 2,
-  "staff_id": 3,
-  "payment_date": "2026-08-25",
+  "ref_payment_id": "PMO-2026-000123",
+  "payment_type": 1,
+  "armada_id": 4,
+  "payment_date": "2026-07-29",
   "payment_amount": 150000,
+  "auto_accept": false,
   "items": [
-    { "amount": 150000, "notes": "Uang jalan", "type": 1 }
+    { "amount": 100000, "type": 2, "notes": "BBM" },
+    { "amount": 50000, "type": 2, "notes": "Uang makan" }
   ]
 }
 
-### Show cash payment by ref_payment_id
-GET {{baseUrl}}/payments/cash/PAY-0001
+### Show cash payment by ref_payment_id (status: pending/accepted/declined/deleted)
+GET {{baseUrl}}/payments/cash/PMO-2026-000123
 X-API-Key: {{apiKey}}
 
 
 ##############################################################################
 # Data Armada
 ##############################################################################
+# "Armada" rows live in the customers table (code = customers.customer_code)
+# — no separate armada table, and no /connect endpoint (every customer
+# always already has a customer_code).
 
 ### List armada
 GET {{baseUrl}}/armada
 X-API-Key: {{apiKey}}
 
-### Create armada (code is the caller-supplied universal id)
+### Create armada (code is the caller-supplied universal id, max 10 chars; not upsert — rejects an already-used code)
 POST {{baseUrl}}/armada
 X-API-Key: {{apiKey}}
 Content-Type: application/json
 
 {
-  "code": "ARM001",
+  "code": "ARM-JKT-001",
   "pic": "Agus",
-  "pic_phone": "081200000000",
-  "nomor_polisi": "B 1234 XYZ",
-  "category": "Truk",
-  "merk_model": "Isuzu Elf",
-  "tahun_kendaraan": "2020",
-  "lokasi": "Jakarta"
+  "pic_phone": "08123456789",
+  "nomor_polisi": "W 9518 PG",
+  "category": "Truk Engkel",
+  "merk_model": "Mitsubishi Colt Diesel",
+  "tahun_kendaraan": "2019",
+  "lokasi": "Pool Surabaya"
 }
 
-### Update armada (path param = code)
-PUT {{baseUrl}}/armada/ARM001
+### Update armada (path param = code; full replace — fields left out are saved EMPTY, not left unchanged)
+PUT {{baseUrl}}/armada/ARM-JKT-001
 X-API-Key: {{apiKey}}
 Content-Type: application/json
 
 {
-  "pic": "Agus Setiawan",
-  "pic_phone": "081200000000",
-  "nomor_polisi": "B 1234 XYZ",
-  "category": "Truk",
-  "merk_model": "Isuzu Elf",
-  "tahun_kendaraan": "2020",
-  "lokasi": "Jakarta"
+  "pic": "Agus",
+  "pic_phone": "08123456789",
+  "nomor_polisi": "W 9518 PG",
+  "category": "Truk Engkel",
+  "merk_model": "Mitsubishi Colt Diesel",
+  "tahun_kendaraan": "2019",
+  "lokasi": "Pool Surabaya"
 }
 
-### Delete armada
-DELETE {{baseUrl}}/armada/ARM001
+### Delete armada (soft delete; code stays attached to the old row, can't be reused via POST)
+DELETE {{baseUrl}}/armada/ARM-JKT-001
 X-API-Key: {{apiKey}}
 
 
@@ -228,42 +260,53 @@ X-API-Key: {{apiKey}}
 ##############################################################################
 
 ### List produk
+# Extra optional flags: show_units, show_category, show_variants (each adds
+# its named field to every row — see the variant request right below).
 GET {{baseUrl}}/produk
 X-API-Key: {{apiKey}}
 
-### Create produk (ref_product_id = id produk di sistem PMO)
+### List produk — with units/category/variants included
+GET {{baseUrl}}/produk?show_units=true&show_category=true&show_variants=true
+X-API-Key: {{apiKey}}
+
+### Create produk (ref_product_id = id produk di sistem PMO; category_id/unit_id/product_unit[] must all point at active rows; not upsert)
 POST {{baseUrl}}/produk
 X-API-Key: {{apiKey}}
 Content-Type: application/json
 
 {
-  "ref_product_id": 5001
+  "ref_product_id": 12,
+  "product_name": "AIR AKI HIKARI",
+  "category_id": 4,
+  "unit_id": 1,
+  "product_unit": [1, 7]
 }
 
-### Update produk profile (path param = ref_product_id)
-PUT {{baseUrl}}/produk/5001
+### Update produk profile (path param = ref_product_id; full replace, all 4 fields required)
+PUT {{baseUrl}}/produk/12
 X-API-Key: {{apiKey}}
 Content-Type: application/json
 
 {
-  "product_name": "Kopi Robusta 1kg",
-  "category_id": 1,
-  "unit_id": 7,
-  "product_unit": [7, 9]
+  "product_name": "AIR AKI HIKARI",
+  "category_id": 4,
+  "unit_id": 1,
+  "product_unit": [1, 7]
 }
 
-### Delete produk
-DELETE {{baseUrl}}/produk/5001
+### Delete produk (soft delete; variants and stock rows deactivated too)
+DELETE {{baseUrl}}/produk/12
 X-API-Key: {{apiKey}}
 
-### Connect existing products in bulk
+### Connect existing products in bulk (connections[].id = Pegasus internal product id, NOT ref_product_id)
 PATCH {{baseUrl}}/produk/connect
 X-API-Key: {{apiKey}}
 Content-Type: application/json
 
 {
   "connections": [
-    { "id": 12, "ref_product_id": 5001 }
+    { "id": 1, "ref_product_id": 12 },
+    { "id": 2, "ref_product_id": 13 }
   ]
 }
 
@@ -273,42 +316,52 @@ Content-Type: application/json
 ##############################################################################
 
 ### List bahan
+# Extra optional flag: show_units (adds "units": resolved supplies_unit + supplies_default_unit).
 GET {{baseUrl}}/bahan
 X-API-Key: {{apiKey}}
 
-### Create bahan (ref_supplies_id = id bahan di sistem PMO)
+### List bahan — with units included
+GET {{baseUrl}}/bahan?show_units=true
+X-API-Key: {{apiKey}}
+
+### Create bahan (ref_supplies_id = id bahan di sistem PMO; supplies_default_unit/supplies_unit[] must be active units; not upsert)
 POST {{baseUrl}}/bahan
 X-API-Key: {{apiKey}}
 Content-Type: application/json
 
 {
-  "ref_supplies_id": 6001
+  "ref_supplies_id": 12,
+  "supplies_name": "Aki Zuur",
+  "supplies_desc": "Cairan pengisi aki",
+  "supplies_default_unit": 1,
+  "supplies_unit": [1, 7]
 }
 
-### Update bahan profile (path param = ref_supplies_id)
-PUT {{baseUrl}}/bahan/6001
+### Update bahan profile (path param = ref_supplies_id; full replace, all fields except supplies_desc required)
+PUT {{baseUrl}}/bahan/12
 X-API-Key: {{apiKey}}
 Content-Type: application/json
 
 {
-  "supplies_name": "Karung Plastik",
-  "supplies_desc": "Karung 50kg",
-  "supplies_default_unit": 7,
-  "supplies_unit": [7, 9]
+  "supplies_name": "Aki Zuur (Kemasan Baru)",
+  "supplies_desc": "Cairan pengisi aki, kemasan drum",
+  "supplies_default_unit": 1,
+  "supplies_unit": [1, 7]
 }
 
-### Delete bahan
-DELETE {{baseUrl}}/bahan/6001
+### Delete bahan (soft delete; can no longer be used as items[].ref_id type=1 on POST /shipments/returns afterwards)
+DELETE {{baseUrl}}/bahan/12
 X-API-Key: {{apiKey}}
 
-### Connect existing bahan in bulk
+### Connect existing bahan in bulk (connections[].id = Pegasus internal supplies id, NOT ref_supplies_id)
 PATCH {{baseUrl}}/bahan/connect
 X-API-Key: {{apiKey}}
 Content-Type: application/json
 
 {
   "connections": [
-    { "id": 4, "ref_supplies_id": 6001 }
+    { "id": 1, "ref_supplies_id": 12 },
+    { "id": 2, "ref_supplies_id": 13 }
   ]
 }
 
@@ -317,20 +370,20 @@ Content-Type: application/json
 # Stok (read-only)
 ##############################################################################
 
-### Check stock availability for a shipment's items
+### Check stock availability for a batch of SKUs against one warehouse
+# gudang_id refers to warehouses.id directly (omit it to use the main
+# warehouse) — items[].unit_id is units.ref_unit_id (PMO's id), not the
+# internal Pegasus unit id. Pure read: nothing is reserved or deducted.
 POST {{baseUrl}}/stock/check
 X-API-Key: {{apiKey}}
 Content-Type: application/json
 
 {
-  "ref_shipment_id": "SHIP-0001",
-  "gudang_id": null,
+  "ref_shipment_id": "SHP-2026-000123",
+  "gudang_id": 1,
   "items": [
-    {
-      "product_variant_sku": "SKU-0001",
-      "qty": 10,
-      "ref_unit_id": 1001
-    }
+    { "sku": "MRP300P", "qty": 50, "unit_id": 5 },
+    { "sku": "SOHP", "qty": 10, "unit_id": 3 }
   ]
 }
 
@@ -338,88 +391,105 @@ Content-Type: application/json
 ##############################################################################
 # Shipment (Pengiriman)
 ##############################################################################
+# Field-name gotcha across this group: /scheduled uses items[].sku (like
+# /stock/check), but /shipments/shipped uses items[].variant_sku instead —
+# same meaning, deliberately different field name per the PMO contract.
 
-### Schedule a shipment (rejects duplicate ref_shipment_id)
+### Schedule a shipment (rejects a reused ref_shipment_id with DUPLICATE_REF_ID — NOT idempotent, unlike /shipped)
+# Always schedules the shipment even if items are short on stock;
+# auto_create_shortage_doc only controls whether a separate shortage
+# document is created for the warehouse/purchasing team.
 POST {{baseUrl}}/shipments/scheduled
 X-API-Key: {{apiKey}}
 Content-Type: application/json
 
 {
-  "ref_shipment_id": "SHIP-0001",
-  "scheduled_date": "2026-08-26",
-  "customer_code": "ARM001",
-  "auto_create_shortage_doc": false,
+  "ref_shipment_id": "SHP-7788",
+  "scheduled_date": "2026-07-25",
+  "armada_code": "L8533N",
+  "auto_create_shortage_doc": true,
   "items": [
-    {
-      "product_variant_sku": "SKU-0001",
-      "qty": 10,
-      "ref_unit_id": 1001
-    }
+    { "sku": "AAHK400ML", "qty": 24, "unit_id": 5 }
   ]
 }
 
-### Mark as shipped (idempotent by ref_shipment_id; actually deducts stock)
+### Mark as shipped (idempotent by ref_shipment_id; actually deducts stock and moves status to "Berjalan")
+# detail_handler: "force" (default) overwrites stored data if it differs
+# from this request; "validate" rejects with SHIPMENT_DETAIL_MISMATCH
+# instead. Only matters when ref_shipment_id already exists and isn't
+# "Berjalan" yet.
 POST {{baseUrl}}/shipments/shipped
 X-API-Key: {{apiKey}}
 Content-Type: application/json
 
 {
-  "ref_shipment_id": "SHIP-0001",
-  "shipment_date": "2026-08-26",
-  "customer_code": "ARM001",
-  "notes": "Dikirim tepat waktu",
-  "detail_handler": "validate",
+  "ref_shipment_id": "SHP-7788",
+  "shipment_date": "2026-07-25",
+  "armada_code": "L8533N",
+  "notes": "Pengiriman PMO SHP-7788",
+  "detail_handler": "force",
   "items": [
     {
-      "product_variant_sku": "SKU-0001",
-      "qty": 10,
-      "ref_unit_id": 1001
+      "variant_sku": "AAHK400ML",
+      "qty": 24,
+      "unit_id": 2,
+      "product_name": "AIR AKI HIKARI",
+      "variant_name": "20 x 400ml"
     }
   ]
 }
 
 ### Show shipment by ref_shipment_id
-GET {{baseUrl}}/shipments/SHIP-0001
+GET {{baseUrl}}/shipments/SHP-7788
 X-API-Key: {{apiKey}}
 
-### Change status (only "Dijadwalkan" -> "Sudah Terkirim" is allowed today)
-PATCH {{baseUrl}}/shipments/SHIP-0001/change-status
+### Show shipment — with resolved unit info per item
+GET {{baseUrl}}/shipments/SHP-7788?show_unit=true
 X-API-Key: {{apiKey}}
-Content-Type: application/json
 
-{
-  "status": "Sudah Terkirim"
-}
-
-### Cancel shipment (restores stock if it had already been deducted)
-PUT {{baseUrl}}/shipments/SHIP-0001/cancel
+### Change status (only "Dijadwalkan" -> "Sudah terkirim" is allowed today; this deducts stock same as /shipped)
+PATCH {{baseUrl}}/shipments/SHP-7788/change-status
 X-API-Key: {{apiKey}}
 Content-Type: application/json
 
 {
-  "reason": "Dibatalkan oleh pelanggan"
+  "status": "Sudah terkirim"
 }
 
-### Create a return (GitHub #58) — type 1 = bahan (ref_supplies_id), 2 = produk (SKU)
-# NOTE: proof_base64 is the simplest to test manually; the API also accepts
-# a multipart "proof" file upload instead.
+### Cancel shipment (restores stock if it had already been deducted; idempotent — cancelling twice doesn't double-restore)
+PUT {{baseUrl}}/shipments/SHP-7788/cancel
+X-API-Key: {{apiKey}}
+Content-Type: application/json
+
+{
+  "reason": "Dibatalkan di PMO karena armada rusak"
+}
+
+### Create a return (GitHub #58) — NOT idempotent, every valid request creates a new document
+# items[].type: 1 = bahan mentah/kemasan (ref_id = supplies.ref_supplies_id,
+# register/connect it first via POST or PATCH /bahan/connect), 2 = produk
+# jadi (ref_id = product_variants.product_variant_sku). items[].satuan_id
+# is units.ref_unit_id, like unit_id elsewhere in this group.
+# items[].gudang_id only actually applies to type=2 rows whose unit is that
+# product's eceran unit — every other row's warehouse is auto-resolved
+# (bahan/non-eceran produk -> gudang utama); left off on an eceran row, that
+# row's warehouse_id is simply left empty (reported via
+# pending_warehouse_items) until staff fill it in via the admin page.
+# proof is a real file upload (multipart/form-data); proof_base64 below is
+# the simpler path for pure-JSON testing — send exactly one of the two.
 POST {{baseUrl}}/shipments/returns
 X-API-Key: {{apiKey}}
 Content-Type: application/json
 
 {
-  "return_date": "2026-08-26",
-  "customer_code": "ARM001",
-  "ref_number": "RET-0001",
-  "notes": "Barang cacat",
-  "proof_base64": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
+  "return_date": "2026-08-17",
+  "armada_code": "L8533N",
+  "ref_number": "RTN-7788",
+  "notes": "Sisa muatan setelah rute selesai",
+  "proof_base64": "data:image/jpeg;base64,/9j/4AAQSkZJRg...",
   "items": [
-    {
-      "type": 2,
-      "ref_id": "SKU-0001",
-      "qty": 1,
-      "ref_unit_id": 1001,
-      "gudang_id": null
-    }
+    { "type": 1, "ref_id": 12, "qty": 5, "satuan_id": 2 },
+    { "type": 2, "ref_id": "AAHK400ML", "qty": 3, "satuan_id": 2 },
+    { "type": 2, "ref_id": "AAHK400ML", "qty": 2, "satuan_id": 7, "gudang_id": 4 }
   ]
 }

--- a/http/external-api-v1.http
+++ b/http/external-api-v1.http
@@ -1,0 +1,425 @@
+### Pegasus External API v1 — request collection
+#
+# Requires the "REST Client" VS Code extension (id: humao.rest-client).
+# Install it, then open this file — every request below gets a clickable
+# "Send Request" link right above it, no Postman/Insomnia/cloud involved;
+# requests go straight from your machine to the app.
+#
+# One-time setup:
+#   1. Install the extension: code --install-extension humao.rest-client
+#   2. Copy http/.env.example to http/.env and fill in EXTERNAL_API_KEY
+#      with a real key (Backoffice > Aplikasi Eksternal > tambah kunci).
+#      http/.env is gitignored (matches the root ".env" pattern) — never
+#      commit a real key.
+#   3. Adjust @baseUrl below if your local host differs from pegasus.test.
+#
+# See http/README.md for more detail. Full endpoint contracts (fields,
+# error codes) live in cdocs/integrations/202607282149-external-api-v1/
+# and config('externalapi.docs').
+
+@baseUrl = https://pegasus.test/api/external/v1
+@apiKey = {{$dotenv EXTERNAL_API_KEY}}
+
+
+##############################################################################
+# Data Master — Satuan (units)                                    API-001
+##############################################################################
+
+### List units
+GET {{baseUrl}}/master/units
+X-API-Key: {{apiKey}}
+
+### Create unit (ref_unit_id = id satuan di sistem PMO)
+POST {{baseUrl}}/master/units
+X-API-Key: {{apiKey}}
+Content-Type: application/json
+
+{
+  "ref_unit_id": 1001
+}
+
+### Update unit profile (path param = ref_unit_id, PMO's id — not Pegasus unit_id)
+PUT {{baseUrl}}/master/units/1001
+X-API-Key: {{apiKey}}
+Content-Type: application/json
+
+{
+  "unit_name": "Kilogram",
+  "unit_short_name": "kg"
+}
+
+### Delete unit
+DELETE {{baseUrl}}/master/units/1001
+X-API-Key: {{apiKey}}
+
+### Connect existing units in bulk (id = Pegasus internal unit_id)
+PATCH {{baseUrl}}/master/units/connect
+X-API-Key: {{apiKey}}
+Content-Type: application/json
+
+{
+  "connections": [
+    { "id": 7, "ref_unit_id": 1001 }
+  ]
+}
+
+### Cash categories (read-only)
+GET {{baseUrl}}/master/cash_categories
+X-API-Key: {{apiKey}}
+
+
+##############################################################################
+# Data Master — Gudang (warehouses)                                API-002
+##############################################################################
+
+### List warehouses
+GET {{baseUrl}}/master/warehouses
+X-API-Key: {{apiKey}}
+
+### Create warehouse (tipe_id upserts warehouse_types — see controller notes)
+POST {{baseUrl}}/master/warehouses
+X-API-Key: {{apiKey}}
+Content-Type: application/json
+
+{
+  "nama": "Gudang Pusat",
+  "tipe_nama": "Gudang Utama",
+  "tipe_id": 1,
+  "alamat": "Jl. Contoh No. 1, Jakarta"
+}
+
+### Update warehouse (path param = gudang_id, Pegasus internal id)
+PUT {{baseUrl}}/master/warehouses/1
+X-API-Key: {{apiKey}}
+Content-Type: application/json
+
+{
+  "nama": "Gudang Pusat (Renov)",
+  "tipe_nama": "Gudang Utama",
+  "tipe_id": 1,
+  "alamat": "Jl. Contoh No. 1, Jakarta"
+}
+
+### Delete warehouse
+DELETE {{baseUrl}}/master/warehouses/1
+X-API-Key: {{apiKey}}
+
+### Warehouse types (read-only)
+GET {{baseUrl}}/master/warehouse_types
+X-API-Key: {{apiKey}}
+
+
+##############################################################################
+# Data Master — Sales (staff)
+##############################################################################
+
+### List sales
+GET {{baseUrl}}/master/sales
+X-API-Key: {{apiKey}}
+
+### Create sales (staff_id = Pegasus internal staff to expose externally)
+POST {{baseUrl}}/master/sales
+X-API-Key: {{apiKey}}
+Content-Type: application/json
+
+{
+  "staff_id": 3
+}
+
+### Update sales profile (path param = staff_id, i.e. external_ref_id)
+PUT {{baseUrl}}/master/sales/3
+X-API-Key: {{apiKey}}
+Content-Type: application/json
+
+{
+  "nama_depan": "Budi",
+  "nama_belakang": "Santoso",
+  "email": "budi@example.com",
+  "alamat": "Jl. Sales No. 2"
+}
+
+### Delete sales
+DELETE {{baseUrl}}/master/sales/3
+X-API-Key: {{apiKey}}
+
+### Connect existing sales in bulk
+PATCH {{baseUrl}}/master/sales/connect
+X-API-Key: {{apiKey}}
+Content-Type: application/json
+
+{
+  "connections": [
+    { "staff_id": 3, "map_staff_id": "SALES-003" }
+  ]
+}
+
+
+##############################################################################
+# Pembayaran Kas                                                   API-005
+##############################################################################
+
+### Create cash payment (idempotent by ref_payment_id; payment_type 1=armada, 2=sales)
+POST {{baseUrl}}/payments/cash
+X-API-Key: {{apiKey}}
+Content-Type: application/json
+
+{
+  "ref_payment_id": "PAY-0001",
+  "payment_type": 2,
+  "staff_id": 3,
+  "payment_date": "2026-08-25",
+  "payment_amount": 150000,
+  "items": [
+    { "amount": 150000, "notes": "Uang jalan", "type": 1 }
+  ]
+}
+
+### Show cash payment by ref_payment_id
+GET {{baseUrl}}/payments/cash/PAY-0001
+X-API-Key: {{apiKey}}
+
+
+##############################################################################
+# Data Armada
+##############################################################################
+
+### List armada
+GET {{baseUrl}}/armada
+X-API-Key: {{apiKey}}
+
+### Create armada (code is the caller-supplied universal id)
+POST {{baseUrl}}/armada
+X-API-Key: {{apiKey}}
+Content-Type: application/json
+
+{
+  "code": "ARM001",
+  "pic": "Agus",
+  "pic_phone": "081200000000",
+  "nomor_polisi": "B 1234 XYZ",
+  "category": "Truk",
+  "merk_model": "Isuzu Elf",
+  "tahun_kendaraan": "2020",
+  "lokasi": "Jakarta"
+}
+
+### Update armada (path param = code)
+PUT {{baseUrl}}/armada/ARM001
+X-API-Key: {{apiKey}}
+Content-Type: application/json
+
+{
+  "pic": "Agus Setiawan",
+  "pic_phone": "081200000000",
+  "nomor_polisi": "B 1234 XYZ",
+  "category": "Truk",
+  "merk_model": "Isuzu Elf",
+  "tahun_kendaraan": "2020",
+  "lokasi": "Jakarta"
+}
+
+### Delete armada
+DELETE {{baseUrl}}/armada/ARM001
+X-API-Key: {{apiKey}}
+
+
+##############################################################################
+# Data Produk
+##############################################################################
+
+### List produk
+GET {{baseUrl}}/produk
+X-API-Key: {{apiKey}}
+
+### Create produk (ref_product_id = id produk di sistem PMO)
+POST {{baseUrl}}/produk
+X-API-Key: {{apiKey}}
+Content-Type: application/json
+
+{
+  "ref_product_id": 5001
+}
+
+### Update produk profile (path param = ref_product_id)
+PUT {{baseUrl}}/produk/5001
+X-API-Key: {{apiKey}}
+Content-Type: application/json
+
+{
+  "product_name": "Kopi Robusta 1kg",
+  "category_id": 1,
+  "unit_id": 7,
+  "product_unit": [7, 9]
+}
+
+### Delete produk
+DELETE {{baseUrl}}/produk/5001
+X-API-Key: {{apiKey}}
+
+### Connect existing products in bulk
+PATCH {{baseUrl}}/produk/connect
+X-API-Key: {{apiKey}}
+Content-Type: application/json
+
+{
+  "connections": [
+    { "id": 12, "ref_product_id": 5001 }
+  ]
+}
+
+
+##############################################################################
+# Data Bahan
+##############################################################################
+
+### List bahan
+GET {{baseUrl}}/bahan
+X-API-Key: {{apiKey}}
+
+### Create bahan (ref_supplies_id = id bahan di sistem PMO)
+POST {{baseUrl}}/bahan
+X-API-Key: {{apiKey}}
+Content-Type: application/json
+
+{
+  "ref_supplies_id": 6001
+}
+
+### Update bahan profile (path param = ref_supplies_id)
+PUT {{baseUrl}}/bahan/6001
+X-API-Key: {{apiKey}}
+Content-Type: application/json
+
+{
+  "supplies_name": "Karung Plastik",
+  "supplies_desc": "Karung 50kg",
+  "supplies_default_unit": 7,
+  "supplies_unit": [7, 9]
+}
+
+### Delete bahan
+DELETE {{baseUrl}}/bahan/6001
+X-API-Key: {{apiKey}}
+
+### Connect existing bahan in bulk
+PATCH {{baseUrl}}/bahan/connect
+X-API-Key: {{apiKey}}
+Content-Type: application/json
+
+{
+  "connections": [
+    { "id": 4, "ref_supplies_id": 6001 }
+  ]
+}
+
+
+##############################################################################
+# Stok (read-only)
+##############################################################################
+
+### Check stock availability for a shipment's items
+POST {{baseUrl}}/stock/check
+X-API-Key: {{apiKey}}
+Content-Type: application/json
+
+{
+  "ref_shipment_id": "SHIP-0001",
+  "gudang_id": null,
+  "items": [
+    {
+      "product_variant_sku": "SKU-0001",
+      "qty": 10,
+      "ref_unit_id": 1001
+    }
+  ]
+}
+
+
+##############################################################################
+# Shipment (Pengiriman)
+##############################################################################
+
+### Schedule a shipment (rejects duplicate ref_shipment_id)
+POST {{baseUrl}}/shipments/scheduled
+X-API-Key: {{apiKey}}
+Content-Type: application/json
+
+{
+  "ref_shipment_id": "SHIP-0001",
+  "scheduled_date": "2026-08-26",
+  "customer_code": "ARM001",
+  "auto_create_shortage_doc": false,
+  "items": [
+    {
+      "product_variant_sku": "SKU-0001",
+      "qty": 10,
+      "ref_unit_id": 1001
+    }
+  ]
+}
+
+### Mark as shipped (idempotent by ref_shipment_id; actually deducts stock)
+POST {{baseUrl}}/shipments/shipped
+X-API-Key: {{apiKey}}
+Content-Type: application/json
+
+{
+  "ref_shipment_id": "SHIP-0001",
+  "shipment_date": "2026-08-26",
+  "customer_code": "ARM001",
+  "notes": "Dikirim tepat waktu",
+  "detail_handler": "validate",
+  "items": [
+    {
+      "product_variant_sku": "SKU-0001",
+      "qty": 10,
+      "ref_unit_id": 1001
+    }
+  ]
+}
+
+### Show shipment by ref_shipment_id
+GET {{baseUrl}}/shipments/SHIP-0001
+X-API-Key: {{apiKey}}
+
+### Change status (only "Dijadwalkan" -> "Sudah Terkirim" is allowed today)
+PATCH {{baseUrl}}/shipments/SHIP-0001/change-status
+X-API-Key: {{apiKey}}
+Content-Type: application/json
+
+{
+  "status": "Sudah Terkirim"
+}
+
+### Cancel shipment (restores stock if it had already been deducted)
+PUT {{baseUrl}}/shipments/SHIP-0001/cancel
+X-API-Key: {{apiKey}}
+Content-Type: application/json
+
+{
+  "reason": "Dibatalkan oleh pelanggan"
+}
+
+### Create a return (GitHub #58) — type 1 = bahan (ref_supplies_id), 2 = produk (SKU)
+# NOTE: proof_base64 is the simplest to test manually; the API also accepts
+# a multipart "proof" file upload instead.
+POST {{baseUrl}}/shipments/returns
+X-API-Key: {{apiKey}}
+Content-Type: application/json
+
+{
+  "return_date": "2026-08-26",
+  "customer_code": "ARM001",
+  "ref_number": "RET-0001",
+  "notes": "Barang cacat",
+  "proof_base64": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
+  "items": [
+    {
+      "type": 2,
+      "ref_id": "SKU-0001",
+      "qty": 1,
+      "ref_unit_id": 1001,
+      "gudang_id": null
+    }
+  ]
+}

--- a/http/external-api-v1.http
+++ b/http/external-api-v1.http
@@ -17,7 +17,7 @@
 # error codes) live in cdocs/integrations/202607282149-external-api-v1/
 # and config('externalapi.docs').
 
-@baseUrl = https://pegasus.test/api/external/v1
+@baseUrl = https://pegasus.okejob.id/api/external/v1
 @apiKey = {{$dotenv EXTERNAL_API_KEY}}
 
 

--- a/postman/collections/Pegasus External/.resources/definition.yaml
+++ b/postman/collections/Pegasus External/.resources/definition.yaml
@@ -1,0 +1,9 @@
+$kind: collection
+name: Pegasus External
+auth:
+  - id: 95a8b258-f989-415f-bde8-418fe8ee8580
+    type: apikey
+    name: API Key
+    credentials:
+      key: X-API-Key
+      value: "{{API_KEY}}"

--- a/postman/collections/Pegasus External/Master/.resources/Daftar Gudang (v1).resources/examples/Success.example.yaml
+++ b/postman/collections/Pegasus External/Master/.resources/Daftar Gudang (v1).resources/examples/Success.example.yaml
@@ -1,0 +1,44 @@
+$kind: http-example
+request:
+  url: "{{ENDPOINT}}/v1/master/warehouses"
+  method: GET
+response:
+  statusCode: 200
+  statusText: OK
+  headers:
+    server: nginx/1.25.4
+    content-type: application/json
+    transfer-encoding: chunked
+    connection: keep-alive
+    vary: Accept-Encoding
+    x-powered-by: PHP/8.4.23
+    cache-control: no-cache, private
+    date: Wed, 29 Jul 2026 17:51:28 GMT
+    access-control-allow-origin: "*"
+    content-encoding: gzip
+  body:
+    type: json
+    content: |-
+      {
+        "success": true,
+        "data": [
+          {
+            "id": 1,
+            "nama": "Gudang Surabaya",
+            "tipe_nama": "Gol A",
+            "tipe_id": 1,
+            "alamat": "Jl. Surabaya"
+          },
+          {
+            "id": 2,
+            "nama": "Jakarta Warehouse",
+            "tipe_nama": "Gol A",
+            "tipe_id": 1,
+            "alamat": "Jl. Jayakarta"
+          }
+        ],
+        "meta": {
+          "total": 2
+        }
+      }
+order: 1785347491051

--- a/postman/collections/Pegasus External/Master/.resources/Daftar Kategori Kas (v1).resources/examples/Error 401.example.yaml
+++ b/postman/collections/Pegasus External/Master/.resources/Daftar Kategori Kas (v1).resources/examples/Error 401.example.yaml
@@ -1,0 +1,27 @@
+$kind: http-example
+request:
+  url: "{{ENDPOINT}}/v1/master/cash_categories"
+  method: GET
+response:
+  statusCode: 401
+  statusText: Unauthorized
+  headers:
+    server: nginx/1.25.4
+    content-type: application/json
+    transfer-encoding: chunked
+    connection: keep-alive
+    x-powered-by: PHP/8.4.23
+    cache-control: no-cache, private
+    date: Wed, 29 Jul 2026 16:03:53 GMT
+    access-control-allow-origin: "*"
+  body:
+    type: json
+    content: |-
+      {
+        "success": false,
+        "error": {
+          "code": "invalid_api_key",
+          "message": "API Key tidak valid."
+        }
+      }
+order: 1785341037218

--- a/postman/collections/Pegasus External/Master/.resources/Daftar Kategori Kas (v1).resources/examples/Success.example.yaml
+++ b/postman/collections/Pegasus External/Master/.resources/Daftar Kategori Kas (v1).resources/examples/Success.example.yaml
@@ -1,0 +1,235 @@
+$kind: http-example
+request:
+  url: "{{ENDPOINT}}/v1/master/cash_categories"
+  method: GET
+response:
+  statusCode: 200
+  statusText: OK
+  headers:
+    server: nginx/1.25.4
+    content-type: application/json
+    transfer-encoding: chunked
+    connection: keep-alive
+    vary: Accept-Encoding
+    x-powered-by: PHP/8.4.23
+    cache-control: no-cache, private
+    date: Wed, 29 Jul 2026 16:17:09 GMT
+    access-control-allow-origin: "*"
+    content-encoding: gzip
+  body:
+    type: json
+    content: |-
+      {
+        "success": true,
+        "data": [
+          {
+            "cc_id": 1,
+            "cc_name": "Uang Setoran Kustomer",
+            "cc_type": "Masuk"
+          },
+          {
+            "cc_id": 2,
+            "cc_name": "Uang Makan",
+            "cc_type": "Keluar"
+          },
+          {
+            "cc_id": 3,
+            "cc_name": "BBM",
+            "cc_type": "Keluar"
+          },
+          {
+            "cc_id": 6,
+            "cc_name": "Hotel",
+            "cc_type": "Keluar"
+          },
+          {
+            "cc_id": 8,
+            "cc_name": "E Tol",
+            "cc_type": "Keluar"
+          },
+          {
+            "cc_id": 10,
+            "cc_name": "Izin",
+            "cc_type": "Keluar"
+          },
+          {
+            "cc_id": 11,
+            "cc_name": "Galon",
+            "cc_type": "Keluar"
+          },
+          {
+            "cc_id": 12,
+            "cc_name": "Uang Mingguan",
+            "cc_type": "Keluar"
+          },
+          {
+            "cc_id": 13,
+            "cc_name": "Parkir",
+            "cc_type": "Keluar"
+          },
+          {
+            "cc_id": 14,
+            "cc_name": "Kuli / Krani",
+            "cc_type": "Keluar"
+          },
+          {
+            "cc_id": 15,
+            "cc_name": "SATPAM",
+            "cc_type": "Keluar"
+          },
+          {
+            "cc_id": 16,
+            "cc_name": "PAK WANDI SORE",
+            "cc_type": "Keluar"
+          },
+          {
+            "cc_id": 17,
+            "cc_name": "BAYAR EXP",
+            "cc_type": "Keluar"
+          },
+          {
+            "cc_id": 18,
+            "cc_name": "UANG MUAT SORE",
+            "cc_type": "Keluar"
+          },
+          {
+            "cc_id": 19,
+            "cc_name": "anak produksi",
+            "cc_type": "Keluar"
+          },
+          {
+            "cc_id": 20,
+            "cc_name": "Uang pir + IL",
+            "cc_type": "Keluar"
+          },
+          {
+            "cc_id": 21,
+            "cc_name": "Santoso",
+            "cc_type": "Keluar"
+          },
+          {
+            "cc_id": 22,
+            "cc_name": "Maestro",
+            "cc_type": "Keluar"
+          },
+          {
+            "cc_id": 23,
+            "cc_name": "MINGGUAN ADM",
+            "cc_type": "Keluar"
+          },
+          {
+            "cc_id": 24,
+            "cc_name": "GANTI BAN",
+            "cc_type": "Keluar"
+          },
+          {
+            "cc_id": 25,
+            "cc_name": "kernet",
+            "cc_type": "Keluar"
+          },
+          {
+            "cc_id": 27,
+            "cc_name": "P5 UD METRO MOTOR",
+            "cc_type": "Keluar"
+          },
+          {
+            "cc_id": 28,
+            "cc_name": "SERVICE BENGKEL",
+            "cc_type": "Keluar"
+          },
+          {
+            "cc_id": 29,
+            "cc_name": "Penyesuaian Kas Sales/Armada (KELUAR)",
+            "cc_type": "Keluar"
+          },
+          {
+            "cc_id": 30,
+            "cc_name": "PENYESUIAN KAS ARMADA/SALES (MASUK)",
+            "cc_type": "Masuk"
+          },
+          {
+            "cc_id": 31,
+            "cc_name": "sewa motor",
+            "cc_type": "Keluar"
+          },
+          {
+            "cc_id": 32,
+            "cc_name": "bus",
+            "cc_type": "Keluar"
+          },
+          {
+            "cc_id": 33,
+            "cc_name": "ojek",
+            "cc_type": "Keluar"
+          },
+          {
+            "cc_id": 34,
+            "cc_name": "ADM",
+            "cc_type": "Keluar"
+          },
+          {
+            "cc_id": 35,
+            "cc_name": "pompa ban",
+            "cc_type": "Keluar"
+          },
+          {
+            "cc_id": 36,
+            "cc_name": "lampu+pitingan",
+            "cc_type": "Keluar"
+          },
+          {
+            "cc_id": 37,
+            "cc_name": "KIR",
+            "cc_type": "Keluar"
+          },
+          {
+            "cc_id": 38,
+            "cc_name": "GAJI SALES",
+            "cc_type": "Keluar"
+          },
+          {
+            "cc_id": 39,
+            "cc_name": "PETUGAS SPBU",
+            "cc_type": "Keluar"
+          },
+          {
+            "cc_id": 40,
+            "cc_name": "CONTAINER",
+            "cc_type": "Keluar"
+          },
+          {
+            "cc_id": 41,
+            "cc_name": "PENGELUARAN NR",
+            "cc_type": "Keluar"
+          },
+          {
+            "cc_id": 42,
+            "cc_name": "PENGELUARAN DIKA",
+            "cc_type": "Keluar"
+          },
+          {
+            "cc_id": 43,
+            "cc_name": "PENGELUARAN BISMA",
+            "cc_type": "Keluar"
+          },
+          {
+            "cc_id": 44,
+            "cc_name": "PENGELUARAN BAGAS",
+            "cc_type": "Keluar"
+          },
+          {
+            "cc_id": 45,
+            "cc_name": "TAMBAL BAN",
+            "cc_type": "Keluar"
+          },
+          {
+            "cc_id": 46,
+            "cc_name": "PENGELUARAN SAIFUL",
+            "cc_type": "Keluar"
+          }
+        ],
+        "meta": {
+          "total": 41
+        }
+      }
+order: 1943560803661366

--- a/postman/collections/Pegasus External/Master/.resources/Daftar Sales (v1).resources/examples/Success.example.yaml
+++ b/postman/collections/Pegasus External/Master/.resources/Daftar Sales (v1).resources/examples/Success.example.yaml
@@ -1,0 +1,93 @@
+$kind: http-example
+request:
+  url: "{{ENDPOINT}}/v1/master/sales"
+  method: GET
+response:
+  statusCode: 200
+  statusText: OK
+  headers:
+    server: nginx/1.25.4
+    content-type: application/json
+    transfer-encoding: chunked
+    connection: keep-alive
+    vary: Accept-Encoding
+    x-powered-by: PHP/8.4.23
+    cache-control: no-cache, private
+    date: Wed, 29 Jul 2026 17:52:19 GMT
+    access-control-allow-origin: "*"
+    content-encoding: gzip
+  body:
+    type: json
+    content: |-
+      {
+        "success": true,
+        "data": [
+          {
+            "staff_id": 20,
+            "nama": "Bisma ",
+            "kode": null,
+            "email": "-",
+            "telepon": "08",
+            "alamat": "-",
+            "role": "Sales"
+          },
+          {
+            "staff_id": 21,
+            "nama": "Dika ",
+            "kode": null,
+            "email": "-",
+            "telepon": "0",
+            "alamat": "-",
+            "role": "Sales"
+          },
+          {
+            "staff_id": 22,
+            "nama": "Nur ",
+            "kode": null,
+            "email": "-",
+            "telepon": "0",
+            "alamat": "-",
+            "role": "Sales"
+          },
+          {
+            "staff_id": 23,
+            "nama": "Adi ",
+            "kode": null,
+            "email": "-",
+            "telepon": "0",
+            "alamat": "-",
+            "role": "Sales"
+          },
+          {
+            "staff_id": 24,
+            "nama": "Suki ",
+            "kode": null,
+            "email": "-",
+            "telepon": "0",
+            "alamat": "-",
+            "role": "Sales"
+          },
+          {
+            "staff_id": 25,
+            "nama": "Nanang ",
+            "kode": null,
+            "email": "-",
+            "telepon": "0",
+            "alamat": "-",
+            "role": "Sales"
+          },
+          {
+            "staff_id": 26,
+            "nama": "Sales Counter",
+            "kode": null,
+            "email": "-",
+            "telepon": "0",
+            "alamat": "-",
+            "role": "Sales"
+          }
+        ],
+        "meta": {
+          "total": 7
+        }
+      }
+order: 1785347556531

--- a/postman/collections/Pegasus External/Master/.resources/Daftar Satuan (v1).resources/examples/Success.example.yaml
+++ b/postman/collections/Pegasus External/Master/.resources/Daftar Satuan (v1).resources/examples/Success.example.yaml
@@ -1,0 +1,96 @@
+$kind: http-example
+request:
+  url: "{{ENDPOINT}}/v1/master/units"
+  method: GET
+response:
+  statusCode: 200
+  statusText: OK
+  headers:
+    server: nginx/1.25.4
+    content-type: application/json
+    transfer-encoding: chunked
+    connection: keep-alive
+    vary: Accept-Encoding
+    x-powered-by: PHP/8.4.23
+    cache-control: no-cache, private
+    date: Wed, 29 Jul 2026 16:17:37 GMT
+    access-control-allow-origin: "*"
+    content-encoding: gzip
+  body:
+    type: json
+    content: |-
+      {
+        "success": true,
+        "data": [
+          {
+            "unit_id": 21,
+            "ref_unit_id": null,
+            "unit_name": "pail",
+            "unit_short_name": "pail"
+          },
+          {
+            "unit_id": 1,
+            "ref_unit_id": null,
+            "unit_name": "Kilogram",
+            "unit_short_name": "kg"
+          },
+          {
+            "unit_id": 2,
+            "ref_unit_id": null,
+            "unit_name": "Jerigen",
+            "unit_short_name": "jerigen"
+          },
+          {
+            "unit_id": 3,
+            "ref_unit_id": null,
+            "unit_name": "Liter",
+            "unit_short_name": "LTR"
+          },
+          {
+            "unit_id": 5,
+            "ref_unit_id": null,
+            "unit_name": "Drum",
+            "unit_short_name": "drum"
+          },
+          {
+            "unit_id": 7,
+            "ref_unit_id": null,
+            "unit_name": "DOS",
+            "unit_short_name": "DOS"
+          },
+          {
+            "unit_id": 8,
+            "ref_unit_id": null,
+            "unit_name": "Pack",
+            "unit_short_name": "pack"
+          },
+          {
+            "unit_id": 9,
+            "ref_unit_id": null,
+            "unit_name": "Piece",
+            "unit_short_name": "pcs"
+          },
+          {
+            "unit_id": 22,
+            "ref_unit_id": null,
+            "unit_name": "Gram",
+            "unit_short_name": "Gr"
+          },
+          {
+            "unit_id": 25,
+            "ref_unit_id": null,
+            "unit_name": "Sak",
+            "unit_short_name": "Sak"
+          },
+          {
+            "unit_id": 26,
+            "ref_unit_id": null,
+            "unit_name": "RIM",
+            "unit_short_name": "RIM"
+          }
+        ],
+        "meta": {
+          "total": 11
+        }
+      }
+order: 1785341859596

--- a/postman/collections/Pegasus External/Master/.resources/Daftar Tipe Gudang (v1).resources/examples/Success.example.yaml
+++ b/postman/collections/Pegasus External/Master/.resources/Daftar Tipe Gudang (v1).resources/examples/Success.example.yaml
@@ -1,0 +1,34 @@
+$kind: http-example
+request:
+  url: "{{ENDPOINT}}/v1/master/warehouse_types"
+  method: GET
+response:
+  statusCode: 200
+  statusText: OK
+  headers:
+    server: nginx/1.25.4
+    content-type: application/json
+    transfer-encoding: chunked
+    connection: keep-alive
+    vary: Accept-Encoding
+    x-powered-by: PHP/8.4.23
+    cache-control: no-cache, private
+    date: Wed, 29 Jul 2026 17:50:51 GMT
+    access-control-allow-origin: "*"
+    content-encoding: gzip
+  body:
+    type: json
+    content: |-
+      {
+        "success": true,
+        "data": [
+          {
+            "nama": "Gol A",
+            "status": 1
+          }
+        ],
+        "meta": {
+          "total": 1
+        }
+      }
+order: 1785347454671

--- a/postman/collections/Pegasus External/Master/.resources/definition.yaml
+++ b/postman/collections/Pegasus External/Master/.resources/definition.yaml
@@ -1,0 +1,3 @@
+$kind: collection
+name: Master
+order: 2172602880622591

--- a/postman/collections/Pegasus External/Master/Daftar Gudang (v1).request.yaml
+++ b/postman/collections/Pegasus External/Master/Daftar Gudang (v1).request.yaml
@@ -1,0 +1,5 @@
+$kind: http-request
+url: "{{ENDPOINT}}/v1/master/warehouses"
+method: GET
+examples: .resources/Daftar Gudang (v1).resources/examples
+order: 3718878061976258

--- a/postman/collections/Pegasus External/Master/Daftar Kategori Kas (v1).request.yaml
+++ b/postman/collections/Pegasus External/Master/Daftar Kategori Kas (v1).request.yaml
@@ -1,0 +1,16 @@
+$kind: http-request
+description: ""
+url: "{{ENDPOINT}}/v1/master/cash_categories"
+method: GET
+auth:
+  type: apikey
+  credentials:
+    value: "{{API_KEY}}"
+    key: X-API-Key
+settings:
+  strictSSL: false
+  followRedirects: true
+  disableCookies: false
+  maxResponseSize: 52428800
+examples: .resources/Daftar Kategori Kas (v1).resources/examples
+order: 1805492027937608

--- a/postman/collections/Pegasus External/Master/Daftar Sales (v1).request.yaml
+++ b/postman/collections/Pegasus External/Master/Daftar Sales (v1).request.yaml
@@ -1,0 +1,5 @@
+$kind: http-request
+url: "{{ENDPOINT}}/v1/master/sales"
+method: GET
+examples: .resources/Daftar Sales (v1).resources/examples
+order: 3834389311003631

--- a/postman/collections/Pegasus External/Master/Daftar Satuan (v1).request.yaml
+++ b/postman/collections/Pegasus External/Master/Daftar Satuan (v1).request.yaml
@@ -1,0 +1,16 @@
+$kind: http-request
+description: ""
+url: "{{ENDPOINT}}/v1/master/units"
+method: GET
+auth:
+  type: apikey
+  credentials:
+    value: "{{API_KEY}}"
+    key: X-API-Key
+settings:
+  strictSSL: false
+  followRedirects: true
+  disableCookies: false
+  maxResponseSize: 52428800
+examples: .resources/Daftar Satuan (v1).resources/examples
+order: 1785347367677

--- a/postman/collections/Pegasus External/Master/Daftar Tipe Gudang (v1).request.yaml
+++ b/postman/collections/Pegasus External/Master/Daftar Tipe Gudang (v1).request.yaml
@@ -1,0 +1,5 @@
+$kind: http-request
+url: "{{ENDPOINT}}/v1/master/warehouse_types"
+method: GET
+examples: .resources/Daftar Tipe Gudang (v1).resources/examples
+order: 2310174279583588

--- a/postman/environments/Pegasus.environment.yaml
+++ b/postman/environments/Pegasus.environment.yaml
@@ -1,0 +1,6 @@
+name: Pegasus
+values:
+  - key: ENDPOINT
+    value: ''
+  - key: API_KEY
+    value: ''

--- a/postman/globals/workspace.globals.yaml
+++ b/postman/globals/workspace.globals.yaml
@@ -1,0 +1,2 @@
+name: Globals
+values: []


### PR DESCRIPTION
## Masalah

Selama ini menguji endpoint External API v1 bergantung pada tool pihak ketiga (Postman) di luar repo — koleksi requestnya tidak ikut ter-versioning bersama kode, susah dibagikan/direview lewat git, dan contoh request gampang basi begitu kontrak sebuah endpoint berubah (tidak ada yang memaksa contohnya disinkronkan ulang).

## Pekerjaan

- `http/external-api-v1.http` — koleksi request untuk **seluruh 39 endpoint** yang terdaftar di `config('externalapi.docs')` (Data Master Satuan/Gudang/Sales, Pembayaran Kas, Data Armada, Data Produk, Data Bahan, Stok, Pengiriman), memakai ekstensi VS Code **REST Client** (`humao.rest-client`) — berkas teks biasa, ikut di-review lewat PR seperti kode lain, jalan langsung dari editor tanpa akun/cloud pihak ketiga.
- Body tiap request disalin langsung dari `requestExample()` milik masing-masing kelas dokumentasi (`app/ExternalApi/Docs/Endpoints/V1/`) — persis sama dengan yang tampil di halaman Dokumentasi API internal, bukan dikarang manual — supaya gampang disinkronkan ulang kalau kontraknya berubah.
- Turut disertakan varian query opsional yang didokumentasikan (`show_units`/`show_category`/`show_variants`/`show_unit`, `force`, serta pola `page`/`per_page`/`sort`/`search` yang dipakai bersama seluruh endpoint list).
- API key dibaca dari `http/.env` (gitignored, tidak pernah ke-commit) lewat `{{$dotenv EXTERNAL_API_KEY}}`; `http/.env.example` sebagai templat, `http/README.md` berisi langkah pemasangan.

**Di luar perubahan REST Client di atas**, branch ini juga membawa commit terpisah (`chore: open postman docs`) yang menambahkan koleksi Postman internal (`postman/`) dan menghapus `/postman` dari `.gitignore` supaya folder itu ikut ter-commit — bukan bagian dari pekerjaan REST Client ini, disertakan apa adanya karena sudah ada di branch yang sama.
