### PR TITLE
feat: perintah audit read-only untuk stok yang stuck under-rolled sebelum #87

### DIFF
--- a/app/Console/Commands/AuditStuckUnitRollUpCommand.php
+++ b/app/Console/Commands/AuditStuckUnitRollUpCommand.php
@@ -1,0 +1,238 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Product;
+use App\Models\ProductStock;
+use App\Models\ProductVariant;
+use App\Models\Supplies;
+use App\Models\SuppliesStock;
+use App\Models\Unit;
+use App\Support\UnitRollUp;
+use Illuminate\Console\Command;
+
+/**
+ * READ-ONLY. GitHub #87 fixed the roll-up logic going forward, but the fix itself never touches a
+ * stock row — it only self-heals a row the NEXT time a stock-in transaction credits it (see the
+ * conversation this command was born from: HKCP60P self-healed because the user's own test
+ * production WAS such a transaction, not because of any migration). A product/bahan with the same
+ * stuck-over-ratio condition that never gets another stock-in transaction (or a Stock Opname, which
+ * independently recomputes via the same collapse() primitive this command reuses) stays wrong
+ * indefinitely and silently.
+ *
+ * This scans every product/bahan with more than one active stock row and asks
+ * `UnitRollUp::collapseProduct()`/`collapseSupplies()` — the exact primitive Stock Opname already
+ * uses to decide the canonical breakdown — "given what's ACTUALLY sitting in each unit's row right
+ * now, what SHOULD it be?". Any row where the answer differs from what's stored is exactly
+ * HKCP60P's situation, sitting unrepaired.
+ *
+ * Writes NOTHING. Safe to run directly against production. This is a diagnostic only; a --fix mode
+ * is a deliberate separate step, not bundled here.
+ */
+class AuditStuckUnitRollUpCommand extends Command
+{
+    protected $signature = 'stock:audit-rollup {--json : Output as JSON instead of a table}';
+
+    protected $description = 'READ-ONLY: find product/bahan stock rows stuck under-rolled from before GitHub #87 (writes nothing)';
+
+    public function handle(): int
+    {
+        $unitNames = Unit::pluck('unit_name', 'unit_id');
+
+        $productFindings = $this->auditProducts($unitNames);
+        $suppliesFindings = $this->auditSupplies($unitNames);
+
+        if ($this->option('json')) {
+            $this->line(json_encode([
+                'products' => $productFindings,
+                'supplies' => $suppliesFindings,
+            ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+            return self::SUCCESS;
+        }
+
+        $this->reportProducts($productFindings);
+        $this->reportSupplies($suppliesFindings);
+
+        $total = count($productFindings) + count($suppliesFindings);
+        $this->newLine();
+        if ($total === 0) {
+            $this->info('Tidak ditemukan baris stok yang stuck under-rolled. Semua sudah konsisten dengan tangga satuannya.');
+        } else {
+            $this->warn("Ditemukan {$total} baris produk/bahan yang stuck under-rolled (lihat detail di atas). Tidak ada yang ditulis -- ini murni laporan.");
+        }
+
+        return self::SUCCESS;
+    }
+
+    /** @return array<int, array{id:int,label:string,before:array<int,int>,after:array<int,int>}> */
+    private function auditProducts($unitNames): array
+    {
+        $variantIds = ProductStock::where('status', 1)
+            ->select('product_variant_id')
+            ->groupBy('product_variant_id')
+            ->havingRaw('COUNT(*) > 1')
+            ->pluck('product_variant_id');
+
+        $findings = [];
+
+        foreach ($variantIds->chunk(200) as $chunk) {
+            $stocksByVariant = ProductStock::where('status', 1)
+                ->whereIn('product_variant_id', $chunk)
+                ->get()
+                ->groupBy('product_variant_id');
+
+            foreach ($stocksByVariant as $variantId => $stocks) {
+                $qtyByUnit = $stocks->pluck('ps_stock', 'unit_id')
+                    ->map(fn ($q) => (int) $q)
+                    ->all();
+
+                // collapse() returns ABSOLUTE canonical values (same contract Stock Opname writes
+                // directly), not deltas -- diff straight against what's actually stored.
+                $collapsed = UnitRollUp::collapseProduct((int) $variantId, $qtyByUnit);
+                if ($collapsed === []) {
+                    continue;
+                }
+
+                $after = $qtyByUnit;
+                $changed = false;
+                foreach ($collapsed as $credit) {
+                    $unitId = (int) $credit['unit_id'];
+                    if (($qtyByUnit[$unitId] ?? 0) !== (int) $credit['qty']) {
+                        $changed = true;
+                    }
+                    $after[$unitId] = (int) $credit['qty'];
+                }
+
+                if (! $changed) {
+                    continue;
+                }
+
+                $pv = ProductVariant::find($variantId);
+                $product = $pv ? Product::find($pv->product_id) : null;
+                $label = trim(($product->product_name ?? '').' '.($pv->product_variant_name ?? ''));
+                $sku = $pv->product_variant_sku ?? '-';
+
+                $findings[] = [
+                    'id' => (int) $variantId,
+                    'sku' => $sku,
+                    'label' => $label !== '' ? $label : "id {$variantId}",
+                    'before' => $this->withUnitNames($qtyByUnit, $unitNames),
+                    'after' => $this->withUnitNames($after, $unitNames),
+                ];
+            }
+        }
+
+        return $findings;
+    }
+
+    /** @return array<int, array{id:int,label:string,before:array<int,int>,after:array<int,int>}> */
+    private function auditSupplies($unitNames): array
+    {
+        $suppliesIds = SuppliesStock::where('status', 1)
+            ->select('supplies_id')
+            ->groupBy('supplies_id')
+            ->havingRaw('COUNT(*) > 1')
+            ->pluck('supplies_id');
+
+        $findings = [];
+
+        foreach ($suppliesIds->chunk(200) as $chunk) {
+            $stocksBySupplies = SuppliesStock::where('status', 1)
+                ->whereIn('supplies_id', $chunk)
+                ->get()
+                ->groupBy('supplies_id');
+
+            foreach ($stocksBySupplies as $suppliesId => $stocks) {
+                $qtyByUnit = $stocks->pluck('ss_stock', 'unit_id')
+                    ->map(fn ($q) => (int) $q)
+                    ->all();
+
+                $collapsed = UnitRollUp::collapseSupplies((int) $suppliesId, $qtyByUnit);
+                if ($collapsed === []) {
+                    continue;
+                }
+
+                $after = $qtyByUnit;
+                $changed = false;
+                foreach ($collapsed as $credit) {
+                    $unitId = (int) $credit['unit_id'];
+                    if (($qtyByUnit[$unitId] ?? 0) !== (int) $credit['qty']) {
+                        $changed = true;
+                    }
+                    $after[$unitId] = (int) $credit['qty'];
+                }
+
+                if (! $changed) {
+                    continue;
+                }
+
+                $supplies = Supplies::find($suppliesId);
+
+                $findings[] = [
+                    'id' => (int) $suppliesId,
+                    'sku' => '-',
+                    'label' => $supplies->supplies_name ?? "id {$suppliesId}",
+                    'before' => $this->withUnitNames($qtyByUnit, $unitNames),
+                    'after' => $this->withUnitNames($after, $unitNames),
+                ];
+            }
+        }
+
+        return $findings;
+    }
+
+    /** @param  array<int,int>  $qtyByUnit */
+    private function withUnitNames(array $qtyByUnit, $unitNames): array
+    {
+        $out = [];
+        foreach ($qtyByUnit as $unitId => $qty) {
+            $out[$unitNames[$unitId] ?? "unit {$unitId}"] = $qty;
+        }
+
+        return $out;
+    }
+
+    private function reportProducts(array $findings): void
+    {
+        $this->info('=== Produk yang stuck under-rolled ===');
+        if ($findings === []) {
+            $this->line('(tidak ada)');
+
+            return;
+        }
+
+        foreach ($findings as $f) {
+            $this->line("- [{$f['sku']}] {$f['label']} (product_variant_id={$f['id']})");
+            $this->line('    sekarang : '.$this->formatBreakdown($f['before']));
+            $this->line('    seharusnya: '.$this->formatBreakdown($f['after']));
+        }
+    }
+
+    private function reportSupplies(array $findings): void
+    {
+        $this->newLine();
+        $this->info('=== Bahan yang stuck under-rolled ===');
+        if ($findings === []) {
+            $this->line('(tidak ada)');
+
+            return;
+        }
+
+        foreach ($findings as $f) {
+            $this->line("- {$f['label']} (supplies_id={$f['id']})");
+            $this->line('    sekarang : '.$this->formatBreakdown($f['before']));
+            $this->line('    seharusnya: '.$this->formatBreakdown($f['after']));
+        }
+    }
+
+    private function formatBreakdown(array $breakdown): string
+    {
+        $parts = [];
+        foreach ($breakdown as $unitName => $qty) {
+            $parts[] = "{$qty} {$unitName}";
+        }
+
+        return implode(', ', $parts);
+    }
+}

--- a/docs/audit-stuck-unit-rollup-github87.sql
+++ b/docs/audit-stuck-unit-rollup-github87.sql
@@ -1,0 +1,212 @@
+-- Audit: stock stuck under-rolled from before GitHub #87 (unit roll-up fix, PR #88)
+-- ============================================================================
+-- READ-ONLY. Every statement below is a SELECT. Nothing is written, nothing is locked beyond a
+-- normal read. Safe to run directly against production in any SQL client (phpMyAdmin, Adminer,
+-- TablePlus, `mysql` CLI, ...) -- no artisan/PHP access required.
+--
+-- Why this exists: GitHub #87 fixed the unit roll-up logic (App\Support\UnitRollUp) going forward,
+-- but the fix is pure code -- it never touches a stock row on its own. It only changes what happens
+-- the NEXT TIME a stock-in transaction (production ACC, PO receipt, product-issue restore, Sales
+-- Order revert) credits that specific row, or the next time a Stock Opname recomputes it. Any
+-- product/bahan that was ALREADY stuck over-ratio before the fix, and hasn't been touched by one of
+-- those since, stays wrong indefinitely and silently. This finds every one of those rows right now.
+--
+-- What "stuck" means, concretely: e.g. 1 DOS = 24 Piece, but a product's Piece-level row shows 24
+-- (or more) while its DOS-level row never absorbed it -- the exact SKU HKCP60P bug that prompted
+-- #87 (11 DOS + 20 Piece, +4 Piece production should have become 12 DOS + 0 Piece, stayed
+-- 11 DOS + 24 Piece).
+--
+-- How it decides "should_be": mirrors App\Support\UnitRollUp::collapse() -- the SAME primitive
+-- Stock Opname already uses to decide a product's canonical unit breakdown -- not a separate,
+-- independently-invented rule. Cross-validated against UnitRollUp::collapseProduct()/
+-- collapseSupplies() on several constructed scenarios (a simple 2-unit combine, a full 3-level
+-- cascade, and the trickiest case: an entered top-level unit that must stay UNTOUCHED because an
+-- intermediate unit has no active stock row at all -- rolling up can only ever move stock into a
+-- unit that already has its own row, same policy as every other roll-up call site) before being
+-- handed over; all matched exactly. See PR #89 and cdocs/... GitHub #87 for the full history.
+--
+-- Reading the output: `current_*_qty` is what's stored right now; `should_be_*_qty` is what
+-- UnitRollUp's own logic says it should be. A row only appears here if those two differ -- i.e.
+-- every row returned is currently wrong. Nothing is flagged for a product/bahan with only one
+-- active stock row (there's nothing to roll into) or where an intermediate unit has no active row
+-- (rolling up cannot reach past that gap, by the same design as every other roll-up call site).
+--
+-- This is a diagnostic only. It deliberately does NOT fix anything -- decide what to do with the
+-- results (an intentional --fix mode in a future artisan command, a manual correction, or leaving
+-- it for the next transaction/opname to self-heal) as a separate step.
+-- ============================================================================
+
+
+-- ============================================================================
+-- PART 1: PRODUCTS (product_stocks / product_relations)
+-- ============================================================================
+WITH RECURSIVE
+chain AS (
+    SELECT product_variant_id, pr_unit_id_2 AS small_unit, pr_unit_id_1 AS big_unit, pr_unit_value_2 AS ratio
+    FROM product_relations WHERE status = 1
+),
+entered AS (
+    SELECT product_variant_id, unit_id, ps_stock AS qty
+    FROM product_stocks WHERE status = 1
+),
+multipliers AS (
+    -- Base case: units that are a "small" unit somewhere in their product's ladder but NEVER a
+    -- "big" one -- the true bottom of that product's own ladder, multiplier 1.
+    SELECT DISTINCT c.product_variant_id, c.small_unit AS unit_id, 1 AS multiplier
+    FROM chain c
+    WHERE NOT EXISTS (
+        SELECT 1 FROM chain c2
+        WHERE c2.product_variant_id = c.product_variant_id AND c2.big_unit = c.small_unit
+    )
+    UNION ALL
+    -- Recursive case: walk upward, each level's multiplier is the level below's times this hop's ratio.
+    SELECT m.product_variant_id, c.big_unit, m.multiplier * c.ratio
+    FROM multipliers m
+    JOIN chain c ON c.product_variant_id = m.product_variant_id AND c.small_unit = m.unit_id
+),
+entered_with_mult AS (
+    SELECT e.product_variant_id, e.unit_id, e.qty, mu.multiplier
+    FROM entered e
+    JOIN multipliers mu ON mu.product_variant_id = e.product_variant_id AND mu.unit_id = e.unit_id
+),
+start_point AS (
+    -- The smallest unit that ACTUALLY has an active stock row -- collapse()'s starting point is
+    -- never the ladder's absolute bottom, it's the smallest unit really touched (GitHub #78 rule:
+    -- never fabricate a value for a unit smaller than the smallest one actually filled).
+    SELECT product_variant_id, start_unit, start_qty FROM (
+        SELECT ewm.product_variant_id, ewm.unit_id AS start_unit, ewm.qty AS start_qty,
+               ROW_NUMBER() OVER (PARTITION BY ewm.product_variant_id ORDER BY ewm.multiplier ASC, ewm.unit_id ASC) AS rn
+        FROM entered_with_mult ewm
+    ) t WHERE rn = 1
+),
+walk AS (
+    SELECT sp.product_variant_id, sp.start_unit AS unit_id, sp.start_qty AS carry, 0 AS depth
+    FROM start_point sp
+
+    UNION ALL
+
+    -- Can only continue to the next unit up if IT has an active row too (INNER JOIN to `entered`)
+    -- -- this is the exact condition that stops the walk dead at a gap, leaving anything above it
+    -- (even if entered) completely untouched, matching UnitRollUp::plan()/collapse()'s
+    -- `isset($allowed[...])` gate precisely.
+    SELECT w.product_variant_id, c.big_unit AS unit_id,
+           FLOOR(w.carry / c.ratio) + big_stock.qty AS carry,
+           w.depth + 1
+    FROM walk w
+    JOIN chain c ON c.product_variant_id = w.product_variant_id AND c.small_unit = w.unit_id
+    JOIN entered big_stock ON big_stock.product_variant_id = w.product_variant_id AND big_stock.unit_id = c.big_unit
+    WHERE c.ratio > 0 AND w.carry >= c.ratio AND w.depth < 20 -- 20-hop guard, same bound as the PHP walkers
+),
+walk_with_next AS (
+    SELECT w.*,
+           ch.ratio AS ratio_up,
+           EXISTS (
+               SELECT 1 FROM walk w2
+               WHERE w2.product_variant_id = w.product_variant_id AND w2.depth = w.depth + 1
+           ) AS has_next
+    FROM walk w
+    LEFT JOIN chain ch ON ch.product_variant_id = w.product_variant_id AND ch.small_unit = w.unit_id
+),
+result AS (
+    -- If the walk continued past this level, the remainder stays; if this was the last level it
+    -- reached, everything carried into it stays here in full.
+    SELECT product_variant_id, unit_id,
+           CASE WHEN has_next THEN carry % ratio_up ELSE carry END AS canonical_qty
+    FROM walk_with_next
+)
+SELECT
+    e.product_variant_id,
+    pv.product_variant_sku AS sku,
+    TRIM(CONCAT(COALESCE(p.product_name, ''), ' ', COALESCE(pv.product_variant_name, ''))) AS product_name,
+    u.unit_name,
+    e.unit_id,
+    e.qty AS current_qty,
+    r.canonical_qty AS should_be_qty
+FROM entered e
+JOIN result r ON r.product_variant_id = e.product_variant_id AND r.unit_id = e.unit_id
+LEFT JOIN product_variants pv ON pv.product_variant_id = e.product_variant_id
+LEFT JOIN products p ON p.product_id = pv.product_id
+LEFT JOIN units u ON u.unit_id = e.unit_id
+WHERE e.qty <> r.canonical_qty
+ORDER BY e.product_variant_id, e.unit_id;
+
+
+-- ============================================================================
+-- PART 2: BAHAN / SUPPLIES (supplies_stocks / supplies_relations)
+-- Identical logic to Part 1, mirrored onto the supplies-side tables.
+-- ============================================================================
+WITH RECURSIVE
+chain AS (
+    SELECT supplies_id, su_id_2 AS small_unit, su_id_1 AS big_unit, sr_value_2 AS ratio
+    FROM supplies_relations WHERE status = 1
+),
+entered AS (
+    SELECT supplies_id, unit_id, ss_stock AS qty
+    FROM supplies_stocks WHERE status = 1
+),
+multipliers AS (
+    SELECT DISTINCT c.supplies_id, c.small_unit AS unit_id, 1 AS multiplier
+    FROM chain c
+    WHERE NOT EXISTS (
+        SELECT 1 FROM chain c2
+        WHERE c2.supplies_id = c.supplies_id AND c2.big_unit = c.small_unit
+    )
+    UNION ALL
+    SELECT m.supplies_id, c.big_unit, m.multiplier * c.ratio
+    FROM multipliers m
+    JOIN chain c ON c.supplies_id = m.supplies_id AND c.small_unit = m.unit_id
+),
+entered_with_mult AS (
+    SELECT e.supplies_id, e.unit_id, e.qty, mu.multiplier
+    FROM entered e
+    JOIN multipliers mu ON mu.supplies_id = e.supplies_id AND mu.unit_id = e.unit_id
+),
+start_point AS (
+    SELECT supplies_id, start_unit, start_qty FROM (
+        SELECT ewm.supplies_id, ewm.unit_id AS start_unit, ewm.qty AS start_qty,
+               ROW_NUMBER() OVER (PARTITION BY ewm.supplies_id ORDER BY ewm.multiplier ASC, ewm.unit_id ASC) AS rn
+        FROM entered_with_mult ewm
+    ) t WHERE rn = 1
+),
+walk AS (
+    SELECT sp.supplies_id, sp.start_unit AS unit_id, sp.start_qty AS carry, 0 AS depth
+    FROM start_point sp
+
+    UNION ALL
+
+    SELECT w.supplies_id, c.big_unit AS unit_id,
+           FLOOR(w.carry / c.ratio) + big_stock.qty AS carry,
+           w.depth + 1
+    FROM walk w
+    JOIN chain c ON c.supplies_id = w.supplies_id AND c.small_unit = w.unit_id
+    JOIN entered big_stock ON big_stock.supplies_id = w.supplies_id AND big_stock.unit_id = c.big_unit
+    WHERE c.ratio > 0 AND w.carry >= c.ratio AND w.depth < 20
+),
+walk_with_next AS (
+    SELECT w.*,
+           ch.ratio AS ratio_up,
+           EXISTS (
+               SELECT 1 FROM walk w2
+               WHERE w2.supplies_id = w.supplies_id AND w2.depth = w.depth + 1
+           ) AS has_next
+    FROM walk w
+    LEFT JOIN chain ch ON ch.supplies_id = w.supplies_id AND ch.small_unit = w.unit_id
+),
+result AS (
+    SELECT supplies_id, unit_id,
+           CASE WHEN has_next THEN carry % ratio_up ELSE carry END AS canonical_qty
+    FROM walk_with_next
+)
+SELECT
+    e.supplies_id,
+    s.supplies_name,
+    u.unit_name,
+    e.unit_id,
+    e.qty AS current_qty,
+    r.canonical_qty AS should_be_qty
+FROM entered e
+JOIN result r ON r.supplies_id = e.supplies_id AND r.unit_id = e.unit_id
+LEFT JOIN supplies s ON s.supplies_id = e.supplies_id
+LEFT JOIN units u ON u.unit_id = e.unit_id
+WHERE e.qty <> r.canonical_qty
+ORDER BY e.supplies_id, e.unit_id;

--- a/tests/Regression/AuditStuckUnitRollUpCommandTest.php
+++ b/tests/Regression/AuditStuckUnitRollUpCommandTest.php
@@ -1,0 +1,202 @@
+<?php
+
+namespace Tests\Regression;
+
+use App\Models\Category;
+use App\Models\Product;
+use App\Models\ProductRelation;
+use App\Models\ProductStock;
+use App\Models\ProductVariant;
+use App\Models\Supplies;
+use App\Models\SuppliesRelation;
+use App\Models\SuppliesStock;
+use Illuminate\Support\Facades\Artisan;
+use Tests\TestCase;
+
+/**
+ * `stock:audit-rollup` (born from a direct question, 2026-08-29, after GitHub #87 shipped: "if the
+ * DB is never touched by this fix, does the bug recur?" — answer: no NEW instances, but any row
+ * already stuck over-ratio from BEFORE the fix stays wrong until something transacts against it
+ * again). This locks in that the command finds a stuck row, leaves a healthy one alone, and — since
+ * it may run directly against production — never writes anything.
+ */
+class AuditStuckUnitRollUpCommandTest extends TestCase
+{
+    private const PIECE_UNIT_ID = 9;
+    private const DOS_UNIT_ID = 7;
+    private const WAREHOUSE_ID = 1;
+
+    public function test_finds_a_stuck_product_row_and_leaves_a_healthy_one_out_of_the_report(): void
+    {
+        $category = new Category();
+        $category->category_name = 'Audit Command Regression Category';
+        $category->status = 1;
+        $category->save();
+
+        // --- STUCK fixture: 24 Piece sitting there, 1 DOS = 24 Piece, DOS row already exists at 11.
+        $stuckProduct = new Product();
+        $stuckProduct->product_name = 'Audit Command Stuck Product';
+        $stuckProduct->category_id = $category->category_id;
+        $stuckProduct->product_unit = json_encode([self::PIECE_UNIT_ID]);
+        $stuckProduct->unit_id = self::PIECE_UNIT_ID;
+        $stuckProduct->status = 1;
+        $stuckProduct->save();
+
+        $stuckVariant = new ProductVariant();
+        $stuckVariant->product_id = $stuckProduct->product_id;
+        $stuckVariant->product_variant_name = 'Audit Command Stuck Variant';
+        $stuckVariant->product_variant_sku = 'WF-AUDIT-STUCK-'.uniqid();
+        $stuckVariant->product_variant_price = 0;
+        $stuckVariant->status = 1;
+        $stuckVariant->save();
+
+        $stuckPiece = new ProductStock();
+        $stuckPiece->product_id = $stuckProduct->product_id;
+        $stuckPiece->product_variant_id = $stuckVariant->product_variant_id;
+        $stuckPiece->unit_id = self::PIECE_UNIT_ID;
+        $stuckPiece->warehouse_id = self::WAREHOUSE_ID;
+        $stuckPiece->ps_stock = 24; // stuck: should have rolled into 1 more DOS
+        $stuckPiece->status = 1;
+        $stuckPiece->save();
+
+        $stuckDos = new ProductStock();
+        $stuckDos->product_id = $stuckProduct->product_id;
+        $stuckDos->product_variant_id = $stuckVariant->product_variant_id;
+        $stuckDos->unit_id = self::DOS_UNIT_ID;
+        $stuckDos->warehouse_id = self::WAREHOUSE_ID;
+        $stuckDos->ps_stock = 11;
+        $stuckDos->status = 1;
+        $stuckDos->save();
+
+        $stuckRelation = new ProductRelation();
+        $stuckRelation->product_variant_id = $stuckVariant->product_variant_id;
+        $stuckRelation->pr_unit_id_1 = self::DOS_UNIT_ID;
+        $stuckRelation->pr_unit_value_1 = 1;
+        $stuckRelation->pr_unit_id_2 = self::PIECE_UNIT_ID;
+        $stuckRelation->pr_unit_value_2 = 24;
+        $stuckRelation->pr_default = 0;
+        $stuckRelation->status = 1;
+        $stuckRelation->save();
+
+        // --- HEALTHY control fixture: already correctly rolled up, must NOT be reported.
+        $healthyProduct = new Product();
+        $healthyProduct->product_name = 'Audit Command Healthy Product';
+        $healthyProduct->category_id = $category->category_id;
+        $healthyProduct->product_unit = json_encode([self::PIECE_UNIT_ID]);
+        $healthyProduct->unit_id = self::PIECE_UNIT_ID;
+        $healthyProduct->status = 1;
+        $healthyProduct->save();
+
+        $healthyVariant = new ProductVariant();
+        $healthyVariant->product_id = $healthyProduct->product_id;
+        $healthyVariant->product_variant_name = 'Audit Command Healthy Variant';
+        $healthyVariant->product_variant_sku = 'WF-AUDIT-HEALTHY-'.uniqid();
+        $healthyVariant->product_variant_price = 0;
+        $healthyVariant->status = 1;
+        $healthyVariant->save();
+
+        $healthyPiece = new ProductStock();
+        $healthyPiece->product_id = $healthyProduct->product_id;
+        $healthyPiece->product_variant_id = $healthyVariant->product_variant_id;
+        $healthyPiece->unit_id = self::PIECE_UNIT_ID;
+        $healthyPiece->warehouse_id = self::WAREHOUSE_ID;
+        $healthyPiece->ps_stock = 5; // below the ratio, correctly left at Piece
+        $healthyPiece->status = 1;
+        $healthyPiece->save();
+
+        $healthyDos = new ProductStock();
+        $healthyDos->product_id = $healthyProduct->product_id;
+        $healthyDos->product_variant_id = $healthyVariant->product_variant_id;
+        $healthyDos->unit_id = self::DOS_UNIT_ID;
+        $healthyDos->warehouse_id = self::WAREHOUSE_ID;
+        $healthyDos->ps_stock = 3;
+        $healthyDos->status = 1;
+        $healthyDos->save();
+
+        $healthyRelation = new ProductRelation();
+        $healthyRelation->product_variant_id = $healthyVariant->product_variant_id;
+        $healthyRelation->pr_unit_id_1 = self::DOS_UNIT_ID;
+        $healthyRelation->pr_unit_value_1 = 1;
+        $healthyRelation->pr_unit_id_2 = self::PIECE_UNIT_ID;
+        $healthyRelation->pr_unit_value_2 = 24;
+        $healthyRelation->pr_default = 0;
+        $healthyRelation->status = 1;
+        $healthyRelation->save();
+
+        Artisan::call('stock:audit-rollup', ['--json' => true]);
+        $output = json_decode(Artisan::output(), true);
+
+        $stuckIds = array_column($output['products'], 'id');
+        $this->assertContains($stuckVariant->product_variant_id, $stuckIds, 'the stuck product must be reported');
+        $this->assertNotContains($healthyVariant->product_variant_id, $stuckIds, 'the already-correct product must NOT be reported');
+
+        $stuckEntry = collect($output['products'])->firstWhere('id', $stuckVariant->product_variant_id);
+        $this->assertSame(24, $stuckEntry['before']['Piece']);
+        $this->assertSame(11, $stuckEntry['before']['DOS']);
+        $this->assertSame(0, $stuckEntry['after']['Piece']);
+        $this->assertSame(12, $stuckEntry['after']['DOS']);
+
+        // The whole point: this is a diagnostic. It must never write anything, anywhere.
+        $stuckPiece->refresh();
+        $stuckDos->refresh();
+        $healthyPiece->refresh();
+        $healthyDos->refresh();
+        $this->assertSame(24, $stuckPiece->ps_stock, 'read-only command must not touch the stuck row');
+        $this->assertSame(11, $stuckDos->ps_stock, 'read-only command must not touch the stuck row');
+        $this->assertSame(5, $healthyPiece->ps_stock);
+        $this->assertSame(3, $healthyDos->ps_stock);
+    }
+
+    public function test_finds_a_stuck_supplies_row(): void
+    {
+        $liter = 3;
+        $drum = 5;
+
+        $supplies = new Supplies();
+        $supplies->supplies_name = 'Audit Command Stuck Supplies';
+        $supplies->supplies_unit = json_encode([$liter, $drum]);
+        $supplies->supplies_default_unit = $liter;
+        $supplies->status = 1;
+        $supplies->save();
+
+        $literStock = new SuppliesStock();
+        $literStock->supplies_id = $supplies->supplies_id;
+        $literStock->unit_id = $liter;
+        $literStock->warehouse_id = self::WAREHOUSE_ID;
+        $literStock->ss_stock = 250; // stuck: 1 Drum = 200 Liter, this should be 1 Drum + 50 Liter
+        $literStock->status = 1;
+        $literStock->save();
+
+        $drumStock = new SuppliesStock();
+        $drumStock->supplies_id = $supplies->supplies_id;
+        $drumStock->unit_id = $drum;
+        $drumStock->warehouse_id = self::WAREHOUSE_ID;
+        $drumStock->ss_stock = 2;
+        $drumStock->status = 1;
+        $drumStock->save();
+
+        $relation = new SuppliesRelation();
+        $relation->supplies_id = $supplies->supplies_id;
+        $relation->su_id_1 = $drum;
+        $relation->su_id_2 = $liter;
+        $relation->sr_value_1 = 1;
+        $relation->sr_value_2 = 200;
+        $relation->status = 1;
+        $relation->save();
+
+        Artisan::call('stock:audit-rollup', ['--json' => true]);
+        $output = json_decode(Artisan::output(), true);
+
+        $entry = collect($output['supplies'])->firstWhere('id', $supplies->supplies_id);
+        $this->assertNotNull($entry, 'the stuck supplies row must be reported');
+        $this->assertSame(250, $entry['before']['Liter']);
+        $this->assertSame(2, $entry['before']['Drum']);
+        $this->assertSame(50, $entry['after']['Liter']);
+        $this->assertSame(3, $entry['after']['Drum']);
+
+        $literStock->refresh();
+        $drumStock->refresh();
+        $this->assertSame(250, $literStock->ss_stock, 'read-only command must not touch the stuck row');
+        $this->assertSame(2, $drumStock->ss_stock, 'read-only command must not touch the stuck row');
+    }
+}


### PR DESCRIPTION
## Latar belakang

Menjawab pertanyaan langsung setelah #87/PR #88 di-merge: **fix #87 murni perubahan kode, tidak pernah menyentuh baris stok mana pun sendiri.** Ia hanya mengubah apa yang terjadi PADA SAAT ADA transaksi stok-masuk baru (ACC produksi, penerimaan PO, retur produk, revert Sales Order) yang mengkredit baris itu — atau saat Stock Opname menghitung ulang produk itu.

Produk/bahan yang SUDAH stuck over-ratio dari SEBELUM fix ini, dan tidak pernah tersentuh transaksi lagi, akan tetap salah selamanya secara diam-diam — tidak ada migration atau proses berkala yang memperbaikinya. SKU HKCP60P sendiri sembuh otomatis bukan karena migration apa pun, tapi karena produksi uji coba user DI PRODUCTION itu sendiri adalah transaksi yang men-trigger perbaikannya.

## Yang ditambahkan

`php artisan stock:audit-rollup` — **read-only**, tidak menulis apa pun ke database (dijamin lewat test). Menggunakan ulang `UnitRollUp::collapseProduct()`/`collapseSupplies()`, primitif yang sama persis dipakai Stock Opname, untuk menanyakan "diberikan angka yang BENAR-BENAR ada di setiap baris satuan produk/bahan ini sekarang, seharusnya seperti apa susunannya?" — lalu melaporkan baris mana pun yang jawabannya berbeda dari yang tersimpan. Itulah persis kondisi HKCP60P sebelum diperbaiki.

- `--json` untuk output scriptable.
- Aman dijalankan langsung di production untuk melihat skala masalah sebenarnya sebelum memutuskan remediasi apa pun.
- **Sengaja TIDAK menyertakan mode `--fix`** — itu keputusan terpisah, menyusul setelah tahu skalanya.

Sanity-check di data dev lokal menemukan 1 baris nyata yang stuck (bahan Hikari Greentech, 3000 Piece rata yang seharusnya 166 DOS + 12 Piece) — bukan cuma fixture buatan test.

## Test

`tests/Regression/AuditStuckUnitRollUpCommandTest.php`: 1 skenario produk stuck + 1 kontrol sehat (harus TIDAK dilaporkan), 1 skenario bahan stuck — semua memverifikasi angka before/after yang benar DAN bahwa tidak ada nilai stok yang berubah setelah command dijalankan.

## Catatan proses

Commit ini sempat tidak sengaja langsung ter-push ke `main` tanpa PR (checkout lokal ikut pindah ke `main` setelah PR #88 di-merge, terlewat sebelum commit). Sudah di-revert bersih di `main` (`git revert`, tidak destruktif) dan dikerjakan ulang di branch ini untuk melalui review yang semestinya.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
