### PR TITLE
fix: naik satuan sekarang menggabungkan stok lama, bukan cuma kredit baru (#87)

### DIFF
--- a/app/Http/Controllers/CustomerController.php
+++ b/app/Http/Controllers/CustomerController.php
@@ -152,35 +152,38 @@ class CustomerController extends Controller
                 ->first();
 
             if($sOld) {
-                $sOld->ps_stock += $rev['qty'];
-                $sOld->save();
-
-                // Baris dihapus dari SO → revert ini final, naikkan satuannya berjenjang.
+                // Baris dihapus dari SO → revert ini final, naikkan satuannya berjenjang. Baris
+                // yang MASIH dipakai cuma perlu flat-add (lihat komentar di atas $masihDipakai).
+                //
+                // GitHub #87 fix (2026-08-29): UnitRollUp::planProduct() sekarang existing-aware —
+                // ia MEMBACA stok yang sedang ada di DB untuk tiap level. Dulu di sini stoknya
+                // ditambah flat DULU baru "dibatalkan lagi" kalau ternyata perlu naik satuan; itu
+                // sekarang akan membuat plan() melihat stok yang SUDAH kena tambahan qty ini duluan
+                // dan menghitung ganda. Jadi urutannya dibalik: hitung rencana roll-up-nya dulu
+                // (sebelum stok berubah sama sekali), baru terapkan sekali jalan.
                 if (!isset($masihDipakai[$revKey])) {
                     $rollUp = UnitRollUp::planProduct((int) $rev['pvr_id'], (int) $rev['unit_id'], (int) $rev['qty']);
-                    $naikLevel = array_slice($rollUp, 1);
 
-                    if ($naikLevel !== []) {
-                        // Turunkan lagi yang sudah terlanjur ditambahkan flat di atas, lalu
-                        // distribusikan sesuai rencana roll-up.
-                        $sOld->ps_stock -= $rev['qty'];
-                        $sOld->ps_stock += (int) $rollUp[0]['qty'];
-                        $sOld->save();
+                    foreach ($rollUp as $credit) {
+                        if ($credit['qty'] === 0) continue;
 
-                        foreach ($naikLevel as $credit) {
-                            if ($credit['qty'] <= 0) continue;
-                            $row = ProductStock::where('product_variant_id', $rev['pvr_id'])
+                        $row = ((int) $credit['unit_id'] === (int) $rev['unit_id'])
+                            ? $sOld
+                            : ProductStock::where('product_variant_id', $rev['pvr_id'])
                                 ->where('unit_id', $credit['unit_id'])
                                 ->where('status', 1)
                                 ->first();
-                            if (!$row) continue;
-                            $row->ps_stock += $credit['qty'];
-                            $row->save();
-                        }
+                        if (!$row) continue;
+
+                        $row->ps_stock += $credit['qty'];
+                        $row->save();
                     }
+                } else {
+                    $sOld->ps_stock += $rev['qty'];
+                    $sOld->save();
                 }
 
-                (new LogStock())->insertLog([                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                
+                (new LogStock())->insertLog([
                     'log_date' => now(), 
                     'log_kode' => $data['so_number'], 
                     'log_type' => 1, 

--- a/app/Http/Controllers/ProductionController.php
+++ b/app/Http/Controllers/ProductionController.php
@@ -801,6 +801,14 @@ class ProductionController extends Controller
 
             if (count($chain) > 1) {
                 foreach ($chain as $credit) {
+                    // Sejalan dengan langkah eksekusi di bawah (yang skip qty===0 dan TIDAK memanggil
+                    // ensureProductStockRow() untuk level yang murni "lewat" tanpa sisa) -- kalau
+                    // level ini tidak akan pernah benar-benar dikreditkan, jangan minta konfirmasi
+                    // untuk baris yang pada akhirnya tidak dibuat sama sekali.
+                    if ($credit['qty'] === 0) {
+                        continue;
+                    }
+
                     $unitId = $credit['unit_id'];
                     $exists = ProductStock::where('product_variant_id', $value['product_variant_id'])
                         ->where('unit_id', $unitId)

--- a/app/Http/Controllers/ProductionController.php
+++ b/app/Http/Controllers/ProductionController.php
@@ -19,6 +19,7 @@ use App\Models\SuppliesStock;
 use App\Models\SuppliesVariant;
 use App\Models\Unit;
 use App\Support\ProductionPendingStockRestorer;
+use App\Support\UnitRollUp;
 use GuzzleHttp\Psr7\UploadedFile;
 use Illuminate\Http\Request;
 use Illuminate\Http\UploadedFile as HttpUploadedFile;
@@ -791,10 +792,12 @@ class ProductionController extends Controller
 
             $jumlahTambah = (int) $value['pd_qty'];
             // Ditambahkan (2026-08-24): dulu cuma cek satu hop ke atas ($r tunggal) — sekarang
-            // menyusuri seluruh rantai lewat creditProductOutputUpChain() (read-only) supaya
-            // konfirmasi "baris stok baru akan dibuat" ini juga menyebutkan level KEDUA/KETIGA dst,
-            // bukan cuma level pertama, sebelum accProduction() benar-benar mengkreditnya di bawah.
-            $chain = $this->creditProductOutputUpChain((int) $value['product_variant_id'], (int) $v->unit_id, $jumlahTambah);
+            // menyusuri seluruh rantai lewat UnitRollUp::planProductOutput() (read-only di sini)
+            // supaya konfirmasi "baris stok baru akan dibuat" ini juga menyebutkan level KEDUA/KETIGA
+            // dst, bukan cuma level pertama, sebelum accProduction() benar-benar mengkreditnya di
+            // bawah. Existing-aware sejak GitHub #87, jadi ikut menangkap kasus split yang baru
+            // ketahuan setelah stok lama di satuan ini digabung dengan tambahan produksi ini.
+            $chain = UnitRollUp::planProductOutput((int) $value['product_variant_id'], (int) $v->unit_id, $jumlahTambah);
 
             if (count($chain) > 1) {
                 foreach ($chain as $credit) {
@@ -1042,20 +1045,27 @@ class ProductionController extends Controller
             $jumlahTambah = (int) $value['pd_qty'];
             if ($v && $v->unit_id == $unitIdInputUser) {
                 // GitHub #19 fix (2026-08-24): naik berjenjang lewat SELURUH rantai product_relations
-                // (bukan cuma satu hop) -- lihat creditProductOutputUpChain() di atas. Setiap level
-                // yang dilewati dikredit dan dicatat log_stocks-nya sendiri; level yang sisa
-                // hasil-baginya 0 (semuanya habis naik ke level berikutnya) tidak perlu disentuh sama
-                // sekali.
-                $chain = $this->creditProductOutputUpChain((int) $value["product_variant_id"], (int) $v->unit_id, $jumlahTambah);
+                // (bukan cuma satu hop) -- lihat UnitRollUp::planProductOutput(). Setiap level yang
+                // dilewati dikredit dan dicatat log_stocks-nya sendiri; level yang tidak berubah
+                // sama sekali (qty 0) tidak perlu disentuh.
+                //
+                // GitHub #87 fix (2026-08-29): plan()-nya sekarang existing-aware, jadi satu kredit
+                // BISA negatif -- itu berarti sebagian stok LAMA di level itu ikut naik satuan
+                // bersama tambahan produksi ini (bukan hilang), bukan cuma level baru yang selalu
+                // >=0 seperti dulu. Makanya loop di bawah ini tunggal untuk SEMUA kasus (baik naik
+                // satuan maupun tidak) -- dulu ada percabangan count($chain)>1 vs flat-add, sekarang
+                // tidak perlu lagi karena plan() dengan chain 1 level pun sudah menghasilkan hasil
+                // yang identik dengan flat-add.
+                $chain = UnitRollUp::planProductOutput((int) $value["product_variant_id"], (int) $v->unit_id, $jumlahTambah);
 
-                if (count($chain) > 1) {
-                    foreach ($chain as $credit) {
-                        if ($credit['qty'] <= 0) continue;
+                foreach ($chain as $credit) {
+                    if ($credit['qty'] === 0) continue;
 
-                        $ps = $this->ensureProductStockRow((int) $value["product_variant_id"], $credit['unit_id']);
-                        $ps->ps_stock += $credit['qty'];
-                        $ps->save();
+                    $ps = $this->ensureProductStockRow((int) $value["product_variant_id"], $credit['unit_id']);
+                    $ps->ps_stock += $credit['qty'];
+                    $ps->save();
 
+                    if ($credit['qty'] > 0) {
                         $insertProductLogOnce([
                             'log_date' => \Carbon\Carbon::parse($p->production_date)->setTimeFrom(now()),
                             'log_kode' => $p->production_code,
@@ -1064,23 +1074,22 @@ class ProductionController extends Controller
                             'log_notes' => "Hasil Produksi Produk " . LogStock::actorSuffix(),
                             'log_jumlah' => $credit['qty'], 'unit_id' => $credit['unit_id'],
                         ]);
-                    }
-                } else  {
-                          //sekarang kita tambah yang belakang
-                        $v->ps_stock += $jumlahTambah;
-                        $v->save();
-
+                    } else {
+                        // Stok lama di level ini ikut tergulung naik ke level di atasnya bersama
+                        // hasil produksi -- catat sebagai konversi satuan (keluar di sini), bukan
+                        // "hasil produksi", supaya ledger tidak menunjukkan penurunan stok tanpa
+                        // penjelasan. Pasangannya (masuk di level atas) tercatat oleh iterasi
+                        // berikutnya lewat cabang "qty > 0" di atas.
                         $insertProductLogOnce([
                             'log_date' => \Carbon\Carbon::parse($p->production_date)->setTimeFrom(now()),
                             'log_kode' => $p->production_code,
-                            'log_type' => 1, 'log_category' => 1,
+                            'log_type' => 1, 'log_category' => 2,
                             'log_item_id' => $value["product_variant_id"],
-                            'log_notes' => "Hasil Produksi Produk " . LogStock::actorSuffix(),
-                            'log_jumlah' => $jumlahTambah, 'unit_id' => $unitIdInputUser,
+                            'log_notes' => "Konversi unit dari hasil produksi (Naik satuan) " . LogStock::actorSuffix(),
+                            'log_jumlah' => abs($credit['qty']), 'unit_id' => $credit['unit_id'],
                         ]);
-
-
                     }
+                }
             } else {
                 $pv = ProductVariant::find($value["product_variant_id"]);
                 $namaProduk = '-';
@@ -1637,56 +1646,6 @@ class ProductionController extends Controller
         }
 
         return $qty;
-    }
-
-    /**
-     * PM task (2026-08-24): accProduction()'s finished-goods output crediting used to roll a
-     * produced quantity up ONE level of product_relations only (see the dead $cek/$ada lookup this
-     * replaced) — a quantity that was an exact multiple of a SECOND level (e.g. 24 Piece = 2 DOS =
-     * 1 Sak) stalled at DOS and never reached Sak. This walks the WHOLE chain, mirroring the
-     * already-correct "bongkar" direction (convertQtyToSmallestUnit()/$siapkanStok above), just
-     * upward instead of downward.
-     *
-     * Pure/read-only — does no DB writes itself, just returns the list of {unit_id, qty} to credit,
-     * ordered from $startUnitId up to the highest level actually reached. The caller (accProduction())
-     * does the ProductStock += and logging. Reused as-is by the pre-check block above to find every
-     * unit level a split might touch, not just the first hop.
-     *
-     * @return array<int, array{unit_id:int, qty:int}>
-     */
-    private function creditProductOutputUpChain(int $productVariantId, int $startUnitId, int $qty): array
-    {
-        $relations = ProductRelation::where('product_variant_id', $productVariantId)
-            ->where('status', 1)
-            ->get();
-
-        $credits = [];
-        $currentUnitId = $startUnitId;
-        $remaining = $qty;
-        $guard = 0;
-
-        while ($guard < 20) {
-            $guard++;
-            $rel = $relations->first(fn ($r) => (int) $r->pr_unit_id_2 === (int) $currentUnitId);
-            if (!$rel || $remaining < $rel->pr_unit_value_2) {
-                break;
-            }
-
-            $tambah = (int) floor($remaining / $rel->pr_unit_value_2);
-            $sisa = $remaining % $rel->pr_unit_value_2;
-
-            $credits[] = ['unit_id' => (int) $currentUnitId, 'qty' => (int) $sisa];
-
-            $currentUnitId = (int) $rel->pr_unit_id_1;
-            $remaining = $tambah;
-        }
-
-        // Sisa/titik teratas yang benar-benar dicapai (baik karena rantainya habis, atau qty yang
-        // dibawa tidak cukup untuk naik lagi) — kalau tidak pernah ada hop sama sekali, ini satu-satunya
-        // entri dan sama dengan {startUnitId, qty} apa adanya (perilaku lama untuk produk tanpa ladder).
-        $credits[] = ['unit_id' => $currentUnitId, 'qty' => (int) $remaining];
-
-        return $credits;
     }
 
     private function getBatchCount(

--- a/app/Models/ProductIssuesDetail.php
+++ b/app/Models/ProductIssuesDetail.php
@@ -186,8 +186,13 @@ class ProductIssuesDetail extends Model
 
             // Level di atasnya dijamin punya baris stok aktif — UnitRollUp hanya menaikkan ke
             // satuan yang sudah punya baris (lihat allowedSuppliesUnitIds()).
+            //
+            // GitHub #87 fix (2026-08-29): plan() sekarang existing-aware, jadi kredit di sini bisa
+            // NEGATIF (stok lama di level itu ikut naik satuan bersama retur ini) -- dulu "<= 0"
+            // salah membuang kredit negatif itu. "+=" tetap benar untuk delta negatif, jadi cukup
+            // skip yang benar-benar nol.
             foreach ($naikLevel as $credit) {
-                if ($credit['qty'] <= 0) continue;
+                if ($credit['qty'] === 0) continue;
 
                 $row = SuppliesStock::where('supplies_id', $m->supplies_id)
                     ->where('unit_id', $credit['unit_id'])
@@ -203,6 +208,11 @@ class ProductIssuesDetail extends Model
             // stok "pindah" satuan tanpa penjelasan. Pola log-nya sama dengan bongkar di
             // stockCheck(): satuan asal keluar (cat 2), satuan hasil masuk (cat 1). Caller tetap
             // menulis log utamanya sendiri.
+            //
+            // $naik ($t->pid_qty - $base['qty']) tetap valid dan tetap >= 0 walau $base['qty'] kini
+            // bisa negatif (existing-aware): plan()'s conservation property menjamin
+            // qty - base['qty'] == jumlah gabungan naikLevel dalam satuan dasar, dan carry hasil
+            // pembagian selalu >= 0 -- lihat UnitRollUp::plan()'s docblock.
             if ($naikLevel !== []) {
                 $naik = (int) $t->pid_qty - (int) $base['qty'];
                 if ($naik > 0) {
@@ -212,13 +222,26 @@ class ProductIssuesDetail extends Model
                         'log_jumlah' => $naik, 'unit_id' => (int) $t->unit_id,
                     ]);
                 }
+                // Level PERANTARA (bukan base, bukan puncak) juga bisa punya kredit negatif kini --
+                // itu berarti stok lama DI LEVEL ITU ikut tergulung naik lagi ke level berikutnya,
+                // bukan cuma menyerap carry dari bawah. Catat sebagai keluar (cat 2) di level itu
+                // juga, supaya ledger konsisten di setiap level yang tersentuh, tidak cuma level
+                // base dan level yang bertambah.
                 foreach ($naikLevel as $credit) {
-                    if ($credit['qty'] <= 0) continue;
-                    (new LogStock())->insertLog([
-                        'log_date' => now(), 'log_kode' => '-', 'log_type' => 2, 'log_category' => 1,
-                        'log_item_id' => $m->supplies_id, 'log_notes' => 'Konversi unit (Hasil naik satuan)',
-                        'log_jumlah' => $credit['qty'], 'unit_id' => $credit['unit_id'],
-                    ]);
+                    if ($credit['qty'] === 0) continue;
+                    if ($credit['qty'] > 0) {
+                        (new LogStock())->insertLog([
+                            'log_date' => now(), 'log_kode' => '-', 'log_type' => 2, 'log_category' => 1,
+                            'log_item_id' => $m->supplies_id, 'log_notes' => 'Konversi unit (Hasil naik satuan)',
+                            'log_jumlah' => $credit['qty'], 'unit_id' => $credit['unit_id'],
+                        ]);
+                    } else {
+                        (new LogStock())->insertLog([
+                            'log_date' => now(), 'log_kode' => '-', 'log_type' => 2, 'log_category' => 2,
+                            'log_item_id' => $m->supplies_id, 'log_notes' => 'Konversi unit (Naik satuan)',
+                            'log_jumlah' => abs($credit['qty']), 'unit_id' => $credit['unit_id'],
+                        ]);
+                    }
                 }
             }
 

--- a/app/Models/PurchaseOrderDeliveryDetail.php
+++ b/app/Models/PurchaseOrderDeliveryDetail.php
@@ -82,8 +82,13 @@ class PurchaseOrderDeliveryDetail extends Model
 
             // Level di atasnya dijamin punya baris stok aktif — UnitRollUp hanya menaikkan ke
             // satuan yang sudah punya baris (lihat allowedSuppliesUnitIds()).
+            //
+            // GitHub #87 fix (2026-08-29): plan() sekarang existing-aware, jadi kredit di sini bisa
+            // NEGATIF (stok lama di level itu ikut naik satuan bersama penerimaan ini) -- dulu
+            // "<= 0" salah membuang kredit negatif itu, membuat stok lama tertinggal tanpa naik.
+            // "+=" tetap benar untuk delta negatif, jadi cukup skip yang benar-benar nol.
             foreach ($rollUp as $credit) {
-                if ($credit['qty'] <= 0) continue;
+                if ($credit['qty'] === 0) continue;
 
                 $row = SuppliesStock::where("supplies_id", "=", $sv->supplies_id)
                     ->where("unit_id", "=", $credit['unit_id'])

--- a/app/Support/UnitRollUp.php
+++ b/app/Support/UnitRollUp.php
@@ -13,13 +13,15 @@ use App\Models\SuppliesStock;
  *
  * Why this exists (2026-08-25): an audit of every `ps_stock`/`ss_stock` write site found that the
  * roll-up direction existed in exactly ONE place — `ProductionController::accProduction()`'s
- * finished-goods crediting (added for GitHub #19). Every other stock-IN path did a flat
- * `$row->ps_stock += $qty` with no conversion at all: Purchase Order goods receipt
- * (`PurchaseOrderDeliveryDetail::insertPoDeliveryDetail()`), stock restores
+ * finished-goods crediting (added for GitHub #19), as its own private duplicate implementation.
+ * Every other stock-IN path did a flat `$row->ps_stock += $qty` with no conversion at all: Purchase
+ * Order goods receipt (`PurchaseOrderDeliveryDetail::insertPoDeliveryDetail()`), stock restores
  * (`ProductIssuesDetail::deleteProductIssuesDetail()`), and Sales Order's edit-time revert
  * (`CustomerController::updateSalesOrder()` TAHAP 1). The same physical goods therefore ended up
  * represented differently depending on how they entered the system — 24 Piece stayed 24 Piece when
- * purchased, but became 1 Sak when produced.
+ * purchased, but became 1 Sak when produced. This class extracted that logic to share it with the
+ * other three paths; production itself only got wired onto it later, via `planProductOutput()`
+ * (GitHub #87 — its private duplicate had drifted from this class and reintroduced the bug below).
  *
  * The opposite direction ("bongkar", big -> small, used when a consuming unit is short) is NOT
  * here: it is need-driven — it only makes sense against a specific target quantity to satisfy —
@@ -32,10 +34,20 @@ use App\Models\SuppliesStock;
  *   rows, because the log note/code differs per flow.
  * - `$allowedUnitIds` is the caller's policy hook for "may I credit this unit?". Production passes
  *   every unit in the ladder because it provisions missing `ProductStock` rows on demand (behind a
- *   user confirmation). Every other caller passes only units that ALREADY have an active stock
- *   row, via `allowedProductUnitIds()`/`allowedSuppliesUnitIds()` below — so a roll-up never
- *   silently creates a stock row the user never asked for. Rolling stops at the first disallowed
- *   unit and the remainder simply stays at the level below it, which is always a valid state.
+ *   user confirmation) — see `planProductOutput()`. Every other caller passes only units that
+ *   ALREADY have an active stock row, via `allowedProductUnitIds()`/`allowedSuppliesUnitIds()`
+ *   below — so a roll-up never silently creates a stock row the user never asked for. Rolling stops
+ *   at the first disallowed unit and the remainder simply stays at the level below it, which is
+ *   always a valid state.
+ * - `$existingByUnitId` (GitHub #87, 2026-08-29) is what's already sitting in each unit's stock row
+ *   BEFORE this credit. Every `plan*()` convenience wrapper below fetches and passes it
+ *   automatically. Without it, a credit that's below a level's ratio on its own but pushes an
+ *   existing leftover over it never rolled up — the leftover just kept growing past its own unit's
+ *   ratio forever, e.g. 20 Piece already in stock + 4 Piece freshly credited never became 1 DOS even
+ *   at exactly 24 Piece = 1 DOS. Folding in the existing amount can make a credit at a given level
+ *   NEGATIVE (existing stock physically moving up a level along with the new credit) — that's
+ *   expected, not an error; every caller applies credits with a plain `+=`, which handles a negative
+ *   delta correctly.
  * - Guarded at 20 hops, same as the ladder walkers in ProductionController, so a circular or
  *   corrupt relation chain can't loop forever.
  */
@@ -46,14 +58,22 @@ class UnitRollUp
     /**
      * @param  array<int, array{small: int, big: int, ratio: int}>  $chain
      * @param  array<int, int>  $allowedUnitIds
+     * @param  array<int, int>  $existingByUnitId  Whatever is ALREADY on the shelf at each unit
+     *         level, keyed by unit_id (0/absent = nothing there yet). Fixed 2026-08-29 (GitHub
+     *         #87): without this, a qty that's below the ratio on its own but pushes an existing
+     *         leftover over it (e.g. 20 Piece already in stock + 4 Piece just credited, 1 DOS = 24
+     *         Piece) never rolled up — the leftover just kept growing past its own unit's ratio
+     *         forever. Passing [] reproduces the old existing-blind behaviour exactly (every
+     *         caller that doesn't pass it gets the pre-fix math, byte for byte).
      * @return array<int, array{unit_id: int, qty: int}>
      */
-    public static function plan(array $chain, int $startUnitId, int $qty, array $allowedUnitIds): array
+    public static function plan(array $chain, int $startUnitId, int $qty, array $allowedUnitIds, array $existingByUnitId = []): array
     {
         $credits = [];
         $currentUnitId = $startUnitId;
         $remaining = $qty;
         $allowed = array_flip(array_map('intval', $allowedUnitIds));
+        $existing = array_map('intval', $existingByUnitId);
         $hops = 0;
 
         while ($hops < self::MAX_HOPS) {
@@ -67,20 +87,31 @@ class UnitRollUp
                 }
             }
 
-            // Chain ended, quantity no longer fills a whole bigger unit, ratio is nonsense, or the
-            // caller won't let us credit the next unit up — stop and leave the rest where it is.
+            $existingHere = $existing[$currentUnitId] ?? 0;
+            $total = $existingHere + $remaining;
+
+            // Chain ended, what's already here PLUS what's being credited now still doesn't fill a
+            // whole bigger unit, ratio is nonsense, or the caller won't let us credit the next unit
+            // up — stop and leave the rest where it is (existing stock untouched).
             if ($rel === null
                 || $rel['ratio'] <= 0
-                || $remaining < $rel['ratio']
+                || $total < $rel['ratio']
                 || ! isset($allowed[$rel['big']])
             ) {
                 break;
             }
 
-            $credits[] = ['unit_id' => $currentUnitId, 'qty' => (int) ($remaining % $rel['ratio'])];
+            // The combined total resettles at $total % ratio here; the delta from whatever was
+            // already sitting at this level can be negative — that's correct, it means some of the
+            // pre-existing stock physically moved up a level along with the new credit, not that it
+            // vanished. Conservation still holds: summed back down to $startUnitId's unit, every
+            // credit in the returned plan always adds up to exactly $qty (existing stock elsewhere
+            // is only ever repositioned, never counted twice) — see UnitRollUpTest's conservation
+            // tests for the proof.
+            $credits[] = ['unit_id' => $currentUnitId, 'qty' => (int) ($total % $rel['ratio']) - $existingHere];
 
             $currentUnitId = $rel['big'];
-            $remaining = (int) floor($remaining / $rel['ratio']);
+            $remaining = (int) floor($total / $rel['ratio']);
         }
 
         $credits[] = ['unit_id' => $currentUnitId, 'qty' => (int) $remaining];
@@ -310,7 +341,39 @@ class UnitRollUp
     }
 
     /**
-     * Convenience wrapper: plan a product roll-up restricted to units that already have stock rows.
+     * What's already on the shelf at each unit level RIGHT NOW, keyed by unit_id — the plan()'s
+     * $existingByUnitId input (GitHub #87). A unit with no active row simply doesn't appear (plan()
+     * treats an absent key as 0, which is correct: nothing there to fold in).
+     *
+     * @return array<int, int> unit_id => ps_stock
+     */
+    public static function existingProductStockByUnit(int $productVariantId): array
+    {
+        return ProductStock::where('product_variant_id', $productVariantId)
+            ->where('status', 1)
+            ->pluck('ps_stock', 'unit_id')
+            ->map(fn ($q) => (int) $q)
+            ->all();
+    }
+
+    /**
+     * Supplies-side counterpart of existingProductStockByUnit().
+     *
+     * @return array<int, int> unit_id => ss_stock
+     */
+    public static function existingSuppliesStockByUnit(int $suppliesId): array
+    {
+        return SuppliesStock::where('supplies_id', $suppliesId)
+            ->where('status', 1)
+            ->pluck('ss_stock', 'unit_id')
+            ->map(fn ($q) => (int) $q)
+            ->all();
+    }
+
+    /**
+     * Convenience wrapper: plan a product roll-up restricted to units that already have stock rows,
+     * folding in whatever is already there (GitHub #87) so a credit that's below the ratio on its
+     * own but crosses it combined with an existing leftover still rolls up correctly.
      *
      * @return array<int, array{unit_id: int, qty: int}>
      */
@@ -320,12 +383,14 @@ class UnitRollUp
             self::productChain($productVariantId),
             $startUnitId,
             $qty,
-            self::allowedProductUnitIds($productVariantId)
+            self::allowedProductUnitIds($productVariantId),
+            self::existingProductStockByUnit($productVariantId)
         );
     }
 
     /**
-     * Convenience wrapper: plan a supplies roll-up restricted to units that already have stock rows.
+     * Convenience wrapper: plan a supplies roll-up restricted to units that already have stock rows,
+     * folding in whatever is already there (GitHub #87) — see planProduct()'s docblock.
      *
      * @return array<int, array{unit_id: int, qty: int}>
      */
@@ -335,7 +400,37 @@ class UnitRollUp
             self::suppliesChain($suppliesId),
             $startUnitId,
             $qty,
-            self::allowedSuppliesUnitIds($suppliesId)
+            self::allowedSuppliesUnitIds($suppliesId),
+            self::existingSuppliesStockByUnit($suppliesId)
+        );
+    }
+
+    /**
+     * Production's own output-crediting policy: unlike planProduct(), this may roll into EVERY unit
+     * in the product's ladder, not just ones that already have an active ProductStock row —
+     * accProduction() auto-provisions missing rows on demand (behind a user confirmation, see
+     * ProductionController::ensureProductStockRow()), so no allowedProductUnitIds() gate applies.
+     * Replaces the private duplicate that used to live in ProductionController as
+     * creditProductOutputUpChain() (GitHub #19, then #87 for the existing-stock fix).
+     *
+     * @return array<int, array{unit_id: int, qty: int}>
+     */
+    public static function planProductOutput(int $productVariantId, int $startUnitId, int $qty): array
+    {
+        $chain = self::productChain($productVariantId);
+
+        $everyUnitId = [];
+        foreach ($chain as $link) {
+            $everyUnitId[$link['small']] = true;
+            $everyUnitId[$link['big']] = true;
+        }
+
+        return self::plan(
+            $chain,
+            $startUnitId,
+            $qty,
+            array_keys($everyUnitId),
+            self::existingProductStockByUnit($productVariantId)
         );
     }
 }

--- a/app/Support/UnitRollUp.php
+++ b/app/Support/UnitRollUp.php
@@ -345,19 +345,36 @@ class UnitRollUp
      * $existingByUnitId input (GitHub #87). A unit with no active row simply doesn't appear (plan()
      * treats an absent key as 0, which is correct: nothing there to fold in).
      *
+     * This ONE query also serves as the allow-list for the `plan*()` wrappers below (its keys are
+     * exactly `allowedProductUnitIds()`'s result), so a roll-up costs one query here, not two
+     * identical ones.
+     *
+     * ⚠️ **Must be given a warehouse scope when the warehouse module merges.** `main`'s
+     * `product_stocks` has no `warehouse_id` at all, so (variant, unit) is always a single row and
+     * the `SUM` below is exactly that row's value. On `fase2` the column exists — the test snapshot
+     * already has 345 (variant, unit) combos with more than one active row — and summing ACROSS
+     * warehouses would be wrong, because a roll-up is per-warehouse: it would decide to roll up
+     * using stock sitting in a warehouse it is not crediting. `fase2`'s
+     * `allowedProductUnitIds($productVariantId, $warehouseId)` already takes that scope; this must
+     * grow the same parameter at merge time rather than keep aggregating blindly. The `SUM` is a
+     * deliberate, deterministic placeholder (`pluck()` would silently pick an arbitrary row
+     * instead), NOT an endorsement of cross-warehouse aggregation.
+     *
      * @return array<int, int> unit_id => ps_stock
      */
     public static function existingProductStockByUnit(int $productVariantId): array
     {
         return ProductStock::where('product_variant_id', $productVariantId)
             ->where('status', 1)
-            ->pluck('ps_stock', 'unit_id')
+            ->groupBy('unit_id')
+            ->selectRaw('unit_id, SUM(ps_stock) AS qty')
+            ->pluck('qty', 'unit_id')
             ->map(fn ($q) => (int) $q)
             ->all();
     }
 
     /**
-     * Supplies-side counterpart of existingProductStockByUnit().
+     * Supplies-side counterpart of existingProductStockByUnit() — including its warehouse caveat.
      *
      * @return array<int, int> unit_id => ss_stock
      */
@@ -365,7 +382,9 @@ class UnitRollUp
     {
         return SuppliesStock::where('supplies_id', $suppliesId)
             ->where('status', 1)
-            ->pluck('ss_stock', 'unit_id')
+            ->groupBy('unit_id')
+            ->selectRaw('unit_id, SUM(ss_stock) AS qty')
+            ->pluck('qty', 'unit_id')
             ->map(fn ($q) => (int) $q)
             ->all();
     }
@@ -379,12 +398,17 @@ class UnitRollUp
      */
     public static function planProduct(int $productVariantId, int $startUnitId, int $qty): array
     {
+        // One lookup, two uses: its KEYS are exactly allowedProductUnitIds() (units with an active
+        // stock row) and its VALUES are the existing quantities plan() folds in — issuing both
+        // queries separately would just run the same WHERE twice.
+        $existing = self::existingProductStockByUnit($productVariantId);
+
         return self::plan(
             self::productChain($productVariantId),
             $startUnitId,
             $qty,
-            self::allowedProductUnitIds($productVariantId),
-            self::existingProductStockByUnit($productVariantId)
+            array_keys($existing),
+            $existing
         );
     }
 
@@ -396,12 +420,15 @@ class UnitRollUp
      */
     public static function planSupplies(int $suppliesId, int $startUnitId, int $qty): array
     {
+        // Single lookup serving both the allow-list and the existing quantities — see planProduct().
+        $existing = self::existingSuppliesStockByUnit($suppliesId);
+
         return self::plan(
             self::suppliesChain($suppliesId),
             $startUnitId,
             $qty,
-            self::allowedSuppliesUnitIds($suppliesId),
-            self::existingSuppliesStockByUnit($suppliesId)
+            array_keys($existing),
+            $existing
         );
     }
 

--- a/tests/Regression/ProductionOutputCascadesThroughAMissingMiddleUnitTest.php
+++ b/tests/Regression/ProductionOutputCascadesThroughAMissingMiddleUnitTest.php
@@ -1,0 +1,216 @@
+<?php
+
+namespace Tests\Regression;
+
+use App\Models\Bom;
+use App\Models\BomDetail;
+use App\Models\Category;
+use App\Models\Product;
+use App\Models\ProductRelation;
+use App\Models\ProductStock;
+use App\Models\ProductVariant;
+use App\Models\Production;
+use App\Models\Supplies;
+use App\Models\SuppliesStock;
+use Tests\Support\ActingAsStaff;
+use Tests\TestCase;
+
+/**
+ * Confirms two things about a 3-level output ladder (Piece -> DOS -> Sak) where NEITHER the middle
+ * (DOS) nor the top (Sak) `ProductStock` row exists yet, and the produced quantity is an EXACT
+ * multiple of the whole ladder (24 Piece = 2 DOS = 1 Sak) — so DOS's own net credit lands on
+ * exactly 0 (everything that reaches it immediately carries on up to Sak, nothing stays behind):
+ *
+ * 1. The roll-up still reaches the TOP level correctly even though the row it passes THROUGH
+ *    (DOS) never existed at all — walking `UnitRollUp::plan()`'s chain only ever depends on
+ *    whether a level's combined total crosses ITS ratio, never on what credit that level nets to,
+ *    so a middle level netting to 0 does not stop the cascade (asked about directly by the user
+ *    2026-08-29 after GitHub #87 — verified here, not just reasoned about).
+ * 2. GitHub #87 cleanup: the pre-check that asks the user to confirm "a new stock row will be
+ *    created at 0" now only lists DOS/Sak-style levels that will ACTUALLY be created. Before this,
+ *    it listed every level touched by the chain regardless of net credit, so it would ask about a
+ *    DOS row that then never actually got created (its net credit was 0, so
+ *    `ensureProductStockRow()` was never even called for it) — a real row it promised never
+ *    materialized. Only Sak (nonzero credit) should appear in the confirmation and only Sak should
+ *    exist afterward.
+ */
+class ProductionOutputCascadesThroughAMissingMiddleUnitTest extends TestCase
+{
+    use ActingAsStaff;
+
+    private const PIECE_UNIT_ID = 9;
+    private const DOS_UNIT_ID = 7;
+    private const SAK_UNIT_ID = 25;
+    private const WAREHOUSE_ID = 1;
+
+    public function test_a_middle_level_with_no_stock_row_and_a_zero_net_credit_does_not_block_the_cascade_or_get_falsely_promised(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $category = new Category();
+        $category->category_name = 'Missing Middle Cascade Regression Category';
+        $category->status = 1;
+        $category->save();
+
+        $product = new Product();
+        $product->product_name = 'Missing Middle Cascade Regression Product';
+        $product->category_id = $category->category_id;
+        $product->product_unit = json_encode([self::PIECE_UNIT_ID]);
+        $product->unit_id = self::PIECE_UNIT_ID;
+        $product->status = 1;
+        $product->save();
+
+        $variant = new ProductVariant();
+        $variant->product_id = $product->product_id;
+        $variant->product_variant_name = 'Missing Middle Cascade Regression Variant';
+        $variant->product_variant_sku = 'WF-CASCADE-MISSING-MID-'.uniqid();
+        $variant->product_variant_price = 0;
+        $variant->status = 1;
+        $variant->save();
+
+        // Only the Piece-level row exists. DOS and Sak are both missing entirely — not just zero.
+        $pieceStock = new ProductStock();
+        $pieceStock->product_id = $product->product_id;
+        $pieceStock->product_variant_id = $variant->product_variant_id;
+        $pieceStock->unit_id = self::PIECE_UNIT_ID;
+        $pieceStock->warehouse_id = self::WAREHOUSE_ID;
+        $pieceStock->ps_stock = 0;
+        $pieceStock->status = 1;
+        $pieceStock->save();
+
+        // Level 1: 1 DOS = 12 Piece
+        $relationDos = new ProductRelation();
+        $relationDos->product_variant_id = $variant->product_variant_id;
+        $relationDos->pr_unit_id_1 = self::DOS_UNIT_ID;
+        $relationDos->pr_unit_value_1 = 1;
+        $relationDos->pr_unit_id_2 = self::PIECE_UNIT_ID;
+        $relationDos->pr_unit_value_2 = 12;
+        $relationDos->pr_default = 0;
+        $relationDos->status = 1;
+        $relationDos->save();
+
+        // Level 2: 1 Sak = 2 DOS (= 24 Piece)
+        $relationSak = new ProductRelation();
+        $relationSak->product_variant_id = $variant->product_variant_id;
+        $relationSak->pr_unit_id_1 = self::SAK_UNIT_ID;
+        $relationSak->pr_unit_value_1 = 1;
+        $relationSak->pr_unit_id_2 = self::DOS_UNIT_ID;
+        $relationSak->pr_unit_value_2 = 2;
+        $relationSak->pr_default = 0;
+        $relationSak->status = 1;
+        $relationSak->save();
+
+        $supplies = new Supplies();
+        $supplies->supplies_name = 'Missing Middle Cascade Regression Ingredient';
+        $supplies->supplies_unit = json_encode([self::PIECE_UNIT_ID]);
+        $supplies->supplies_default_unit = self::PIECE_UNIT_ID;
+        $supplies->status = 1;
+        $supplies->save();
+
+        $suppliesStock = new SuppliesStock();
+        $suppliesStock->supplies_id = $supplies->supplies_id;
+        $suppliesStock->unit_id = self::PIECE_UNIT_ID;
+        $suppliesStock->warehouse_id = self::WAREHOUSE_ID;
+        $suppliesStock->ss_stock = 1000;
+        $suppliesStock->status = 1;
+        $suppliesStock->save();
+
+        $bom = new Bom();
+        $bom->product_id = $variant->product_variant_id;
+        $bom->bom_qty = 1;
+        $bom->unit_id = self::PIECE_UNIT_ID;
+        $bom->status = 1;
+        $bom->save();
+
+        $bomDetail = new BomDetail();
+        $bomDetail->bom_id = $bom->bom_id;
+        $bomDetail->supplies_id = $supplies->supplies_id;
+        $bomDetail->bom_detail_qty = 1;
+        $bomDetail->unit_id = self::PIECE_UNIT_ID;
+        $bomDetail->status = 1;
+        $bomDetail->save();
+
+        $pdQty = 24; // exact multiple all the way up: DOS's own net credit lands on exactly 0
+
+        $insertResponse = $this->post('/insertProduction', [
+            'production_date' => now()->toDateString(),
+            'production_desc' => 'Missing middle cascade regression test',
+            'detail' => json_encode([[
+                'bom_id' => $bom->bom_id,
+                'product_variant_id' => $variant->product_variant_id,
+                'pd_qty' => $pdQty,
+                'unit_id' => self::PIECE_UNIT_ID,
+            ]]),
+            'list_bahan' => json_encode([[
+                'supplies_id' => $supplies->supplies_id,
+                'bom_detail_qty' => 1,
+                'unit_id' => self::PIECE_UNIT_ID,
+            ]]),
+        ]);
+        $insertResponse->assertStatus(200);
+        $production = Production::orderByDesc('production_id')->firstOrFail();
+
+        // First call: no confirmation flag. Must be blocked, and must ONLY ask about Sak — DOS's
+        // own net credit is 0 so it will never actually be created, and must not be promised here.
+        $firstResponse = $this->post('/accProduction', ['production_id' => $production->production_id]);
+        $firstResponse->assertStatus(200);
+        $firstResponse->assertJson(['status' => -3, 'header' => 'Konfirmasi Diperlukan']);
+        $firstResponse->assertJsonFragment([
+            'product_variant_id' => $variant->product_variant_id,
+            'unit_id' => self::SAK_UNIT_ID,
+        ]);
+        $missingStock = $firstResponse->json('missing_stock');
+        $this->assertCount(1, $missingStock, 'only Sak should be listed — DOS nets to 0 and will never actually be created');
+        $this->assertSame(self::SAK_UNIT_ID, $missingStock[0]['unit_id']);
+
+        $production->refresh();
+        $this->assertSame(1, (int) $production->status, 'blocked pending confirmation — must not be approved yet');
+        $this->assertNull(
+            ProductStock::where('product_variant_id', $variant->product_variant_id)
+                ->where('unit_id', self::SAK_UNIT_ID)
+                ->where('status', 1)
+                ->first(),
+            'blocked pending confirmation — the Sak row must not be created yet either'
+        );
+
+        // Second call: confirmed. The cascade must still reach Sak even though it walks THROUGH a
+        // DOS row that never existed and never gets created (its own net credit is 0).
+        $secondResponse = $this->post('/accProduction', [
+            'production_id' => $production->production_id,
+            'confirm_create_stock' => 1,
+        ]);
+        $secondResponse->assertStatus(200);
+
+        $production->refresh();
+        $this->assertSame(2, (int) $production->status);
+
+        $pieceStock->refresh();
+        $this->assertSame(0, $pieceStock->ps_stock, '24 is an exact multiple of the whole ladder — nothing left over at Piece');
+
+        $dosStock = ProductStock::where('product_variant_id', $variant->product_variant_id)
+            ->where('unit_id', self::DOS_UNIT_ID)
+            ->where('status', 1)
+            ->first();
+        $this->assertNull($dosStock, 'DOS nets to a 0 credit — it is a pure pass-through and is never actually provisioned');
+
+        $sakStock = ProductStock::where('product_variant_id', $variant->product_variant_id)
+            ->where('unit_id', self::SAK_UNIT_ID)
+            ->where('status', 1)
+            ->first();
+        $this->assertNotNull($sakStock, 'the cascade reached all the way past the missing DOS row to Sak');
+        $this->assertSame(1, $sakStock->ps_stock, '24 Piece = 2 DOS = 1 Sak, credited directly at the top');
+
+        $this->assertDatabaseHas('log_stocks', [
+            'log_type' => 1,
+            'log_category' => 1,
+            'log_item_id' => $variant->product_variant_id,
+            'unit_id' => self::SAK_UNIT_ID,
+            'log_jumlah' => 1,
+        ]);
+        // No log at all for DOS — nothing was ever credited there to log.
+        $this->assertDatabaseMissing('log_stocks', [
+            'log_item_id' => $variant->product_variant_id,
+            'unit_id' => self::DOS_UNIT_ID,
+        ]);
+    }
+}

--- a/tests/Regression/ProductionOutputRollUpIgnoredExistingStockTest.php
+++ b/tests/Regression/ProductionOutputRollUpIgnoredExistingStockTest.php
@@ -1,0 +1,186 @@
+<?php
+
+namespace Tests\Regression;
+
+use App\Models\Bom;
+use App\Models\BomDetail;
+use App\Models\Category;
+use App\Models\Product;
+use App\Models\ProductRelation;
+use App\Models\ProductStock;
+use App\Models\ProductVariant;
+use App\Models\Production;
+use App\Models\Supplies;
+use App\Models\SuppliesStock;
+use Tests\Support\ActingAsStaff;
+use Tests\TestCase;
+
+/**
+ * ✅ FIXED (2026-08-29, GitHub #87). Reported directly by the user against a real SKU (HKCP60P):
+ * stock before production was 11 DOS + 20 Piece (1 DOS = 24 Piece there); a production run
+ * credited 4 more Piece. Expected result: 20 + 4 = 24 = exactly 1 more DOS, ending at 12 DOS + 0
+ * Piece. Actual result: 11 DOS + 24 Piece — the DOS row was never touched.
+ *
+ * `ProductionController::creditProductOutputUpChain()` (now removed, replaced by
+ * `UnitRollUp::planProductOutput()`) decided whether to roll a credited quantity up a level using
+ * ONLY the newly credited amount, completely ignoring whatever was already sitting in that unit's
+ * stock row:
+ *
+ *   if (!$rel || $remaining < $rel->pr_unit_value_2) { break; } // $remaining was $qty alone
+ *
+ * For this fixture: qty=4, ratio=24. Since 4 < 24 the loop broke immediately without ever checking
+ * whether the EXISTING 20 Piece plus this credit's 4 reaches the ratio. The credit then fell
+ * through to a flat `ps_stock += 4`, leaving the DOS row untouched forever — this is why the old
+ * `ProductionUnitConversionFlowTest`/`ProductionOutputConversionDoesNotCascadeMultipleLevelsTest`
+ * suite never caught it: every one of those fixtures starts the smallest unit's stock at 0, so
+ * "existing stock plus new credit" and "new credit alone" always happened to be the same number.
+ *
+ * Fixed by making `UnitRollUp::plan()` (and every `plan*()` wrapper) existing-aware — see
+ * `tests/Unit/UnitRollUpTest.php`'s `$existingByUnitId` section for the pure-logic proof, and
+ * `docs/...`/GitHub #87 for the full writeup of why this also affected PO receipt, product-issue
+ * stock restores, and Sales Order's edit-time revert (all built on the same `UnitRollUp::plan()`).
+ */
+class ProductionOutputRollUpIgnoredExistingStockTest extends TestCase
+{
+    use ActingAsStaff;
+
+    private const PIECE_UNIT_ID = 9;
+    private const DOS_UNIT_ID = 7;
+    private const WAREHOUSE_ID = 1;
+
+    public function test_a_below_ratio_production_credit_still_rolls_up_when_combined_with_existing_leftover_stock(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $category = new Category();
+        $category->category_name = 'Existing Stock Roll-Up Regression Category';
+        $category->status = 1;
+        $category->save();
+
+        $product = new Product();
+        $product->product_name = 'Existing Stock Roll-Up Regression Product';
+        $product->category_id = $category->category_id;
+        $product->product_unit = json_encode([self::PIECE_UNIT_ID]);
+        $product->unit_id = self::PIECE_UNIT_ID;
+        $product->status = 1;
+        $product->save();
+
+        $variant = new ProductVariant();
+        $variant->product_id = $product->product_id;
+        $variant->product_variant_name = 'Existing Stock Roll-Up Regression Variant';
+        $variant->product_variant_sku = 'WF-ROLLUP-EXISTING-'.uniqid();
+        $variant->product_variant_price = 0;
+        $variant->status = 1;
+        $variant->save();
+
+        // Stock BEFORE production: 20 Piece, 11 DOS — this is the whole point of the test.
+        $pieceStock = new ProductStock();
+        $pieceStock->product_id = $product->product_id;
+        $pieceStock->product_variant_id = $variant->product_variant_id;
+        $pieceStock->unit_id = self::PIECE_UNIT_ID;
+        $pieceStock->warehouse_id = self::WAREHOUSE_ID;
+        $pieceStock->ps_stock = 20;
+        $pieceStock->status = 1;
+        $pieceStock->save();
+
+        $dosStock = new ProductStock();
+        $dosStock->product_id = $product->product_id;
+        $dosStock->product_variant_id = $variant->product_variant_id;
+        $dosStock->unit_id = self::DOS_UNIT_ID;
+        $dosStock->warehouse_id = self::WAREHOUSE_ID;
+        $dosStock->ps_stock = 11;
+        $dosStock->status = 1;
+        $dosStock->save();
+
+        // 1 DOS = 24 Piece, matching the real HKCP60P ladder.
+        $relationDos = new ProductRelation();
+        $relationDos->product_variant_id = $variant->product_variant_id;
+        $relationDos->pr_unit_id_1 = self::DOS_UNIT_ID;
+        $relationDos->pr_unit_value_1 = 1;
+        $relationDos->pr_unit_id_2 = self::PIECE_UNIT_ID;
+        $relationDos->pr_unit_value_2 = 24;
+        $relationDos->pr_default = 0;
+        $relationDos->status = 1;
+        $relationDos->save();
+
+        $supplies = new Supplies();
+        $supplies->supplies_name = 'Existing Stock Roll-Up Regression Ingredient';
+        $supplies->supplies_unit = json_encode([self::PIECE_UNIT_ID]);
+        $supplies->supplies_default_unit = self::PIECE_UNIT_ID;
+        $supplies->status = 1;
+        $supplies->save();
+
+        $suppliesStock = new SuppliesStock();
+        $suppliesStock->supplies_id = $supplies->supplies_id;
+        $suppliesStock->unit_id = self::PIECE_UNIT_ID;
+        $suppliesStock->warehouse_id = self::WAREHOUSE_ID;
+        $suppliesStock->ss_stock = 1000;
+        $suppliesStock->status = 1;
+        $suppliesStock->save();
+
+        $bom = new Bom();
+        $bom->product_id = $variant->product_variant_id;
+        $bom->bom_qty = 1;
+        $bom->unit_id = self::PIECE_UNIT_ID;
+        $bom->status = 1;
+        $bom->save();
+
+        $bomDetail = new BomDetail();
+        $bomDetail->bom_id = $bom->bom_id;
+        $bomDetail->supplies_id = $supplies->supplies_id;
+        $bomDetail->bom_detail_qty = 1;
+        $bomDetail->unit_id = self::PIECE_UNIT_ID;
+        $bomDetail->status = 1;
+        $bomDetail->save();
+
+        $pdQty = 4; // below the 24-Piece ratio on its own — only reaches it combined with the 20 already in stock
+
+        $insertResponse = $this->post('/insertProduction', [
+            'production_date' => now()->toDateString(),
+            'production_desc' => 'Existing stock roll-up regression test',
+            'detail' => json_encode([[
+                'bom_id' => $bom->bom_id,
+                'product_variant_id' => $variant->product_variant_id,
+                'pd_qty' => $pdQty,
+                'unit_id' => self::PIECE_UNIT_ID,
+            ]]),
+            'list_bahan' => json_encode([[
+                'supplies_id' => $supplies->supplies_id,
+                'bom_detail_qty' => 1,
+                'unit_id' => self::PIECE_UNIT_ID,
+            ]]),
+        ]);
+        $insertResponse->assertStatus(200);
+        $production = Production::orderByDesc('production_id')->firstOrFail();
+
+        $accResponse = $this->post('/accProduction', ['production_id' => $production->production_id]);
+        $accResponse->assertStatus(200);
+
+        $production->refresh();
+        $this->assertSame(2, (int) $production->status);
+
+        $pieceStock->refresh();
+        $dosStock->refresh();
+
+        $this->assertSame(0, $pieceStock->ps_stock, '20 existing + 4 produced = 24 = exactly 1 DOS, none left over at the Piece level');
+        $this->assertSame(12, $dosStock->ps_stock, '11 existing + 1 rolled up from the combined Piece total = 12 DOS');
+
+        // The 20 pre-existing Piece leaving this row is logged as a unit conversion (OUT here),
+        // not silently vanishing from the ledger.
+        $this->assertDatabaseHas('log_stocks', [
+            'log_type' => 1,
+            'log_category' => 2,
+            'log_item_id' => $variant->product_variant_id,
+            'unit_id' => self::PIECE_UNIT_ID,
+            'log_jumlah' => 20,
+        ]);
+        // ... and its reappearance as 1 new DOS is logged as the production result (IN here).
+        $this->assertDatabaseHas('log_stocks', [
+            'log_type' => 1,
+            'log_category' => 1,
+            'log_item_id' => $variant->product_variant_id,
+            'unit_id' => self::DOS_UNIT_ID,
+            'log_jumlah' => 1,
+        ]);
+    }
+}

--- a/tests/Unit/UnitRollUpTest.php
+++ b/tests/Unit/UnitRollUpTest.php
@@ -127,6 +127,116 @@ class UnitRollUpTest extends TestCase
         $this->assertLessThanOrEqual(21, count($plan));
     }
 
+    // ============================================================ $existingByUnitId (GitHub #87)
+
+    /**
+     * The exact reported bug (GitHub #87): SKU HKCP60P had 11 DOS + 20 Piece in stock (1 DOS =
+     * 24 Piece there), a production run credited 4 more Piece. 4 alone never reaches the ratio, but
+     * 20 + 4 does — the old existing-blind plan() left this at 11 DOS + 24 Piece forever instead of
+     * rolling into a 12th DOS.
+     */
+    public function test_an_existing_leftover_plus_a_below_ratio_credit_rolls_up_together(): void
+    {
+        $hkcp60pLadder = [['small' => self::PIECE, 'big' => self::DOS, 'ratio' => 24]];
+
+        $plan = UnitRollUp::plan(
+            $hkcp60pLadder,
+            self::PIECE,
+            4,
+            [self::PIECE, self::DOS],
+            [self::PIECE => 20]
+        );
+
+        $this->assertSame([
+            ['unit_id' => self::PIECE, 'qty' => -20], // the old 20 Piece leaves this row entirely
+            ['unit_id' => self::DOS, 'qty' => 1],      // ... and reappears as 1 new DOS (11 -> 12)
+        ], $plan);
+    }
+
+    /** Existing + credit landing exactly on the ratio still counts as reaching it (not "below"). */
+    public function test_existing_plus_credit_exactly_on_the_ratio_still_rolls_up(): void
+    {
+        $plan = UnitRollUp::plan($this->twoLevelLadder(), self::PIECE, 12, [self::PIECE, self::DOS], [self::PIECE => 0]);
+        $this->assertSame([
+            ['unit_id' => self::PIECE, 'qty' => 0],
+            ['unit_id' => self::DOS, 'qty' => 1],
+        ], $plan);
+
+        // Same combined total (12), split differently between existing and new — same result.
+        $plan2 = UnitRollUp::plan($this->twoLevelLadder(), self::PIECE, 5, [self::PIECE, self::DOS], [self::PIECE => 7]);
+        $this->assertSame([
+            ['unit_id' => self::PIECE, 'qty' => -7],
+            ['unit_id' => self::DOS, 'qty' => 1],
+        ], $plan2);
+    }
+
+    /** Existing + credit still short of the ratio: nothing rolls, existing stock is left alone. */
+    public function test_existing_plus_credit_still_below_the_ratio_stays_put(): void
+    {
+        $plan = UnitRollUp::plan($this->twoLevelLadder(), self::PIECE, 4, [self::PIECE, self::DOS], [self::PIECE => 5]);
+
+        $this->assertSame([['unit_id' => self::PIECE, 'qty' => 4]], $plan);
+    }
+
+    /**
+     * A pre-existing leftover can cascade through MULTIPLE levels too, not just the level it's
+     * sitting at — 20 existing Piece + 4 new Piece rolls to 2 new DOS, and those 2 DOS combined
+     * with 5 ALREADY-existing DOS (7 total, ratio 2) roll again into 3 Sak + 1 DOS remainder.
+     */
+    public function test_an_existing_leftover_can_cascade_up_more_than_one_level(): void
+    {
+        $plan = UnitRollUp::plan(
+            $this->ladder(),
+            self::PIECE,
+            4,
+            $this->allUnits(),
+            [self::PIECE => 20, self::DOS => 5]
+        );
+
+        $this->assertSame([
+            ['unit_id' => self::PIECE, 'qty' => -20],
+            ['unit_id' => self::DOS, 'qty' => -4], // 5 existing - 1 remainder = 4 also leave, folded into the Sak
+            ['unit_id' => self::SAK, 'qty' => 3],
+        ], $plan);
+
+        // Conservation: -20*1 + -4*12 + 3*24 = 4, exactly the credited qty — see the dedicated
+        // conservation test below for why this must always hold.
+    }
+
+    /** Omitting $existingByUnitId reproduces the pre-fix, existing-blind behaviour exactly. */
+    public function test_omitting_existing_stock_defaults_to_the_old_existing_blind_behaviour(): void
+    {
+        $withDefault = UnitRollUp::plan($this->twoLevelLadder(), self::PIECE, 4, [self::PIECE, self::DOS]);
+        $withExplicitZero = UnitRollUp::plan($this->twoLevelLadder(), self::PIECE, 4, [self::PIECE, self::DOS], [self::PIECE => 0]);
+
+        $this->assertSame([['unit_id' => self::PIECE, 'qty' => 4]], $withDefault);
+        $this->assertSame($withDefault, $withExplicitZero);
+    }
+
+    /**
+     * Conservation still holds with a nonzero existing balance: summed back down to the base unit,
+     * the plan's credits always add up to exactly $qty — existing stock elsewhere is only ever
+     * repositioned by the plan, never counted as part of what's being credited.
+     */
+    public function test_conservation_holds_even_when_existing_stock_is_folded_in(): void
+    {
+        $plan = UnitRollUp::plan(
+            $this->ladder(),
+            self::PIECE,
+            4,
+            $this->allUnits(),
+            [self::PIECE => 20, self::DOS => 5]
+        );
+
+        $pieceEquivalent = [self::PIECE => 1, self::DOS => 12, self::SAK => 24];
+        $total = 0;
+        foreach ($plan as $credit) {
+            $total += $credit['qty'] * $pieceEquivalent[$credit['unit_id']];
+        }
+
+        $this->assertSame(4, $total, 'the plan only ever accounts for the newly credited 4 Piece, not the existing stock it repositions');
+    }
+
     // ================================================================== collapse()
 
     /**


### PR DESCRIPTION
## Ringkasan

Perbaiki #87: stok satuan terkecil tidak pernah naik satuan kalau jumlah yang baru ditambahkan sendirian belum cukup melewati rasio, walaupun digabung dengan sisa stok lama sudah cukup. Kasus nyata (dilaporkan user, sudah dicoba langsung di production dan berhasil): SKU HKCP60P, 11 DOS + 20 Piece, produksi +4 Piece seharusnya jadi 12 DOS + 0 Piece, malah jadi 11 DOS + 24 Piece.

## Penyebab

`App\Support\UnitRollUp::plan()` (dan duplikat privatnya, `ProductionController::creditProductOutputUpChain()`) menguji naik-satuan hanya terhadap qty transaksi yang sedang dikreditkan, tidak pernah membaca stok yang sudah ada di baris satuan itu.

## Perubahan

**Perbaikan inti:**
- `UnitRollUp::plan()` menerima `$existingByUnitId` opsional dan menguji `(existing + qty)` terhadap rasio tiap level. Delta yang dihasilkan bisa negatif (stok lama ikut naik bersama kredit baru) — semua pemanggil sudah pakai `+=` jadi otomatis benar; conservation tetap terjaga (total kredit selalu == qty yang dikreditkan, stok lama cuma dipindah representasinya).
- `planProduct()`/`planSupplies()` otomatis membaca stok existing lewat helper baru `existingProductStockByUnit()`/`existingSuppliesStockByUnit()`.
- `planProductOutput()` baru menggantikan `ProductionController::creditProductOutputUpChain()` yang sudah *drift* dari `UnitRollUp` sejak #19 — produksi sekarang benar-benar terhubung ke kelas ini seperti diklaim docblock-nya (private method lama dihapus).
- Guard `qty <= 0 continue` di 4 caller (Production, PO receipt, Product Issues restore, Sales Order revert) diganti `qty === 0` supaya kredit negatif tidak dibuang diam-diam.
- `CustomerController::updateSalesOrder` TAHAP 1 dirapikan: urutan "tambah flat dulu, batalkan kalau ternyata perlu naik satuan" sekarang salah karena `planProduct()` membaca stok live dari DB — dibalik jadi hitung rencana dulu, baru terapkan sekali jalan.
- Kredit negatif di Production & Product Issues restore dicatat sebagai log konversi satuan (keluar) supaya ledger tetap jelas kenapa satu baris stok berkurang.

**Follow-up 1 — pesan konfirmasi ikut dirapikan:** ditemukan saat memverifikasi cascading tetap benar walau level tengah tangga satuan belum punya baris stok sama sekali. Cascading-nya sendiri terbukti benar (dibuktikan lewat test baru), tapi ketahuan `confirm_create_stock` pre-check dulu menjanjikan baris baru untuk SETIAP level yang disentuh rantai, termasuk level yang net kredit-nya persis 0 (murni "lewat" tanpa sisa) — padahal langkah eksekusi sudah skip level ber-qty 0 dan baris itu tidak pernah benar-benar dibuat. Sekarang pre-check hanya menyebutkan baris yang benar-benar akan dibuat.

**Follow-up 2 — efisiensi & pengerasan (hardening):** `planProduct()`/`planSupplies()` sempat menjalankan 2 query dengan `WHERE` identik (allow-list & stok existing dari tabel yang sama) — sekarang 1 query saja, key-nya dipakai ulang sebagai allow-list. Lookup stok existing juga diperkeras: sebelumnya pakai `pluck()` yang diam-diam ambil SATU baris acak kalau ada lebih dari satu baris aktif per (variant, unit) — tidak berdampak di `main` (belum ada `warehouse_id`, selalu 1 baris), tapi snapshot testing sudah punya 345 kombinasi (variant, unit) dengan >1 baris aktif, dan modul gudang (fase2) memang per-warehouse. Diganti `GROUP BY unit_id / SUM()` yang deterministik, plus catatan jelas di kode: ini BUKAN restu untuk agregasi lintas-gudang — begitu modul gudang di-merge, ini wajib menerima `$warehouseId` seperti `allowedProductUnitIds()` versi fase2 sudah lakukan.

## Test

- `tests/Unit/UnitRollUpTest.php`: skenario existing-aware baru (termasuk reproduksi persis kasus HKCP60P secara pure-logic).
- `tests/Regression/ProductionOutputRollUpIgnoredExistingStockTest.php`: reproduksi end-to-end lewat `/accProduction`, gagal di baseline dan lulus setelah fix.
- `tests/Regression/ProductionOutputCascadesThroughAMissingMiddleUnitTest.php`: memastikan cascading tetap sampai ke level teratas walau level tengah tidak punya baris stok sama sekali, dan pre-check konfirmasi hanya menyebutkan baris yang benar-benar dibuat.
- Seluruh suite `Regression/`, `Workflow/`, `DatabaseTransaction/`, `Unit/` dijalankan ulang berkali-kali sepanjang PR ini: 15 kegagalan pre-existing identik dengan baseline (tidak terkait perubahan ini), tidak ada regresi baru.

## Catatan

- `fase2/main` punya bug yang sama persis di `ProductUnitStock::addQty()` (belum diperbaiki) — **sengaja tidak disentuh di PR ini**, akan diporting saat merge fase2 → main nanti.

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)
