### PR TITLE
fix: sambungkan self-heal ke accProduction(), dijaga oleh Stock Opname yang sudah disetujui (#83)

### DIFF
--- a/app/Http/Controllers/ProductionController.php
+++ b/app/Http/Controllers/ProductionController.php
@@ -21,6 +21,7 @@ use App\Models\SuppliesStock;
 use App\Models\SuppliesVariant;
 use App\Models\Unit;
 use App\Models\Warehouse;
+use App\Support\ProductionPendingStockRestorer;
 use App\Support\ProductUnitStock;
 use App\Support\UnitRollUp;
 use Illuminate\Http\Request;
@@ -545,14 +546,18 @@ class ProductionController extends Controller
      * ACC produksi (pending → approved).
      *
      * Alur keamanan stok (wajib dijaga):
-     * 1) pre-check SEMUA bahan tanpa mutasi
-     * 2) potong bahan + tambah produk + update status dalam 1 DB transaction
+     * 1) self-heal log/stok orphan dari ACC gagal sebelumnya — HANYA kalau belum ada Stock
+     *    Opname yang disetujui sejak orphan itu ditulis (lihat findLockingOpnameCode()); kalau
+     *    sudah dikunci opname, ACC ditolak (status -4) dan minta review manual, TIDAK dipaksa
+     *    auto-restore. Lihat docs/laporan-opname-vs-pending-production-2026-08-01.md — insiden
+     *    PR0258 yang jadi alasan awal fitur ini dimatikan dari ACC.
+     * 2) pre-check SEMUA bahan tanpa mutasi
+     * 3) potong bahan + tambah produk + update status dalam 1 DB transaction
      *
-     * Self-heal orphan TIDAK dijalankan otomatis di ACC (opname bisa sudah
-     * mengunci angka stok setelah potongan salah). Perbaikan massal hanya via:
+     * Perbaikan massal manual (tanpa cek opname, dipakai admin yang sudah meninjau sendiri):
      * php artisan production:restore-pending-stock
      *
-     * Detail: docs/production-acc-stock-safety.md
+     * Detail: docs/production-acc-stock-safety.md, GitHub #83
      */
     function accProduction(Request $req)
     {
@@ -584,6 +589,33 @@ class ProductionController extends Controller
                 "header" => "Gagal ACC",
                 "message" => "Pengajuan sudah diterma/ditolak oleh " . $staff
             ]);
+        }
+
+        // Self-heal (GitHub #83): produksi ini masih "Menunggu", tapi kalau sebuah ACC
+        // sebelumnya sempat memotong bahan lalu gagal sebelum status berubah (mis. proses PHP
+        // mati mendadak, bukan exception biasa -- kasus normal sudah aman lewat DB transaction
+        // di bawah), log_stocks-nya masih aktif menggantung. Balikkan dulu supaya retry ini
+        // tidak memotong bahan untuk kedua kalinya.
+        $stockRestorer = new ProductionPendingStockRestorer();
+        $orphanLogs = $stockRestorer->activeLogsFor($p->production_code);
+        if ($orphanLogs->isNotEmpty()) {
+            $lockingOpnameCode = $stockRestorer->findLockingOpnameCode($orphanLogs);
+            if ($lockingOpnameCode !== null) {
+                return response()->json([
+                    'status' => -4,
+                    'header' => 'Perlu Peninjauan Manual',
+                    'message' => "Produksi ini punya potongan stok menggantung dari percobaan ACC "
+                        . "sebelumnya, tapi Stock Opname {$lockingOpnameCode} sudah terlanjur "
+                        . "disetujui setelah potongan itu terjadi. Tidak bisa dikembalikan otomatis "
+                        . "supaya tidak merusak angka opname tersebut -- hubungi admin untuk "
+                        . "peninjauan manual (php artisan production:restore-pending-stock).",
+                ]);
+            }
+
+            $staffId = (int) (session('user')->staff_id ?? 0);
+            DB::transaction(function () use ($stockRestorer, $p, $staffId) {
+                $stockRestorer->revertProductionCode($p->production_code, true, $staffId > 0 ? $staffId : null);
+            });
         }
 
         $item = ProductionDetails::where('production_id', $data['production_id'])->where('status', 1)->get();

