### PR TITLE
test: konfirmasi Stock Alert Bahan sudah benar per tipe gudang, perbaiki test yang salah asumsi (#84)

### DIFF
--- a/tests/Regression/SnapshotRestoreOutputWasSwallowedByNestedArtisanCallTest.php
+++ b/tests/Regression/SnapshotRestoreOutputWasSwallowedByNestedArtisanCallTest.php
@@ -28,15 +28,23 @@ use Tests\TestCase;
  * pegasus_testing outside DatabaseTransactions' rollback safety net — TRUNCATE causes an implicit
  * commit, so a transaction rollback would not undo it anyway). A mock would prove the right command
  * was *requested*, not that its output survives the nested-call round trip, which is the actual bug.
- * So this restores the "default" snapshot for real, then explicitly reseeds pegasus_testing back to
- * its baseline in tearDown() regardless of pass/fail, exactly like the documented `php artisan
- * db:seed --env=testing --force` reset step (cdocs/testing/README.md).
+ * So this restores the "default" snapshot for real, then explicitly restores pegasus_testing back to
+ * ITS OWN standing baseline in tearDown() regardless of pass/fail.
+ *
+ * That baseline is the `okeh8644` snapshot (real production-shaped data), not the bare `db:seed`
+ * default — see memory pegasus-testing-db-okeh8644-switch. Restoring plain `db:seed --force` here
+ * used to leave `pegasus_testing` sitting on the old, much smaller default snapshot for every test
+ * that ran later in the same process (this test has no filter pinning it last), silently
+ * reintroducing everything the okeh8644 switch fixed — e.g. the MRP300P/SOHP duplicate-SKU
+ * collision the default snapshot's source data still has (see pegasus-duplicate-sku-data-issue) —
+ * for the rest of that run. Confirmed as the actual root cause 2026-08-29 after that exact
+ * regression recurred three times in one session.
  */
 class SnapshotRestoreOutputWasSwallowedByNestedArtisanCallTest extends TestCase
 {
     protected function tearDown(): void
     {
-        Artisan::call('db:seed', ['--force' => true]);
+        Artisan::call('snapshot:restore', ['name' => 'okeh8644']);
         parent::tearDown();
     }
 

--- a/tests/Workflow/StockAlertSuppliesFlowTest.php
+++ b/tests/Workflow/StockAlertSuppliesFlowTest.php
@@ -7,6 +7,7 @@ use App\Models\SuppliesRelation;
 use App\Models\SuppliesStock;
 use Illuminate\Support\Facades\DB;
 use Tests\Support\ActingAsStaff;
+use Tests\Support\ResolvesTestWarehouses;
 use Tests\TestCase;
 
 /**
@@ -14,37 +15,38 @@ use Tests\TestCase;
  * tests added upstream) — App\Models\StockAlertSupplies. Same shape as
  * tests/Workflow/StockAlertFlowTest.php (product side) but with its own separate unit-conversion
  * implementation: every stored value (supplies_alert, supplies_min_stock, safety_stock) is kept
- * in `supplies.supplies_default_unit` and converted to the "eceran" (leaf/smallest) unit in the
- * response — see StockAlertSupplies::resolveEceranUnitId()/convertQty(), which walks
- * supplies_relations like a graph, unlike ProductUnitStock's relation-table approach used on the
- * product side.
+ * in `supplies.supplies_default_unit` and, on read, displayed in whichever unit the ACTIVE
+ * WAREHOUSE's type calls for — see StockAlertSupplies::resolveEceranUnitId()/convertQty(), which
+ * walks supplies_relations like a graph, unlike ProductUnitStock's relation-table approach used on
+ * the product side.
+ *
+ * GitHub #84 investigated whether that per-warehouse-type split was itself a bug (a MAIN warehouse
+ * reports quantities in the supply's DEFAULT unit e.g. DOS; an ECERAN/retail warehouse reports them
+ * converted into the leaf "eceran" unit e.g. Piece — `$isEceranWarehouse` in
+ * getStockAlertSupplies()). Confirmed with the repo owner 2026-08-29: this is the intended
+ * behavior, not a bug — a main/bulk warehouse tracks in the bulk unit, a retail warehouse tracks in
+ * the retail unit. #84 closed as "working as intended"; this suite now covers BOTH branches
+ * explicitly (it previously only exercised the main-warehouse path, and did so with an assumption —
+ * always-leaf-conversion — that predated the warehouse-type split entirely).
+ *
+ * The WRITE side (updateStockAlertSupplies()/updateMinOrderSupplies()) is warehouse-agnostic on
+ * purpose: staff always type thresholds in the small/eceran unit regardless of which warehouse is
+ * active, and the value is converted back to the default unit for storage either way — see
+ * test_updateStockAlertSupplies_persists_the_value_converted_back_to_the_default_unit(), which is
+ * not warehouse-type-sensitive and needs no main/eceran split.
  *
  * Usage (for avg_daily) comes from log_stocks (log_type=2, log_category=2, log_notes LIKE
  * '%Pengurangan bahan untuk produksi%'), not sales_order_details — bahan mentah is consumed by
  * Production, not sold directly.
  *
  * GET /getStockAlertSupplies used to 500 unconditionally on any active supply row (undefined
- * `$leadTimeDays` in StockAlertSupplies::getStockAlertSupplies(), GitHub issue #35), so every test
- * below that calls that endpoint was marked skipped rather than deleted, ready to run once the fix
- * landed. rubenyw has since fixed it upstream — confirmed 2026-08-29, see
- * tests/Regression/StockAlertSuppliesUndefinedVariableCrashTest — so the skips are removed and this
- * suite now runs in full.
+ * `$leadTimeDays` in StockAlertSupplies::getStockAlertSupplies(), GitHub issue #35) — fixed
+ * upstream, see tests/Regression/StockAlertSuppliesUndefinedVariableCrashTest.
  */
 class StockAlertSuppliesFlowTest extends TestCase
 {
     use ActingAsStaff;
-
-    /**
-     * GitHub issue #35 (the unconditional 500) is FIXED, so most of this suite now runs. These
-     * three still don't: the endpoint reports the supply's DEFAULT unit (DOS) and its unconverted
-     * quantities, where this suite expects the leaf "eceran" unit (Piece) and values converted into
-     * it. That is a SEPARATE, still-open gap in the Stock Alert rewrite -- tracked on its own issue,
-     * not fixed here (teammate's code, report-only per project policy).
-     */
-    private function skipUntilLeafUnitConversionIsImplemented(): void
-    {
-        $this->markTestSkipped('Stock Alert reports the default unit (DOS) unconverted instead of the leaf eceran unit (Piece) — separate open gap, see the Stock Alert leaf-unit conversion issue.');
-    }
+    use ResolvesTestWarehouses;
 
     private const MAIN_WAREHOUSE_ID = 1;
     private const DOS_UNIT_ID = 7;   // parent unit, used as supplies_default_unit
@@ -77,12 +79,12 @@ class StockAlertSuppliesFlowTest extends TestCase
         $relation->save();
     }
 
-    private function createStock(Supplies $supply, float $stockInDosUnit): SuppliesStock
+    private function createStock(Supplies $supply, float $stockInDosUnit, int $warehouseId = self::MAIN_WAREHOUSE_ID): SuppliesStock
     {
         $ss = new SuppliesStock();
         $ss->supplies_id = $supply->supplies_id;
         $ss->unit_id = self::DOS_UNIT_ID;
-        $ss->warehouse_id = self::MAIN_WAREHOUSE_ID;
+        $ss->warehouse_id = $warehouseId;
         $ss->ss_stock = $stockInDosUnit;
         $ss->status = 1;
         $ss->save();
@@ -90,7 +92,7 @@ class StockAlertSuppliesFlowTest extends TestCase
         return $ss;
     }
 
-    private function logProductionUsage(Supplies $supply, float $qtyInPiece): void
+    private function logProductionUsage(Supplies $supply, float $qtyInPiece, int $warehouseId = self::MAIN_WAREHOUSE_ID): void
     {
         DB::table('log_stocks')->insert([
             'log_date' => now(),
@@ -102,15 +104,15 @@ class StockAlertSuppliesFlowTest extends TestCase
             'log_jumlah' => $qtyInPiece,
             'unit_id' => self::PIECE_UNIT_ID,
             'status' => 1,
-            'warehouse_id' => self::MAIN_WAREHOUSE_ID,
+            'warehouse_id' => $warehouseId,
             'created_at' => now(),
             'updated_at' => now(),
         ]);
     }
 
-    private function getAlertFor(int $suppliesId): ?object
+    private function getAlertFor(int $suppliesId, int $warehouseId = self::MAIN_WAREHOUSE_ID): ?object
     {
-        $response = $this->get('/getStockAlertSupplies?warehouse_id='.self::MAIN_WAREHOUSE_ID);
+        $response = $this->get('/getStockAlertSupplies?warehouse_id='.$warehouseId);
         $response->assertStatus(200);
 
         $row = collect($response->json())->first(fn ($r) => (int) $r['supplies_id'] === $suppliesId);
@@ -118,25 +120,57 @@ class StockAlertSuppliesFlowTest extends TestCase
         return $row === null ? null : (object) $row;
     }
 
-    public function test_values_are_converted_from_default_unit_to_the_leaf_eceran_unit(): void
+    public function test_a_main_warehouse_keeps_values_in_the_default_unit_unconverted(): void
     {
-        $this->skipUntilLeafUnitConversionIsImplemented();
         $this->actingAsSuperAdminStaff();
         $this->withActiveWarehouse(self::MAIN_WAREHOUSE_ID);
+
+        // lead_time_days=3, safety_stock=2 DOS (stays 2 DOS -- main warehouse doesn't convert).
+        $supply = $this->createSupply(leadTimeDays: 3, safetyStockInDefaultUnit: 2);
+        $this->relateDosToPiece($supply);
+        $supply->supplies_alert = 1; // stays 1 DOS
+        $supply->save();
+        $this->createStock($supply, stockInDosUnit: 0);
+        // 90 Piece used today -> converted DOWN to the display unit (DOS): 90/12 = 7.5 DOS,
+        // avg_daily = 7.5/30 = 0.25.
+        $this->logProductionUsage($supply, qtyInPiece: 90);
+
+        $row = $this->getAlertFor($supply->supplies_id);
+        $this->assertNotNull($row, 'supply must appear in the stock alert list');
+
+        $this->assertSame(self::DOS_UNIT_ID, $row->unit_id, 'a main warehouse displays the default unit (DOS), not the leaf eceran unit');
+        $this->assertFalse((bool) $row->is_eceran_warehouse);
+        $this->assertEqualsWithDelta(0.25, $row->avg_daily, 0.0001, '90 Piece usage converted down to 7.5 DOS, /30 days');
+        $this->assertEqualsWithDelta(2.0, $row->safety_stock, 0.0001, 'already in the default unit, no conversion applied');
+        $this->assertSame(3, $row->reorder_point, 'ceil(0.25*3 + 2.0) = 3');
+        $this->assertEqualsWithDelta(0.0, $row->current_stock, 0.0001);
+        $this->assertEqualsWithDelta(1.0, $row->supplies_alert, 0.0001, 'alert threshold left in DOS, unconverted');
+        $this->assertNull($row->min_order_manual);
+        $this->assertFalse($row->min_order_is_manual);
+        $this->assertSame(1, $row->min_order, 'falls back to the (unconverted) alert threshold');
+        $this->assertSame(1, $row->minim_order, 'max(0, round(1 - 0)) = 1');
+    }
+
+    public function test_an_eceran_warehouse_converts_values_to_the_leaf_unit(): void
+    {
+        $this->actingAsSuperAdminStaff();
+        $warehouseId = $this->resolveActiveRetailWarehouseId('Peringatan Stok Bahan Mentah');
+        $this->withActiveWarehouse($warehouseId);
 
         // lead_time_days=3, safety_stock=2 DOS (-> 24 Piece once converted).
         $supply = $this->createSupply(leadTimeDays: 3, safetyStockInDefaultUnit: 2);
         $this->relateDosToPiece($supply);
         $supply->supplies_alert = 1; // 1 DOS -> 12 Piece
         $supply->save();
-        $this->createStock($supply, stockInDosUnit: 0);
+        $this->createStock($supply, stockInDosUnit: 0, warehouseId: $warehouseId);
         // 90 Piece used today -> avg_daily = 90/30 = 3.
-        $this->logProductionUsage($supply, qtyInPiece: 90);
+        $this->logProductionUsage($supply, qtyInPiece: 90, warehouseId: $warehouseId);
 
-        $row = $this->getAlertFor($supply->supplies_id);
+        $row = $this->getAlertFor($supply->supplies_id, $warehouseId);
         $this->assertNotNull($row, 'supply must appear in the stock alert list');
 
-        $this->assertSame(self::PIECE_UNIT_ID, $row->unit_id, 'eceran unit must resolve to the leaf unit (Piece), not the default (DOS)');
+        $this->assertSame(self::PIECE_UNIT_ID, $row->unit_id, 'an eceran warehouse resolves to the leaf unit (Piece), not the default (DOS)');
+        $this->assertTrue((bool) $row->is_eceran_warehouse);
         $this->assertEqualsWithDelta(3.0, $row->avg_daily, 0.0001);
         $this->assertEqualsWithDelta(24.0, $row->safety_stock, 0.0001, '2 DOS safety stock converted to 24 Piece');
         $this->assertSame(33, $row->reorder_point, 'ceil(3*3 + 24) = 33');
@@ -148,20 +182,41 @@ class StockAlertSuppliesFlowTest extends TestCase
         $this->assertSame(12, $row->minim_order, 'max(0, round(12 - 0)) = 12');
     }
 
-    public function test_manual_min_stock_override_replaces_the_alert_threshold(): void
+    public function test_manual_min_stock_override_replaces_the_alert_threshold_in_a_main_warehouse(): void
     {
-        $this->skipUntilLeafUnitConversionIsImplemented();
         $this->actingAsSuperAdminStaff();
         $this->withActiveWarehouse(self::MAIN_WAREHOUSE_ID);
+
+        $supply = $this->createSupply();
+        $this->relateDosToPiece($supply);
+        $supply->supplies_alert = 1;        // stays 1 DOS if it were used (it must NOT be)
+        $supply->supplies_min_stock = 2;    // stays 2 DOS -- main warehouse doesn't convert
+        $supply->save();
+        $this->createStock($supply, stockInDosUnit: 0);
+
+        $row = $this->getAlertFor($supply->supplies_id);
+        $this->assertNotNull($row);
+
+        $this->assertSame(2, $row->min_order_manual);
+        $this->assertTrue($row->min_order_is_manual);
+        $this->assertSame(2, $row->min_order);
+        $this->assertSame(2, $row->minim_order, 'manual override wins outright, the 1-DOS alert threshold must be ignored');
+    }
+
+    public function test_manual_min_stock_override_replaces_the_alert_threshold_in_an_eceran_warehouse(): void
+    {
+        $this->actingAsSuperAdminStaff();
+        $warehouseId = $this->resolveActiveRetailWarehouseId('Peringatan Stok Bahan Mentah');
+        $this->withActiveWarehouse($warehouseId);
 
         $supply = $this->createSupply();
         $this->relateDosToPiece($supply);
         $supply->supplies_alert = 1;        // -> 12 Piece if it were used (it must NOT be)
         $supply->supplies_min_stock = 2;    // -> 24 Piece, DOS -> Piece
         $supply->save();
-        $this->createStock($supply, stockInDosUnit: 0);
+        $this->createStock($supply, stockInDosUnit: 0, warehouseId: $warehouseId);
 
-        $row = $this->getAlertFor($supply->supplies_id);
+        $row = $this->getAlertFor($supply->supplies_id, $warehouseId);
         $this->assertNotNull($row);
 
         $this->assertSame(24, $row->min_order_manual);
@@ -217,26 +272,30 @@ class StockAlertSuppliesFlowTest extends TestCase
 
     public function test_updateMinOrderSupplies_persists_and_can_be_reset_back_to_automatic(): void
     {
-        $this->skipUntilLeafUnitConversionIsImplemented();
+        // updateMinOrderSupplies() is warehouse-agnostic on purpose (see class docblock) -- the
+        // input is always the eceran/leaf-unit value regardless of which warehouse is active, and
+        // it's always converted back to the default unit for storage. Run the write half under the
+        // main warehouse and confirm the WRITE-side conversion (input Piece -> stored DOS) is
+        // unaffected by the reader's warehouse-type display split covered elsewhere in this suite.
         $this->actingAsSuperAdminStaff();
         $this->withActiveWarehouse(self::MAIN_WAREHOUSE_ID);
 
         $supply = $this->createSupply();
         $this->relateDosToPiece($supply);
-        $supply->supplies_alert = 1; // -> 12 Piece
+        $supply->supplies_alert = 1; // stays 1 DOS as read back in this (main) warehouse
         $supply->save();
         $this->createStock($supply, stockInDosUnit: 0);
 
         $this->post('/updateMinOrderSupplies', [
             'supplies_id' => $supply->supplies_id,
-            'min_order' => 24, // eceran (Piece)
+            'min_order' => 24, // eceran (Piece) -- always, regardless of active warehouse
         ])->assertJson(['success' => true]);
 
         $this->assertSame(2, $supply->fresh()->supplies_min_stock, '24 Piece / 12 = 2 DOS stored');
 
         $row = $this->getAlertFor($supply->supplies_id);
         $this->assertTrue($row->min_order_is_manual);
-        $this->assertSame(24, $row->min_order);
+        $this->assertSame(2, $row->min_order, 'main warehouse reads it back unconverted (2 DOS)');
 
         $this->post('/updateMinOrderSupplies', [
             'supplies_id' => $supply->supplies_id,
@@ -246,6 +305,45 @@ class StockAlertSuppliesFlowTest extends TestCase
         $this->assertNull($supply->fresh()->supplies_min_stock);
 
         $row = $this->getAlertFor($supply->supplies_id);
+        $this->assertFalse($row->min_order_is_manual);
+        $this->assertSame(1, $row->min_order, 'falls back to the (unconverted) alert threshold once cleared');
+    }
+
+    public function test_updateMinOrderSupplies_read_back_through_an_eceran_warehouse_stays_converted(): void
+    {
+        // Companion to the test above: same warehouse-agnostic write, but read back through an
+        // ECERAN warehouse this time, confirming the display-side conversion (covered by
+        // test_an_eceran_warehouse_converts_values_to_the_leaf_unit()) also applies to a manually
+        // overridden threshold, not just the automatic alert one.
+        $this->actingAsSuperAdminStaff();
+        $warehouseId = $this->resolveActiveRetailWarehouseId('Peringatan Stok Bahan Mentah');
+        $this->withActiveWarehouse($warehouseId);
+
+        $supply = $this->createSupply();
+        $this->relateDosToPiece($supply);
+        $supply->supplies_alert = 1; // -> 12 Piece
+        $supply->save();
+        $this->createStock($supply, stockInDosUnit: 0, warehouseId: $warehouseId);
+
+        $this->post('/updateMinOrderSupplies', [
+            'supplies_id' => $supply->supplies_id,
+            'min_order' => 24, // eceran (Piece)
+        ])->assertJson(['success' => true]);
+
+        $this->assertSame(2, $supply->fresh()->supplies_min_stock, '24 Piece / 12 = 2 DOS stored, same as any warehouse');
+
+        $row = $this->getAlertFor($supply->supplies_id, $warehouseId);
+        $this->assertTrue($row->min_order_is_manual);
+        $this->assertSame(24, $row->min_order, 'eceran warehouse reads it back converted (24 Piece)');
+
+        $this->post('/updateMinOrderSupplies', [
+            'supplies_id' => $supply->supplies_id,
+            'min_order' => '',
+        ])->assertJson(['success' => true]);
+
+        $this->assertNull($supply->fresh()->supplies_min_stock);
+
+        $row = $this->getAlertFor($supply->supplies_id, $warehouseId);
         $this->assertFalse($row->min_order_is_manual);
         $this->assertSame(12, $row->min_order, 'falls back to the (converted) alert threshold once cleared');
     }


### PR DESCRIPTION
## Ringkasan

Menutup #84 — tapi bukan sebagai perbaikan bug kode produksi, melainkan sebagai **konfirmasi bahwa perilaku saat ini sudah benar**, plus perbaikan test yang salah asumsi.

## Temuan

`StockAlertSupplies::getStockAlertSupplies()` sudah punya aturan yang disengaja: gudang **UTAMA** menampilkan angka dalam satuan default/bulk bahan (mis. DOS), gudang **ECERAN** (retail) mengkonversinya ke satuan daun/eceran (mis. Piece) — lihat `$isEceranWarehouse`, dialirkan ke seluruh method dan dikembalikan ke frontend sebagai `is_eceran_warehouse`. Ini bukan kebetulan: nama variabelnya eksplisit, dan ini ditambahkan lewat commit rubenyw ("fix: stock alert 7-column layout and **default-unit stock qty**", 14 Agustus).

3 test yang di-skip di balik #84 (`StockAlertSuppliesFlowTest`, ditulis 10 Agustus — sebelum aturan per-tipe-gudang itu ada) semuanya berjalan di atas `MAIN_WAREHOUSE_ID` sambil mengharapkan perilaku ECERAN (konversi ke satuan daun) — persis cabang yang menurut desainnya justru TIDAK boleh dikonversi. #84 sendiri (yang saya buat) mewarisi asumsi yang sama tanpa mengecek nuansa ini — makanya isinya sendiri sudah menulis "perlu dipastikan dulu mana yang benar."

**Dikonfirmasi bersama pemilik repo**: perilaku saat ini (tergantung tipe gudang) sudah benar. #84 ditutup sebagai *"berjalan sesuai desain"*, bukan bug.

## Perbaikan test

Bukan sekadar hapus skip dengan angka yang dikoreksi — tiap test dipecah jadi 2 varian:
- **Gudang utama** — angka tetap satuan default, tidak dikonversi.
- **Gudang eceran** — angka dikonversi ke satuan daun (pakai `ResolvesTestWarehouses` yang sudah ada).

Jalur gudang eceran sebelumnya **tidak punya coverage sama sekali** meski itu justru separuh yang lebih kompleks dari aturan ini. Test round-trip `updateMinOrderSupplies` (tulis + baca) juga dipecah serupa, karena sisi TULIS memang sengaja tidak peduli tipe gudang (selalu terima/simpan nilai dalam satuan eceran), sementara sisi BACA peduli — dua hal yang perlu dites terpisah, bukan diasumsikan sama.

## Temuan sampingan, ikut diperbaiki

Saat menjalankan full suite untuk verifikasi, `SnapshotRestoreOutputWasSwallowedByNestedArtisanCallTest` ternyata jadi penyebab **drift data test berulang** yang saya kejar-kejar sepanjang sesi ini: `tearDown()`-nya memanggil `db:seed --force` polos, yang me-restore snapshot **"default"** lama — bukan `okeh8644` yang sekarang jadi baseline resmi `pegasus_testing`. Karena test ini tidak dipin jalan terakhir, setiap full-suite run yang mengeksekusinya meninggalkan DB di snapshot lama untuk SEMUA test setelahnya di proses yang sama — diam-diam memunculkan lagi masalah SKU duplikat MRP300P/SOHP yang sudah pernah diperbaiki, berulang 3x dalam sesi ini sebelum akhirnya ketemu akar masalahnya. Diperbaiki: `tearDown()` sekarang me-restore `okeh8644`, bukan `db:seed` polos.

## Testing

Full suite: **724 test (naik dari 721), 0 gagal**, 10 skip (turun dari 13 — 3 test Stock Alert yang tadinya skip sekarang jalan). Dijalankan 2x berturut-turut untuk memastikan fix drift-nya benar-benar stabil.

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)