--- a/app/Support/ProductionPendingStockRestorer.php
+++ b/app/Support/ProductionPendingStockRestorer.php
@@ -5,17 +5,85 @@ namespace App\Support;
 use App\Models\LogStock;
 use App\Models\Production;
 use App\Models\ProductStock;
+use App\Models\StockOpnameBahanLine;
+use App\Models\StockOpnameLine;
 use App\Models\SuppliesStock;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 
 /**
  * Kembalikan stok yang kepotong dari ACC produksi gagal
  * sementara header productions masih pending (status = 1).
  *
- * Lihat: docs/production-acc-stock-safety.md
+ * Lihat: docs/production-acc-stock-safety.md,
+ * docs/laporan-opname-vs-pending-production-2026-08-01.md
  */
 class ProductionPendingStockRestorer
 {
+    /**
+     * Log_stocks aktif (belum di-revert) untuk satu production_code, terbaru dulu.
+     *
+     * @return Collection<int, LogStock>
+     */
+    public function activeLogsFor(string $productionCode): Collection
+    {
+        return LogStock::where('log_kode', $productionCode)
+            ->where('status', 1)
+            ->orderByDesc('log_id')
+            ->get();
+    }
+
+    /**
+     * Cek apakah salah satu log orphan ini sudah "dikunci" oleh Stock Opname (bahan atau
+     * produk) yang DISETUJUI setelah log itu ditulis. Kalau iya, jangan auto-restore --
+     * lihat docs/laporan-opname-vs-pending-production-2026-08-01.md (insiden PR0258): opname
+     * itu sudah menghitung fisik dengan angka yang (sudah terpotong) itu sebagai kenyataan,
+     * jadi mengembalikan stok sekarang akan menyuntik stok yang secara fisik tidak ada.
+     *
+     * Sengaja tidak menyaring per unit_id -- item+gudang+waktu saja, supaya kalau ragu,
+     * diblokir (lebih aman daripada meloloskan restore yang ternyata merusak sebuah opname).
+     *
+     * @param Collection<int, LogStock> $logs
+     * @return string|null kode Stock Opname yang mengunci (mis. "SB0069"/"SP0069"), atau null kalau aman
+     */
+    public function findLockingOpnameCode(Collection $logs): ?string
+    {
+        foreach ($logs as $log) {
+            $since = $log->created_at ?? $log->log_date;
+            $warehouseId = $log->warehouse_id ? (int) $log->warehouse_id : null;
+
+            if ((int) $log->log_type === 2) {
+                $stobCode = StockOpnameBahanLine::query()
+                    ->join('stock_opname_bahans', 'stock_opname_bahans.stob_id', '=', 'stock_opname_bahan_lines.stob_id')
+                    ->where('stock_opname_bahan_lines.supplies_id', $log->log_item_id)
+                    ->where('stock_opname_bahan_lines.status', 1)
+                    ->where('stock_opname_bahans.status', 2)
+                    // stob_decided_at = kapan snapshot beku diputuskan (v2); dokumen versi
+                    // lama tidak mengisinya, jatuh balik ke updated_at.
+                    ->whereRaw('COALESCE(stock_opname_bahans.stob_decided_at, stock_opname_bahans.updated_at) >= ?', [$since])
+                    ->when($warehouseId, fn ($qq) => $qq->where('stock_opname_bahans.warehouse_id', $warehouseId))
+                    ->value('stock_opname_bahans.stob_code');
+                if ($stobCode) {
+                    return (string) $stobCode;
+                }
+            } elseif ((int) $log->log_type === 1) {
+                $stoCode = StockOpnameLine::query()
+                    ->join('stock_opnames', 'stock_opnames.sto_id', '=', 'stock_opname_lines.sto_id')
+                    ->where('stock_opname_lines.product_variant_id', $log->log_item_id)
+                    ->where('stock_opname_lines.status', 1)
+                    ->where('stock_opnames.status', 2)
+                    ->whereRaw('COALESCE(stock_opnames.sto_decided_at, stock_opnames.updated_at) >= ?', [$since])
+                    ->when($warehouseId, fn ($qq) => $qq->where('stock_opnames.warehouse_id', $warehouseId))
+                    ->value('stock_opnames.sto_code');
+                if ($stoCode) {
+                    return (string) $stoCode;
+                }
+            }
+        }
+
+        return null;
+    }
+
     /**
      * @return array{
      *   productions: int,

--- a/docs/production-acc-stock-safety.md
+++ b/docs/production-acc-stock-safety.md
@@ -34,7 +34,22 @@ Loop potong bahan satu per satu, lalu return error tanpa rollback (versi lama).
 
 ### Solusi sekarang
 
-`DB::transaction` + pre-check bahan sebelum mutasi. Self-heal orphan log sudah dihapus (data historis sudah dibersihkan di server).
+`DB::transaction` + pre-check bahan sebelum mutasi menutup akar masalah untuk ACC BARU (PR
+#74) — exception apa pun di tengah ACC sekarang rollback bersih, tidak ada lagi potongan
+setengah jalan lewat jalur ini.
+
+**Update GitHub #83 (2026-08-29):** itu tidak menutup kasus lama/langka lainnya — produksi
+yang SUDAH kepentok dalam keadaan orphan dari sebelum PR #74 (atau proses PHP yang mati total,
+di luar jangkauan `try/catch`), retry ACC-nya tetap memotong bahan untuk kedua kalinya karena
+tidak ada apa pun yang membersihkan orphan itu duluan. Self-heal kini **dihidupkan kembali di
+ACC, tapi dijaga**: `ProductionPendingStockRestorer::findLockingOpnameCode()` dicek dulu — kalau
+ADA Stock Opname (bahan/produk) yang sudah **disetujui** untuk item+gudang yang sama SEJAK
+orphan log itu ditulis, auto-restore **dibatalkan** (balas `status: -4`, minta peninjauan
+manual) persis karena alasan insiden PR0258 di
+`docs/laporan-opname-vs-pending-production-2026-08-01.md`: opname begitu sudah menghitung fisik
+dengan angka yang terpotong itu sebagai kenyataan, jadi mengembalikan stok sistem akan
+menyuntik stok yang secara fisik tidak ada. Kalau tidak ada opname yang mengunci, self-heal
+jalan otomatis (dengan log kompensasi) sebelum ACC lanjut seperti biasa.
 
 ---
 
@@ -42,19 +57,22 @@ Loop potong bahan satu per satu, lalu return error tanpa rollback (versi lama).
 
 ```
 1. Validasi migrasi / status == pending (1)
-2. Agregasi kebutuhan BOM
-3. Validasi gudang utama + rencana Stock Transfer
-4. PRE-CHECK  → cek SEMUA bahan cukup (tanpa mutasi)
-5. Jika kurang → return status -1 (belum potong)
-6. TRANSACTION:
+2. SELF-HEAL (GitHub #83): kalau ada log_stocks aktif untuk production_code ini —
+     - ada Opname yang mengunci (disetujui sejak log ditulis)? → status -4, stop, minta review
+     - tidak ada → revert orphan (ProductionPendingStockRestorer, +log kompensasi), lanjut
+3. Agregasi kebutuhan BOM
+4. Validasi gudang utama + rencana Stock Transfer
+5. PRE-CHECK  → cek SEMUA bahan cukup (tanpa mutasi)
+6. Jika kurang → return status -1 (belum potong)
+7. TRANSACTION:
      - lock production
      - potong bahan + log (+ log_saldo)
      - inventori hasil produksi ke gudang asal (+ log Hasil produksi)
      - create Stock Transfer (Pending) per gudang tujuan
      - update status production → 2
    Gagal → DB::rollBack()
-7. ST Kirim → potong stok gudang asal
-8. ST Terima → tambah stok gudang tujuan
+8. ST Kirim → potong stok gudang asal
+9. ST Terima → tambah stok gudang tujuan
 ```
 
 ### Pre-check
@@ -87,4 +105,8 @@ GROUP BY p.production_code, p.status;
 1. Jaga pre-check + transaction; jangan potong stok di luar transaction.
 2. Logika BOM / konversi tidak diganti; yang ditambah guard + atomicity.
 3. Setelah ACC sukses, stok produk mengikuti alur **Stock Transfer** (Pending → Kirim → Terkirim).
-4. FE handle `status: -1` untuk pesan bahan kurang.
+4. FE handle `status: -1` untuk pesan bahan kurang, `status: -4` untuk orphan yang dikunci opname
+   (butuh review manual — FE tidak punya aksi khusus, cukup tampilkan `header`/`message` seperti
+   status error lainnya).
+5. `findLockingOpnameCode()` sengaja tidak menyaring per `unit_id` — item+gudang+waktu saja.
+   Kalau ragu, blokir; jangan longgarkan tanpa alasan kuat, ini pagar terhadap kasus PR0258.

--- a/tests/Workflow/ProductionAccSelfHealBlockedByOpnameTest.php
+++ b/tests/Workflow/ProductionAccSelfHealBlockedByOpnameTest.php
@@ -10,34 +10,28 @@ use App\Models\Product;
 use App\Models\ProductStock;
 use App\Models\ProductVariant;
 use App\Models\Production;
+use App\Models\StockOpnameBahan;
+use App\Models\StockOpnameBahanLine;
 use App\Models\Supplies;
 use App\Models\SuppliesStock;
-use Illuminate\Support\Facades\DB;
+use App\Support\StockOpname\BahanOpnameLifecycle;
 use Tests\Support\ActingAsStaff;
 use Tests\TestCase;
 
 /**
- * Covers the self-heal guard wired into `ProductionController::accProduction()` for GitHub #83
- * (`App\Support\ProductionPendingStockRestorer::activeLogsFor()`/`findLockingOpnameCode()`) — see
- * `docs/production-acc-stock-safety.md` for the current ACC flow and
- * `docs/laporan-opname-vs-pending-production-2026-08-01.md` for the real incident this recovers
- * from (`PR0258`: an ACC attempt crashed partway through, leaving `supplies_stocks` already
- * decremented and `log_stocks` already written while `productions.status` stayed at `1`/pending).
+ * Covers the guard half of GitHub #83's self-heal fix (companion to
+ * ProductionAccSelfHealTest): self-heal must NOT auto-revert an orphaned production stock cut
+ * if a Stock Opname Bahan has already been APPROVED for the same item+warehouse since the
+ * orphan was cut. See docs/laporan-opname-vs-pending-production-2026-08-01.md (the PR0258
+ * incident) — by that point the opname's approved physical count already reflects the
+ * (incorrectly) reduced quantity as ground truth, so silently adding the quantity back would
+ * inject stock that was never physically found on the shelf.
  *
- * Before this fix, retrying ACC on such a stuck production would apply ANOTHER full ingredient
- * deduction on top of the orphaned one already sitting in stock — silently doubling the loss and,
- * per the real incident report, making the "bahan baku tidak mencukupi" shortfall message grow
- * worse on every retry rather than resolving it. This test reproduces that exact stuck state by
- * hand (the original crash path is already closed by PR #74's transaction wrapping — reproducing
- * it isn't the point here) and confirms a plain retry recovers cleanly: self-heal reverts the
- * orphaned mutation BEFORE the pre-check runs, then the real ACC applies the correct deduction
- * exactly once.
- *
- * The companion test below covers the guard itself: self-heal must NOT run if a Stock Opname has
- * already been approved for the same item+warehouse since the orphan was cut — see
- * `ProductionAccSelfHealBlockedByOpnameTest`.
+ * In that situation ACC must refuse with a clear "needs manual review" response instead of
+ * either (a) auto-restoring and corrupting the approved opname, or (b) the pre-fix behavior of
+ * silently double-deducting.
  */
-class ProductionAccSelfHealTest extends TestCase
+class ProductionAccSelfHealBlockedByOpnameTest extends TestCase
 {
     use ActingAsStaff;
 
@@ -50,12 +44,12 @@ class ProductionAccSelfHealTest extends TestCase
     private function createFixture(): array
     {
         $category = new Category();
-        $category->category_name = 'Self-Heal Test Category';
+        $category->category_name = 'Self-Heal Blocked Test Category';
         $category->status = 1;
         $category->save();
 
         $product = new Product();
-        $product->product_name = 'Self-Heal Test Product';
+        $product->product_name = 'Self-Heal Blocked Test Product';
         $product->category_id = $category->category_id;
         $product->product_unit = json_encode([self::UNIT_ID]);
         $product->unit_id = self::UNIT_ID;
@@ -64,8 +58,8 @@ class ProductionAccSelfHealTest extends TestCase
 
         $variant = new ProductVariant();
         $variant->product_id = $product->product_id;
-        $variant->product_variant_name = 'Self-Heal Test Variant';
-        $variant->product_variant_sku = 'WF-SELFHEAL-'.uniqid();
+        $variant->product_variant_name = 'Self-Heal Blocked Test Variant';
+        $variant->product_variant_sku = 'WF-SELFHEAL-BLOCKED-'.uniqid();
         $variant->product_variant_price = 0;
         $variant->status = 1;
         $variant->save();
@@ -80,7 +74,7 @@ class ProductionAccSelfHealTest extends TestCase
         $productStock->save();
 
         $supplies = new Supplies();
-        $supplies->supplies_name = 'Self-Heal Test Supplies';
+        $supplies->supplies_name = 'Self-Heal Blocked Test Supplies';
         $supplies->supplies_unit = json_encode([self::UNIT_ID]);
         $supplies->supplies_default_unit = self::UNIT_ID;
         $supplies->status = 1;
@@ -112,13 +106,9 @@ class ProductionAccSelfHealTest extends TestCase
         return compact('variant', 'productStock', 'supplies', 'suppliesStock', 'bom');
     }
 
-    public function test_retrying_acc_on_a_stuck_pending_production_self_heals_before_reapplying(): void
+    public function test_retrying_acc_is_blocked_when_an_opname_already_locked_the_orphaned_cut(): void
     {
-        $this->actingAsSuperAdminStaff();
-        // Wajib: insertProduction()/accProduction() menolak kalau gudang aktif sesi bukan gudang
-        // utama, dan menolaknya sebagai HTTP 200 + body error -- tanpa pin ini insert-nya gagal
-        // diam-diam lalu test mengambil produksi lama yang sudah di-ACC (gagal "-2 sudah
-        // diterma/ditolak"). Lihat memory pegasus-testing-db-multiwarehouse-drift.
+        $staff = $this->actingAsSuperAdminStaff();
         $this->withActiveWarehouse(self::WAREHOUSE_ID);
 
         $fx = $this->createFixture();
@@ -127,7 +117,7 @@ class ProductionAccSelfHealTest extends TestCase
 
         $insertResponse = $this->post('/insertProduction', [
             'production_date' => now()->toDateString(),
-            'production_desc' => 'Self-heal test production',
+            'production_desc' => 'Self-heal blocked-by-opname test production',
             'detail' => json_encode([[
                 'bom_id' => $fx['bom']->bom_id,
                 'product_variant_id' => $fx['variant']->product_variant_id,
@@ -143,9 +133,8 @@ class ProductionAccSelfHealTest extends TestCase
         $insertResponse->assertStatus(200);
         $production = Production::orderByDesc('production_id')->firstOrFail();
 
-        // Hand-simulate the OLD bug's aftermath: an ACC attempt that already cut ingredient stock
-        // and wrote its log, but crashed before ever reaching the status update — bypassing the
-        // (now-fixed) crash path entirely, since reproducing it isn't the point of this test.
+        // Same hand-simulated stuck state as ProductionAccSelfHealTest: an ACC attempt that
+        // already cut ingredient stock and wrote its log, but never reached the status update.
         $fx['suppliesStock']->ss_stock = self::STARTING_SUPPLIES_STOCK - $correctDeduction;
         $fx['suppliesStock']->save();
         (new LogStock())->insertLog([
@@ -158,32 +147,61 @@ class ProductionAccSelfHealTest extends TestCase
             'log_jumlah' => $correctDeduction,
             'unit_id' => self::UNIT_ID,
         ]);
-        $this->assertSame(1, (int) $production->fresh()->status, 'the production must still look pending, exactly like the real stuck-production incident');
 
-        // A plain retry — no special payload, this is exactly what a user clicking ACC again does.
+        // Unlike the happy-path test: a Stock Opname Bahan now counts this exact item in this
+        // exact warehouse AFTER the orphan cut, finds it matches the (already reduced) system
+        // stock, and gets approved — freezing 980 as the physically-verified truth.
+        $stob = new StockOpnameBahan();
+        $stob->stob_date = now()->toDateString();
+        $stob->stob_code = 'SB'.substr((string) microtime(true), -4);
+        $stob->staff_id = (int) $staff->staff_id;
+        $stob->status = 1;
+        $stob->is_draft = false;
+        $stob->is_old_version = false;
+        $stob->warehouse_id = self::WAREHOUSE_ID;
+        $stob->save();
+
+        StockOpnameBahanLine::upsertLine([
+            'stob_id' => $stob->stob_id,
+            'supplies_id' => $fx['supplies']->supplies_id,
+            'unit_id' => self::UNIT_ID,
+            'sobl_counted_qty' => (int) $fx['suppliesStock']->fresh()->ss_stock,
+            'sobl_notes' => null,
+        ]);
+
+        $lifecycle = new BahanOpnameLifecycle();
+        $lifecycle->publish($stob);
+        $lifecycle->freezeSystemQty($stob); // membekukan 980 sebagai "sistem" yang disetujui
+        $stob->status = 2;
+        $stob->save();
+        $lifecycle->stampDecision($stob, (int) $staff->staff_id);
+
+        // A plain retry — the same request a user clicking ACC again sends.
         $accResponse = $this->post('/accProduction', ['production_id' => $production->production_id]);
         $accResponse->assertStatus(200);
+        $accResponse->assertJson(['status' => -4]);
+        $accResponse->assertJsonFragment(['header' => 'Perlu Peninjauan Manual']);
+        $this->assertStringContainsString(
+            $stob->stob_code,
+            $accResponse->json('message'),
+            'the rejection must name the specific Stock Opname blocking the auto-restore, for whoever has to review it'
+        );
 
         $production->refresh();
-        $this->assertSame(2, (int) $production->status, 'the retried ACC must succeed cleanly once self-heal clears the orphaned state');
+        $this->assertSame(1, (int) $production->status, 'ACC must be refused outright — not silently processed with a stale deduction');
 
         $fx['suppliesStock']->refresh();
         $this->assertSame(
             self::STARTING_SUPPLIES_STOCK - $correctDeduction,
             $fx['suppliesStock']->ss_stock,
-            'self-heal must undo the orphaned cut, then the real ACC deducts the correct amount exactly ONCE — not double-deducted (1000-20-20=960) and not left under-deducted'
+            'stock must be left exactly as the approved opname already verified it — neither restored (phantom stock) nor double-deducted'
         );
 
-        $fx['productStock']->refresh();
-        $this->assertSame($pdQty, $fx['productStock']->ps_stock, 'output credit must apply normally once the retry succeeds');
-
-        // The orphaned log is gone (deleted by self-heal); only fresh logs from the successful
-        // retry remain for this production_code.
-        $this->assertDatabaseMissing('log_stocks', [
+        // The orphaned log must survive untouched — self-heal never ran.
+        $this->assertDatabaseHas('log_stocks', [
             'log_kode' => $production->production_code,
             'log_notes' => 'Pengurangan bahan untuk produksi (orphaned, simulating a pre-fix crash)',
+            'status' => 1,
         ]);
-        $remainingLogs = DB::table('log_stocks')->where('log_kode', $production->production_code)->get();
-        $this->assertTrue($remainingLogs->every(fn ($l) => $l->log_notes !== 'Pengurangan bahan untuk produksi (orphaned, simulating a pre-fix crash)'));
     }
 }


### PR DESCRIPTION
## Ringkasan

Menutup #83 — stok bahan terpotong dua kali saat ACC produksi diulang setelah ACC sebelumnya gagal di tengah jalan.

`App\Support\ProductionPendingStockRestorer` (mekanisme pemulihan/self-heal) sudah ada di codebase, tapi hanya pernah dipanggil dari 2 perintah artisan manual, tidak pernah dari `ProductionController::accProduction()` itu sendiri. Jadi kalau ada produksi yang nyangkut "Menunggu" padahal stok bahannya sudah terlanjur terpotong (ACC sebelumnya gagal separuh jalan), menekan ACC lagi memotong bahan untuk kedua kalinya — tanpa error apa pun.

## Kenapa tidak langsung "sambungkan saja" self-heal-nya

Itu sudah pernah dipertimbangkan dan sengaja ditolak sebelumnya. `docs/laporan-opname-vs-pending-production-2026-08-01.md` mencatat insiden nyata (`PR0258`) yang jadi alasan mekanisme ini dibangun: saat ditemukan, sebuah Stock Opname **sudah terlanjur dihitung fisik dan disetujui** dengan angka yang sudah terpotong itu sebagai kenyataan (sistem = fisik, cocok). Kesimpulan operasional saat itu eksplisit: **"Healer ACC otomatis: OFF"** — auto-restore setelah titik itu akan menyuntikkan stok yang secara fisik tidak pernah ada di rak, bukan cuma memperbaiki angka.

Jadi PR ini **tidak** sekadar memanggil restorer di awal `accProduction()`. Sebelum self-heal jalan, dicek dulu: *apakah ada Stock Opname (bahan atau produk) untuk item+gudang yang sama yang sudah **disetujui** sejak potongan orphan itu ditulis?*

- **Tidak ada** → aman, self-heal jalan otomatis (dengan log kompensasi untuk jejak audit), lalu ACC lanjut normal — potongan orphan dibalikkan dulu, baru dipotong sekali dengan benar.
- **Ada** → ACC ditolak (`status: -4`, "Perlu Peninjauan Manual"), menyebut kode Stock Opname yang mengunci, mengarahkan ke `php artisan production:restore-pending-stock` untuk peninjauan manual oleh orang yang benar-benar mengecek kasusnya — bukan auto-restore yang bisa merusak opname yang sudah disetujui, dan bukan juga dobel potong diam-diam.

Pengecekan ini pakai `stob_decided_at`/`sto_decided_at` (timestamp keputusan eksplisit dari redesain Stock Opname v2, PR #82) — bukan sekadar `updated_at` — dan sengaja tidak menyaring per `unit_id`, cuma item+gudang+waktu, supaya kalau ragu, diblokir (lebih aman daripada meloloskan restore yang ternyata salah).

Keputusan pendekatan ini (ketimbang alternatif "selalu auto-heal" atau "deteksi+blokir tanpa self-heal sama sekali") sudah dikonfirmasi bersama pemilik repo sebelum diimplementasikan.

## Catatan tambahan yang jujur perlu disebut

Akar masalah ASLI insiden `PR0258` (loop potong bahan tanpa `DB::transaction`, jadi crash di tengah jalan meninggalkan potongan setengah) **sudah ditutup lebih dulu** oleh PR #74 (`253ac98`, sudah masuk lewat #82) — ACC baru sekarang atomik, rollback bersih kalau ada exception. Yang masih relevan untuk PR ini:
- Produksi lama yang sudah nyangkut sejak SEBELUM PR #74 (kalau ada).
- Kasus langka di luar jangkauan `try/catch` (proses PHP mati total, koneksi DB putus).

Jadi fix ini adalah jaring pengaman tambahan, bukan penutup sebuah lubang yang masih aktif untuk ACC baru sehari-hari.

## Testing

- `ProductionAccSelfHealTest` (sudah ada, tadinya gagal) — sekarang lolos: jalur self-heal normal (tanpa opname yang mengunci).
- `ProductionAccSelfHealBlockedByOpnameTest` (baru) — membangun Stock Opname Bahan yang benar-benar disetujui atas item+gudang yang sama persis, dan memastikan ACC ditolak, stok tidak berubah sama sekali (tidak di-restore, tidak dobel potong), dan log orphan-nya tetap utuh untuk ditinjau manual.
- Suite penuh: **721 test (naik dari 679), 0 gagal**, 13 skip (tidak terkait, sudah ada sebelumnya).

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)
