### PR TITLE
Batch 12: merge main → fase2/main — roll-up satuan existing-aware (#87), audit stok stuck (#89), heal stok saat Opname menunggu (#91), perbaikan modul getLog

### DIFF
--- a/app/Console/Commands/AuditStuckUnitRollUpCommand.php
+++ b/app/Console/Commands/AuditStuckUnitRollUpCommand.php
@@ -1,0 +1,254 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Product;
+use App\Models\ProductStock;
+use App\Models\ProductVariant;
+use App\Models\Supplies;
+use App\Models\SuppliesStock;
+use App\Models\Unit;
+use App\Support\UnitRollUp;
+use Illuminate\Console\Command;
+
+/**
+ * READ-ONLY. GitHub #87 fixed the roll-up logic going forward, but the fix itself never touches a
+ * stock row — it only self-heals a row the NEXT time a stock-in transaction credits it (see the
+ * conversation this command was born from: HKCP60P self-healed because the user's own test
+ * production WAS such a transaction, not because of any migration). A product/bahan with the same
+ * stuck-over-ratio condition that never gets another stock-in transaction (or a Stock Opname, which
+ * independently recomputes via the same collapse() primitive this command reuses) stays wrong
+ * indefinitely and silently.
+ *
+ * This scans every product/bahan with more than one active stock row PER WAREHOUSE and asks
+ * `UnitRollUp::collapseProduct()`/`collapseSupplies()` — the exact primitive Stock Opname already
+ * uses to decide the canonical breakdown — "given what's ACTUALLY sitting in each unit's row right
+ * now IN THIS WAREHOUSE, what SHOULD it be?". Any row where the answer differs from what's stored
+ * is exactly HKCP60P's situation, sitting unrepaired.
+ *
+ * Ported from main's `349841b` (PR #89) — main has no warehouse concept for stock at all, so its
+ * version grouped by product_variant_id/supplies_id ALONE. Porting that as-is onto fase2/main would
+ * be a real false-positive generator: a variant with one unit's row in warehouse A and a different
+ * unit's row in warehouse B is completely healthy (two independent warehouses, nothing to roll up),
+ * but grouping globally would see ">1 row" and collapse them together as if they were one pool. This
+ * version groups by (variant, warehouse) / (supplies, warehouse) instead, using
+ * `withoutGlobalScope('active_warehouse')` to see every warehouse rather than just the ambient one.
+ *
+ * Writes NOTHING. Safe to run directly against production. This is a diagnostic only; a --fix mode
+ * is a deliberate separate step, not bundled here.
+ */
+class AuditStuckUnitRollUpCommand extends Command
+{
+    protected $signature = 'stock:audit-rollup {--json : Output as JSON instead of a table}';
+
+    protected $description = 'READ-ONLY: find product/bahan stock rows stuck under-rolled from before GitHub #87 (writes nothing)';
+
+    public function handle(): int
+    {
+        $unitNames = Unit::pluck('unit_name', 'unit_id');
+
+        $productFindings = $this->auditProducts($unitNames);
+        $suppliesFindings = $this->auditSupplies($unitNames);
+
+        if ($this->option('json')) {
+            $this->line(json_encode([
+                'products' => $productFindings,
+                'supplies' => $suppliesFindings,
+            ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+            return self::SUCCESS;
+        }
+
+        $this->reportProducts($productFindings);
+        $this->reportSupplies($suppliesFindings);
+
+        $total = count($productFindings) + count($suppliesFindings);
+        $this->newLine();
+        if ($total === 0) {
+            $this->info('Tidak ditemukan baris stok yang stuck under-rolled. Semua sudah konsisten dengan tangga satuannya.');
+        } else {
+            $this->warn("Ditemukan {$total} baris produk/bahan (per gudang) yang stuck under-rolled (lihat detail di atas). Tidak ada yang ditulis -- ini murni laporan.");
+        }
+
+        return self::SUCCESS;
+    }
+
+    /** @return array<int, array{id:int,warehouse_id:int,label:string,before:array<string,int>,after:array<string,int>}> */
+    private function auditProducts($unitNames): array
+    {
+        $groups = ProductStock::withoutGlobalScope('active_warehouse')
+            ->where('status', 1)
+            ->select('product_variant_id', 'warehouse_id')
+            ->groupBy('product_variant_id', 'warehouse_id')
+            ->havingRaw('COUNT(*) > 1')
+            ->get();
+
+        $findings = [];
+
+        foreach ($groups as $group) {
+            $variantId = (int) $group->product_variant_id;
+            $warehouseId = (int) $group->warehouse_id;
+
+            $stocks = ProductStock::withoutGlobalScope('active_warehouse')
+                ->where('status', 1)
+                ->where('product_variant_id', $variantId)
+                ->where('warehouse_id', $warehouseId)
+                ->get();
+
+            $qtyByUnit = $stocks->pluck('ps_stock', 'unit_id')
+                ->map(fn ($q) => (int) $q)
+                ->all();
+
+            // collapse() returns ABSOLUTE canonical values (same contract Stock Opname writes
+            // directly), not deltas -- diff straight against what's actually stored.
+            $collapsed = UnitRollUp::collapseProduct($variantId, $qtyByUnit, $warehouseId);
+            if ($collapsed === []) {
+                continue;
+            }
+
+            $after = $qtyByUnit;
+            $changed = false;
+            foreach ($collapsed as $credit) {
+                $unitId = (int) $credit['unit_id'];
+                if (($qtyByUnit[$unitId] ?? 0) !== (int) $credit['qty']) {
+                    $changed = true;
+                }
+                $after[$unitId] = (int) $credit['qty'];
+            }
+
+            if (! $changed) {
+                continue;
+            }
+
+            $pv = ProductVariant::find($variantId);
+            $product = $pv ? Product::find($pv->product_id) : null;
+            $label = trim(($product->product_name ?? '').' '.($pv->product_variant_name ?? ''));
+            $sku = $pv->product_variant_sku ?? '-';
+
+            $findings[] = [
+                'id' => $variantId,
+                'warehouse_id' => $warehouseId,
+                'sku' => $sku,
+                'label' => $label !== '' ? $label : "id {$variantId}",
+                'before' => $this->withUnitNames($qtyByUnit, $unitNames),
+                'after' => $this->withUnitNames($after, $unitNames),
+            ];
+        }
+
+        return $findings;
+    }
+
+    /** @return array<int, array{id:int,warehouse_id:int,label:string,before:array<string,int>,after:array<string,int>}> */
+    private function auditSupplies($unitNames): array
+    {
+        $groups = SuppliesStock::withoutGlobalScope('active_warehouse')
+            ->where('status', 1)
+            ->select('supplies_id', 'warehouse_id')
+            ->groupBy('supplies_id', 'warehouse_id')
+            ->havingRaw('COUNT(*) > 1')
+            ->get();
+
+        $findings = [];
+
+        foreach ($groups as $group) {
+            $suppliesId = (int) $group->supplies_id;
+            $warehouseId = (int) $group->warehouse_id;
+
+            $stocks = SuppliesStock::withoutGlobalScope('active_warehouse')
+                ->where('status', 1)
+                ->where('supplies_id', $suppliesId)
+                ->where('warehouse_id', $warehouseId)
+                ->get();
+
+            $qtyByUnit = $stocks->pluck('ss_stock', 'unit_id')
+                ->map(fn ($q) => (int) $q)
+                ->all();
+
+            $collapsed = UnitRollUp::collapseSupplies($suppliesId, $qtyByUnit, $warehouseId);
+            if ($collapsed === []) {
+                continue;
+            }
+
+            $after = $qtyByUnit;
+            $changed = false;
+            foreach ($collapsed as $credit) {
+                $unitId = (int) $credit['unit_id'];
+                if (($qtyByUnit[$unitId] ?? 0) !== (int) $credit['qty']) {
+                    $changed = true;
+                }
+                $after[$unitId] = (int) $credit['qty'];
+            }
+
+            if (! $changed) {
+                continue;
+            }
+
+            $supplies = Supplies::find($suppliesId);
+
+            $findings[] = [
+                'id' => $suppliesId,
+                'warehouse_id' => $warehouseId,
+                'sku' => '-',
+                'label' => $supplies->supplies_name ?? "id {$suppliesId}",
+                'before' => $this->withUnitNames($qtyByUnit, $unitNames),
+                'after' => $this->withUnitNames($after, $unitNames),
+            ];
+        }
+
+        return $findings;
+    }
+
+    /** @param  array<int,int>  $qtyByUnit */
+    private function withUnitNames(array $qtyByUnit, $unitNames): array
+    {
+        $out = [];
+        foreach ($qtyByUnit as $unitId => $qty) {
+            $out[$unitNames[$unitId] ?? "unit {$unitId}"] = $qty;
+        }
+
+        return $out;
+    }
+
+    private function reportProducts(array $findings): void
+    {
+        $this->info('=== Produk yang stuck under-rolled ===');
+        if ($findings === []) {
+            $this->line('(tidak ada)');
+
+            return;
+        }
+
+        foreach ($findings as $f) {
+            $this->line("- [{$f['sku']}] {$f['label']} (product_variant_id={$f['id']}, warehouse_id={$f['warehouse_id']})");
+            $this->line('    sekarang : '.$this->formatBreakdown($f['before']));
+            $this->line('    seharusnya: '.$this->formatBreakdown($f['after']));
+        }
+    }
+
+    private function reportSupplies(array $findings): void
+    {
+        $this->newLine();
+        $this->info('=== Bahan yang stuck under-rolled ===');
+        if ($findings === []) {
+            $this->line('(tidak ada)');
+
+            return;
+        }
+
+        foreach ($findings as $f) {
+            $this->line("- {$f['label']} (supplies_id={$f['id']}, warehouse_id={$f['warehouse_id']})");
+            $this->line('    sekarang : '.$this->formatBreakdown($f['before']));
+            $this->line('    seharusnya: '.$this->formatBreakdown($f['after']));
+        }
+    }
+
+    private function formatBreakdown(array $breakdown): string
+    {
+        $parts = [];
+        foreach ($breakdown as $unitName => $qty) {
+            $parts[] = "{$qty} {$unitName}";
+        }
+
+        return implode(', ', $parts);
+    }
+}

--- a/app/Http/Controllers/GeneralController.php
+++ b/app/Http/Controllers/GeneralController.php
@@ -70,8 +70,8 @@ class GeneralController extends Controller
      */
     function getLog(Request $req){
         $module = match ((int) $req->input('log_type')) {
-            1 => 'Daftar Produk',
-            2 => 'Daftar Bahan Mentah',
+            1 => 'Stok Produk',
+            2 => 'Stok Bahan Mentah',
             default => null,
         };
         if ($module === null || !RoleAccess::can(Session::get('user'), $module, 'view')) {

--- a/app/Http/Controllers/ProductionController.php
+++ b/app/Http/Controllers/ProductionController.php
@@ -893,14 +893,18 @@ class ProductionController extends Controller
         // membuat itu aman -- satuan yang belum punya baris dilaporkan di sini, dan barulah setelah
         // user menekan konfirmasi (confirm_create_stock) addQty() membuatnya. Caller lain yang
         // TIDAK punya langkah konfirmasi tetap memakai kebijakan ketat bawaan addQty().
+        //
+        // planProductOutput() (GH #87, 2026-08-30): existing-aware, sama seperti kredit
+        // sesungguhnya di addQty() di bawah -- preview ini tidak boleh berbeda dari yang benar-benar
+        // terjadi, jadi harus baca stok yang sudah ada juga, bukan cuma qty transaksi ini.
         $missingProductStockRows = [];
         foreach ($transferPlan['groups'] as $group) {
             foreach ($group['items'] as $output) {
-                $credits = UnitRollUp::plan(
-                    UnitRollUp::productChain((int) $output['product_variant_id']),
+                $credits = UnitRollUp::planProductOutput(
+                    (int) $output['product_variant_id'],
                     (int) $output['unit_id'],
                     (int) $output['qty'],
-                    UnitRollUp::ladderUnitIds((int) $output['product_variant_id'])
+                    (int) $mainWarehouse->id
                 );
 
                 foreach ($credits as $credit) {

--- a/app/Http/Controllers/StockController.php
+++ b/app/Http/Controllers/StockController.php
@@ -117,6 +117,12 @@ class StockController extends Controller
             // untuk draft: publish() sendiri yang menolak selama is_draft masih true.
             $lifecycle->publish(StockOpname::find($id));
 
+            // Sembuhkan stok live yang stuck under-rolled (mis. dari sebelum GitHub #87) untuk
+            // satuan yang TIDAK dihitung di dokumen ini -- lihat OpnameLifecycle::
+            // healUntouchedSystemStock(). Aman untuk draft: method-nya sendiri yang menolak
+            // selama is_draft masih true.
+            $lifecycle->healUntouchedSystemStock(StockOpname::find($id));
+
             return response()->json(['status' => 1, 'sto_id' => $id]);
         });
     }
@@ -211,7 +217,11 @@ class StockController extends Controller
         // dokumen keluar dari draft di sini -- inilah saat snapshot identitas dibekukan untuk
         // alur draft (tombol .btn-ajukan). Idempoten, jadi tidak masalah kalau dokumen ini
         // ternyata sudah pernah publish lewat insert.
-        (new OpnameLifecycle())->publish($sto->refresh());
+        $lifecycle = new OpnameLifecycle();
+        $lifecycle->publish($sto->refresh());
+        // Draft -> menunggu adalah momen yang sama seperti insert langsung non-draft: sembuhkan
+        // stok live yang stuck under-rolled untuk satuan yang tidak dihitung di dokumen ini.
+        $lifecycle->healUntouchedSystemStock($sto->refresh());
 
         return 1;
     }
@@ -894,6 +904,9 @@ class StockController extends Controller
             // draft ataupun langsung menunggu, sebelum publish() membekukan identitasnya.
             $lifecycle->rollUpUnits(StockOpnameBahan::find($id));
             $lifecycle->publish(StockOpnameBahan::find($id));
+            // Kembaran keputusan PM di insertStockOpname() Produk -- sembuhkan stok bahan yang
+            // stuck under-rolled untuk satuan yang tidak dihitung di dokumen ini.
+            $lifecycle->healUntouchedSystemStock(StockOpnameBahan::find($id));
 
             return response()->json(['status' => 1, 'stob_id' => $id]);
         });
@@ -974,7 +987,9 @@ class StockController extends Controller
         // NB (merged from main's efef95e, 2026-08-28): main called
         // (new StockOpnameBahan())->submitStockOpnameBahan($data), a model method that doesn't
         // exist in this tree -- see submitStockOpname()'s (Produk) matching note.
-        (new BahanOpnameLifecycle())->publish($stob->refresh());
+        $lifecycle = new BahanOpnameLifecycle();
+        $lifecycle->publish($stob->refresh());
+        $lifecycle->healUntouchedSystemStock($stob->refresh());
 
         return 1;
     }

--- a/app/Models/ProductIssuesDetail.php
+++ b/app/Models/ProductIssuesDetail.php
@@ -186,8 +186,13 @@ class ProductIssuesDetail extends Model
 
             // Level di atasnya dijamin punya baris stok aktif — UnitRollUp hanya menaikkan ke
             // satuan yang sudah punya baris (lihat allowedSuppliesUnitIds()).
+            //
+            // GitHub #87 fix (2026-08-30): plan() sekarang existing-aware, jadi kredit di sini bisa
+            // NEGATIF (stok lama di level itu ikut naik satuan bersama retur ini) -- dulu "<= 0"
+            // salah membuang kredit negatif itu. "+=" tetap benar untuk delta negatif, jadi cukup
+            // skip yang benar-benar nol.
             foreach ($naikLevel as $credit) {
-                if ($credit['qty'] <= 0) continue;
+                if ($credit['qty'] === 0) continue;
 
                 $row = SuppliesStock::where('supplies_id', $m->supplies_id)
                     ->where('unit_id', $credit['unit_id'])
@@ -203,6 +208,11 @@ class ProductIssuesDetail extends Model
             // stok "pindah" satuan tanpa penjelasan. Pola log-nya sama dengan bongkar di
             // stockCheck(): satuan asal keluar (cat 2), satuan hasil masuk (cat 1). Caller tetap
             // menulis log utamanya sendiri.
+            //
+            // $naik ($t->pid_qty - $base['qty']) tetap valid dan tetap >= 0 walau $base['qty'] kini
+            // bisa negatif (existing-aware): plan()'s conservation property menjamin
+            // qty - base['qty'] == jumlah gabungan naikLevel dalam satuan dasar, dan carry hasil
+            // pembagian selalu >= 0 -- lihat UnitRollUp::plan()'s docblock.
             if ($naikLevel !== []) {
                 $naik = (int) $t->pid_qty - (int) $base['qty'];
                 if ($naik > 0) {
@@ -212,13 +222,26 @@ class ProductIssuesDetail extends Model
                         'log_jumlah' => $naik, 'unit_id' => (int) $t->unit_id,
                     ]);
                 }
+                // Level PERANTARA (bukan base, bukan puncak) juga bisa punya kredit negatif kini --
+                // itu berarti stok lama DI LEVEL ITU ikut tergulung naik lagi ke level berikutnya,
+                // bukan cuma menyerap carry dari bawah. Catat sebagai keluar (cat 2) di level itu
+                // juga, supaya ledger konsisten di setiap level yang tersentuh, tidak cuma level
+                // base dan level yang bertambah.
                 foreach ($naikLevel as $credit) {
-                    if ($credit['qty'] <= 0) continue;
-                    (new LogStock())->insertLog([
-                        'log_date' => now(), 'log_kode' => '-', 'log_type' => 2, 'log_category' => 1,
-                        'log_item_id' => $m->supplies_id, 'log_notes' => 'Konversi unit (Hasil naik satuan)',
-                        'log_jumlah' => $credit['qty'], 'unit_id' => $credit['unit_id'],
-                    ]);
+                    if ($credit['qty'] === 0) continue;
+                    if ($credit['qty'] > 0) {
+                        (new LogStock())->insertLog([
+                            'log_date' => now(), 'log_kode' => '-', 'log_type' => 2, 'log_category' => 1,
+                            'log_item_id' => $m->supplies_id, 'log_notes' => 'Konversi unit (Hasil naik satuan)',
+                            'log_jumlah' => $credit['qty'], 'unit_id' => $credit['unit_id'],
+                        ]);
+                    } else {
+                        (new LogStock())->insertLog([
+                            'log_date' => now(), 'log_kode' => '-', 'log_type' => 2, 'log_category' => 2,
+                            'log_item_id' => $m->supplies_id, 'log_notes' => 'Konversi unit (Naik satuan)',
+                            'log_jumlah' => abs($credit['qty']), 'unit_id' => $credit['unit_id'],
+                        ]);
+                    }
                 }
             }
 

--- a/app/Models/PurchaseOrderDeliveryDetail.php
+++ b/app/Models/PurchaseOrderDeliveryDetail.php
@@ -82,8 +82,13 @@ class PurchaseOrderDeliveryDetail extends Model
 
             // Level di atasnya dijamin punya baris stok aktif — UnitRollUp hanya menaikkan ke
             // satuan yang sudah punya baris (lihat allowedSuppliesUnitIds()).
+            //
+            // GitHub #87 fix (2026-08-30): plan() sekarang existing-aware, jadi kredit di sini bisa
+            // NEGATIF (stok lama di level itu ikut naik satuan bersama penerimaan ini) -- dulu
+            // "<= 0" salah membuang kredit negatif itu, membuat stok lama tertinggal tanpa naik.
+            // "+=" tetap benar untuk delta negatif, jadi cukup skip yang benar-benar nol.
             foreach ($rollUp as $credit) {
-                if ($credit['qty'] <= 0) continue;
+                if ($credit['qty'] === 0) continue;
 
                 $row = SuppliesStock::where("supplies_id", "=", $sv->supplies_id)
                     ->where("unit_id", "=", $credit['unit_id'])

--- a/app/Support/ProductUnitStock.php
+++ b/app/Support/ProductUnitStock.php
@@ -1043,14 +1043,20 @@ class ProductUnitStock
     /**
      * Tambah stok di gudang (satuan yang sama, kecuali $rollUp). Buat baris stok jika belum ada.
      *
-     * $rollUp (merged from main's GH #19 + PR #75, 2026-08-28): kalau true, $qty di $unitId
-     * dinaikkan berjenjang lewat UnitRollUp::planProduct() sebelum dikredit -- 24 Piece yang
-     * exact-multiple dari rasio DOS/Sak masuk sebagai DOS/Sak, bukan menumpuk sebagai Piece.
-     * UnitRollUp hanya menaikkan ke satuan yang SUDAH punya baris ProductStock aktif, jadi tidak
-     * ada baris baru yang dibuat diam-diam oleh roll-up itu sendiri -- baris di satuan awal
-     * ($unitId) tetap dibuat otomatis seperti biasa kalau belum ada (lihat di bawah). Default
-     * false supaya caller lain (Stock Transfer, retur SO, dll -- lihat pemanggil addQty()
-     * lainnya) tetap kredit flat persis di satuan yang diminta, tanpa reinterpretasi.
+     * $rollUp (merged from main's GH #19 + PR #75, 2026-08-28; existing-aware since GH #87,
+     * 2026-08-30): kalau true, $qty di $unitId dinaikkan berjenjang lewat UnitRollUp::plan()
+     * sebelum dikredit -- 24 Piece yang exact-multiple dari rasio DOS/Sak masuk sebagai DOS/Sak,
+     * bukan menumpuk sebagai Piece. Sejak GH #87, plan() juga membaca stok yang SUDAH ada di tiap
+     * level (bukan cuma $qty transaksi ini): 20 Piece yang sudah ada + 4 Piece baru = 24 Piece
+     * digabung dan naik jadi 1 DOS, bukan diam-diam menumpuk lewat rasio selamanya. Itu bisa membuat
+     * kredit di satu level jadi NEGATIF (stok lama di level itu ikut naik bersama kredit baru) --
+     * ditangani di bawah dengan mencatatnya sebagai konversi satuan (keluar), bukan sebagai
+     * penambahan biasa. UnitRollUp hanya menaikkan ke satuan yang SUDAH punya baris ProductStock
+     * aktif secara default, jadi tidak ada baris baru yang dibuat diam-diam oleh roll-up itu
+     * sendiri -- baris di satuan awal ($unitId) tetap dibuat otomatis seperti biasa kalau belum ada
+     * (lihat di bawah). Default false supaya caller lain (Stock Transfer, retur SO, dll -- lihat
+     * pemanggil addQty() lainnya) tetap kredit flat persis di satuan yang diminta, tanpa
+     * reinterpretasi.
      *
      * @return array{ok: bool, message?: string}
      */
@@ -1069,36 +1075,59 @@ class ProductUnitStock
             return ['ok' => true];
         }
 
-        // Daftar "satuan yang boleh dikredit" (lihat UnitRollUp's design notes):
-        //  - default (null): HANYA satuan yang sudah punya baris stok DI GUDANG INI. $warehouseId
-        //    wajib diteruskan -- dihitung dari gudang aktif sesi malah bisa meloloskan satuan yang
-        //    tak punya baris di gudang tujuan, dan creditOneProductUnit() akan MEMBUAT baris itu
-        //    (persis yang dicegah allow-list-nya).
+        // Satu query melayani baik daftar "satuan yang boleh dikredit" (lihat UnitRollUp's design
+        // notes) MAUPUN stok yang sudah ada di tiap level (GH #87):
+        //  - default (null): HANYA satuan yang sudah punya baris stok DI GUDANG INI (kunci hasil
+        //    lookup ini). $warehouseId wajib diteruskan -- dihitung dari gudang aktif sesi malah
+        //    bisa meloloskan satuan yang tak punya baris di gudang tujuan, dan
+        //    creditOneProductUnit() akan MEMBUAT baris itu (persis yang dicegah allow-list-nya).
         //  - eksplisit: caller yang memang sengaja menyediakan baris baru dengan konfirmasi user
         //    lebih dulu (accProduction() + confirm_create_stock) meneruskan seluruh tangga satuan
-        //    lewat UnitRollUp::ladderUnitIds().
+        //    lewat UnitRollUp::ladderUnitIds() sebagai $rollUpAllowedUnitIds -- existing map di
+        //    bawah tetap dipakai untuk pembacaannya, hanya allow-list-nya yang berbeda.
+        $existing = UnitRollUp::existingProductStockByUnit($productVariantId, $warehouseId);
         $credits = $rollUp
             ? UnitRollUp::plan(
                 UnitRollUp::productChain($productVariantId),
                 $unitId,
                 (int) $qty,
-                $rollUpAllowedUnitIds ?? UnitRollUp::allowedProductUnitIds($productVariantId, $warehouseId)
+                $rollUpAllowedUnitIds ?? array_keys($existing),
+                $existing
             )
             : [['unit_id' => $unitId, 'qty' => $qty]];
 
         foreach ($credits as $credit) {
-            if ($credit['qty'] <= 0) {
+            $creditQty = (float) $credit['qty'];
+            if ($creditQty === 0.0) {
                 continue;
             }
-            self::creditOneProductUnit(
-                $warehouseId,
-                $productId,
-                $productVariantId,
-                (int) $credit['unit_id'],
-                (float) $credit['qty'],
-                $logCode,
-                $logNotes
-            );
+            if ($creditQty > 0) {
+                self::creditOneProductUnit(
+                    $warehouseId,
+                    $productId,
+                    $productVariantId,
+                    (int) $credit['unit_id'],
+                    $creditQty,
+                    $logCode,
+                    $logNotes
+                );
+            } else {
+                // GH #87: stok LAMA di level ini ikut tergulung naik ke level berikutnya bersama
+                // kredit baru -- catat sebagai konversi satuan keluar, bukan $logNotes asli (yang
+                // berarti "masuk"), supaya ledger tetap jelas kenapa baris ini turun tanpa transaksi
+                // keluar yang sebenarnya. Pasangannya (masuk di level atas) tercatat oleh iterasi
+                // lain di $credits lewat cabang di atas.
+                self::creditOneProductUnit(
+                    $warehouseId,
+                    $productId,
+                    $productVariantId,
+                    (int) $credit['unit_id'],
+                    $creditQty,
+                    $logCode,
+                    'Konversi unit (naik satuan)',
+                    2
+                );
+            }
         }
 
         self::clearCache();
@@ -1113,7 +1142,8 @@ class ProductUnitStock
         int $unitId,
         float $qty,
         string $logCode,
-        string $logNotes
+        string $logNotes,
+        int $logCategory = 1
     ): void {
         $rows = ProductStock::withoutGlobalScope('active_warehouse')
             ->where('status', 1)
@@ -1149,10 +1179,10 @@ class ProductUnitStock
             'log_date' => now(),
             'log_kode' => $logCode,
             'log_type' => 1,
-            'log_category' => 1,
+            'log_category' => $logCategory,
             'log_item_id' => $productVariantId,
             'log_notes' => $logNotes,
-            'log_jumlah' => $qty,
+            'log_jumlah' => abs($qty),
             'log_saldo' => (float) $row->ps_stock,
             'unit_id' => $unitId,
             'warehouse_id' => $warehouseId,

--- a/app/Support/StockOpname/BahanOpnameLifecycle.php
+++ b/app/Support/StockOpname/BahanOpnameLifecycle.php
@@ -2,6 +2,7 @@
 
 namespace App\Support\StockOpname;
 
+use App\Models\LogStock;
 use App\Models\Staff;
 use App\Models\StockOpnameBahanLine;
 use App\Models\Supplies;
@@ -120,6 +121,76 @@ class BahanOpnameLifecycle
                     'unit_id' => $credit['unit_id'],
                     'sobl_counted_qty' => $credit['qty'],
                     'sobl_notes' => $first->sobl_notes,
+                ]);
+            }
+        }
+    }
+
+    /**
+     * Kembaran persis OpnameLifecycle::healUntouchedSystemStock() (Produk), untuk Supplies. Lihat
+     * kelas itu untuk alasan lengkap -- termasuk kenapa gudangnya diambil dari DOKUMEN, bukan dari
+     * gudang aktif sesi (beda dari versi main, yang tidak punya konsep gudang sama sekali).
+     */
+    public function healUntouchedSystemStock($stob): void
+    {
+        if (! $stob || $stob->is_draft || $stob->is_old_version) {
+            return;
+        }
+
+        $lines = StockOpnameBahanLine::getLines($stob->stob_id)->groupBy('supplies_id');
+        $warehouseId = $stob->warehouse_id ?: null;
+
+        foreach ($lines as $suppliesId => $group) {
+            if (! $suppliesId) {
+                continue;
+            }
+
+            $touchedUnitIds = $group->filter(fn ($l) => $l->sobl_counted_qty !== null)
+                ->pluck('unit_id')->map(fn ($u) => (int) $u)->all();
+
+            $stocks = ($warehouseId !== null
+                    ? SuppliesStock::withoutGlobalScope('active_warehouse')->where('warehouse_id', $warehouseId)
+                    : SuppliesStock::query())
+                ->where('supplies_id', $suppliesId)
+                ->where('status', 1)
+                ->get();
+
+            $qtyByUnit = $stocks->pluck('ss_stock', 'unit_id')->map(fn ($q) => (int) $q)->all();
+            $collapsed = UnitRollUp::collapseSupplies((int) $suppliesId, $qtyByUnit, $warehouseId);
+            if ($collapsed === []) {
+                continue;
+            }
+
+            $stocksByUnit = $stocks->keyBy('unit_id');
+
+            foreach ($collapsed as $credit) {
+                $unitId = (int) $credit['unit_id'];
+                if (in_array($unitId, $touchedUnitIds, true)) {
+                    continue;
+                }
+
+                $stock = $stocksByUnit->get($unitId);
+                $before = $stock ? (int) $stock->ss_stock : 0;
+                $after = (int) $credit['qty'];
+                if (! $stock || $before === $after) {
+                    continue;
+                }
+
+                $delta = $after - $before;
+                $stock->ss_stock = $after;
+                $stock->save();
+
+                (new LogStock())->insertLog([
+                    'log_date' => now(),
+                    'log_kode' => $stob->stob_code,
+                    'log_type' => 2,
+                    'log_category' => $delta > 0 ? 1 : 2,
+                    'log_item_id' => $suppliesId,
+                    'log_notes' => 'Konversi unit dari Stock Opname Bahan (perbaikan stok tergulung) '.LogStock::actorSuffix(),
+                    'log_jumlah' => abs($delta),
+                    'log_saldo' => $after,
+                    'unit_id' => $unitId,
+                    'warehouse_id' => $warehouseId,
                 ]);
             }
         }

--- a/app/Support/StockOpname/OpnameLifecycle.php
+++ b/app/Support/StockOpname/OpnameLifecycle.php
@@ -2,6 +2,7 @@
 
 namespace App\Support\StockOpname;
 
+use App\Models\LogStock;
 use App\Models\Product;
 use App\Models\ProductStock;
 use App\Models\ProductVariant;
@@ -169,6 +170,94 @@ class OpnameLifecycle
                     'unit_id' => $credit['unit_id'],
                     'sol_counted_qty' => $credit['qty'],
                     'sol_notes' => $first->sol_notes,
+                ]);
+            }
+        }
+    }
+
+    /**
+     * Sembuhkan LIVE ps_stock produk yang ikut di dokumen ini SEBELUM dokumen mulai dipercaya --
+     * keputusan PM 2026-08-31: stok yang stuck under-rolled dari sebelum GitHub #87 (mis. 12 DOS +
+     * 24 Piece padahal 1 DOS = 24 Piece, seharusnya 13 DOS + 0 Piece) tetap salah selamanya kalau
+     * tidak ada transaksi stok-masuk lain yang kebetulan menyentuhnya (lihat docblock
+     * AuditStuckUnitRollUpCommand). Membuat Stock Opname adalah persis momen staf akan MEMPERCAYAI
+     * angka live itu, jadi sembuhkan di sini juga -- primitif yang sama (UnitRollUp::
+     * collapseProduct()) yang dipakai command audit itu dan rollUpUnits() di atas.
+     *
+     * HANYA menyentuh satuan yang TIDAK dihitung di dokumen ini (sol_counted_qty === null).
+     * Satuan yang sedang diisi staf akan ditimpa langsung oleh hasil hitungnya sendiri saat ACC
+     * (lihat accStockOpnameV2()), jadi menyembuhkannya di sini cuma kerja ganda yang percuma --
+     * dan tidak menyentuhnya menjaga efek method ini persis sebatas satuan yang memang diminta.
+     *
+     * Dipanggil dari insertStockOpname() (dokumen baru langsung menunggu) dan submitStockOpname()
+     * (draft -> menunggu). TIDAK dipanggil selama masih draft (dijaga is_draft di bawah) --
+     * idempoten, memanggilnya lagi pada produk yang sudah sembuh tidak mengubah apa pun lagi.
+     *
+     * Gudang DOKUMEN, bukan gudang aktif sesi (beda dari versi main, yang tidak punya konsep gudang
+     * sama sekali) -- alasan sama persis dengan freezeSystemQty()/rollUpUnits() di atas: staf yang
+     * menyimpan dokumen bisa punya gudang aktif yang berbeda dari gudang dokumennya, dan
+     * menyembuhkan stok gudang yang salah jauh lebih buruk daripada tidak menyembuhkan sama sekali.
+     */
+    public function healUntouchedSystemStock($sto): void
+    {
+        if (! $sto || $sto->is_draft || $sto->is_old_version) {
+            return;
+        }
+
+        $lines = StockOpnameLine::getLines($sto->sto_id)->groupBy('product_variant_id');
+        $warehouseId = $sto->warehouse_id ?: null;
+
+        foreach ($lines as $productVariantId => $group) {
+            if (! $productVariantId) {
+                continue;
+            }
+
+            $touchedUnitIds = $group->filter(fn ($l) => $l->sol_counted_qty !== null)
+                ->pluck('unit_id')->map(fn ($u) => (int) $u)->all();
+
+            $stocks = ($warehouseId !== null
+                    ? ProductStock::withoutGlobalScope('active_warehouse')->where('warehouse_id', $warehouseId)
+                    : ProductStock::query())
+                ->where('product_variant_id', $productVariantId)
+                ->where('status', 1)
+                ->get();
+
+            $qtyByUnit = $stocks->pluck('ps_stock', 'unit_id')->map(fn ($q) => (int) $q)->all();
+            $collapsed = UnitRollUp::collapseProduct((int) $productVariantId, $qtyByUnit, $warehouseId);
+            if ($collapsed === []) {
+                continue;
+            }
+
+            $stocksByUnit = $stocks->keyBy('unit_id');
+
+            foreach ($collapsed as $credit) {
+                $unitId = (int) $credit['unit_id'];
+                if (in_array($unitId, $touchedUnitIds, true)) {
+                    continue;
+                }
+
+                $stock = $stocksByUnit->get($unitId);
+                $before = $stock ? (int) $stock->ps_stock : 0;
+                $after = (int) $credit['qty'];
+                if (! $stock || $before === $after) {
+                    continue;
+                }
+
+                $delta = $after - $before;
+                $stock->ps_stock = $after;
+                $stock->save();
+
+                (new LogStock())->insertLog([
+                    'log_date' => now(),
+                    'log_kode' => $sto->sto_code,
+                    'log_type' => 1,
+                    'log_category' => $delta > 0 ? 1 : 2,
+                    'log_item_id' => $productVariantId,
+                    'log_notes' => 'Konversi unit dari Stock Opname (perbaikan stok tergulung) '.LogStock::actorSuffix(),
+                    'log_jumlah' => abs($delta),
+                    'log_saldo' => $after,
+                    'unit_id' => $unitId,
+                    'warehouse_id' => $warehouseId,
                 ]);
             }
         }

--- a/app/Support/UnitRollUp.php
+++ b/app/Support/UnitRollUp.php
@@ -32,10 +32,20 @@ use App\Models\SuppliesStock;
  *   rows, because the log note/code differs per flow.
  * - `$allowedUnitIds` is the caller's policy hook for "may I credit this unit?". Production passes
  *   every unit in the ladder because it provisions missing `ProductStock` rows on demand (behind a
- *   user confirmation). Every other caller passes only units that ALREADY have an active stock
- *   row, via `allowedProductUnitIds()`/`allowedSuppliesUnitIds()` below — so a roll-up never
- *   silently creates a stock row the user never asked for. Rolling stops at the first disallowed
- *   unit and the remainder simply stays at the level below it, which is always a valid state.
+ *   user confirmation) — see `planProductOutput()`. Every other caller passes only units that
+ *   ALREADY have an active stock row, via `allowedProductUnitIds()`/`allowedSuppliesUnitIds()`
+ *   below — so a roll-up never silently creates a stock row the user never asked for. Rolling stops
+ *   at the first disallowed unit and the remainder simply stays at the level below it, which is
+ *   always a valid state.
+ * - `$existingByUnitId` (GitHub #87, 2026-08-29) is what's already sitting in each unit's stock row
+ *   BEFORE this credit. Every `plan*()` convenience wrapper below fetches and passes it
+ *   automatically. Without it, a credit that's below a level's ratio on its own but pushes an
+ *   existing leftover over it never rolled up — the leftover just kept growing past its own unit's
+ *   ratio forever, e.g. 20 Piece already in stock + 4 Piece freshly credited never became 1 DOS even
+ *   at exactly 24 Piece = 1 DOS. Folding in the existing amount can make a credit at a given level
+ *   NEGATIVE (existing stock physically moving up a level along with the new credit) — that's
+ *   expected, not an error; every caller applies credits with a plain `+=`, which handles a negative
+ *   delta correctly.
  * - Guarded at 20 hops, same as the ladder walkers in ProductionController, so a circular or
  *   corrupt relation chain can't loop forever.
  */
@@ -46,14 +56,22 @@ class UnitRollUp
     /**
      * @param  array<int, array{small: int, big: int, ratio: int}>  $chain
      * @param  array<int, int>  $allowedUnitIds
+     * @param  array<int, int>  $existingByUnitId  Whatever is ALREADY on the shelf at each unit
+     *         level, keyed by unit_id (0/absent = nothing there yet). Fixed 2026-08-29 (GitHub
+     *         #87): without this, a qty that's below the ratio on its own but pushes an existing
+     *         leftover over it (e.g. 20 Piece already in stock + 4 Piece just credited, 1 DOS = 24
+     *         Piece) never rolled up — the leftover just kept growing past its own unit's ratio
+     *         forever. Passing [] reproduces the old existing-blind behaviour exactly (every
+     *         caller that doesn't pass it gets the pre-fix math, byte for byte).
      * @return array<int, array{unit_id: int, qty: int}>
      */
-    public static function plan(array $chain, int $startUnitId, int $qty, array $allowedUnitIds): array
+    public static function plan(array $chain, int $startUnitId, int $qty, array $allowedUnitIds, array $existingByUnitId = []): array
     {
         $credits = [];
         $currentUnitId = $startUnitId;
         $remaining = $qty;
         $allowed = array_flip(array_map('intval', $allowedUnitIds));
+        $existing = array_map('intval', $existingByUnitId);
         $hops = 0;
 
         while ($hops < self::MAX_HOPS) {
@@ -67,20 +85,31 @@ class UnitRollUp
                 }
             }
 
-            // Chain ended, quantity no longer fills a whole bigger unit, ratio is nonsense, or the
-            // caller won't let us credit the next unit up — stop and leave the rest where it is.
+            $existingHere = $existing[$currentUnitId] ?? 0;
+            $total = $existingHere + $remaining;
+
+            // Chain ended, what's already here PLUS what's being credited now still doesn't fill a
+            // whole bigger unit, ratio is nonsense, or the caller won't let us credit the next unit
+            // up — stop and leave the rest where it is (existing stock untouched).
             if ($rel === null
                 || $rel['ratio'] <= 0
-                || $remaining < $rel['ratio']
+                || $total < $rel['ratio']
                 || ! isset($allowed[$rel['big']])
             ) {
                 break;
             }
 
-            $credits[] = ['unit_id' => $currentUnitId, 'qty' => (int) ($remaining % $rel['ratio'])];
+            // The combined total resettles at $total % ratio here; the delta from whatever was
+            // already sitting at this level can be negative — that's correct, it means some of the
+            // pre-existing stock physically moved up a level along with the new credit, not that it
+            // vanished. Conservation still holds: summed back down to $startUnitId's unit, every
+            // credit in the returned plan always adds up to exactly $qty (existing stock elsewhere
+            // is only ever repositioned, never counted twice) — see UnitRollUpTest's conservation
+            // tests for the proof.
+            $credits[] = ['unit_id' => $currentUnitId, 'qty' => (int) ($total % $rel['ratio']) - $existingHere];
 
             $currentUnitId = $rel['big'];
-            $remaining = (int) floor($remaining / $rel['ratio']);
+            $remaining = (int) floor($total / $rel['ratio']);
         }
 
         $credits[] = ['unit_id' => $currentUnitId, 'qty' => (int) $remaining];
@@ -360,32 +389,114 @@ class UnitRollUp
     }
 
     /**
-     * Convenience wrapper: plan a product roll-up restricted to units that already have stock rows.
+     * What's already on the shelf at each unit level RIGHT NOW, keyed by unit_id — the plan()'s
+     * $existingByUnitId input (GitHub #87). A unit with no active row simply doesn't appear (plan()
+     * treats an absent key as 0, which is correct: nothing there to fold in).
+     *
+     * This ONE query also serves as the allow-list for the `plan*()` wrappers below (its keys are
+     * exactly `allowedProductUnitIds()`'s result), so a roll-up costs one query here, not two
+     * identical ones.
+     *
+     * $warehouseId behaves exactly as in allowedProductUnitIds() — REQUIRED to avoid summing stock
+     * across warehouses (a roll-up is per-warehouse; folding in another warehouse's stock would
+     * decide to roll up using stock this call isn't even crediting). main's port of this fix has no
+     * warehouse_id at all and aggregates blindly across every row for the variant — that landmine
+     * doesn't apply here since fase2 already threads $warehouseId everywhere this matters.
+     *
+     * @return array<int, int> unit_id => ps_stock
+     */
+    public static function existingProductStockByUnit(int $productVariantId, ?int $warehouseId = null): array
+    {
+        return (($warehouseId !== null)
+                ? ProductStock::withoutGlobalScope('active_warehouse')->where('warehouse_id', $warehouseId)
+                : ProductStock::query())
+            ->where('product_variant_id', $productVariantId)
+            ->where('status', 1)
+            ->groupBy('unit_id')
+            ->selectRaw('unit_id, SUM(ps_stock) AS qty')
+            ->pluck('qty', 'unit_id')
+            ->map(fn ($q) => (int) $q)
+            ->all();
+    }
+
+    /**
+     * Supplies-side counterpart of existingProductStockByUnit() — including its warehouse scoping.
+     *
+     * @return array<int, int> unit_id => ss_stock
+     */
+    public static function existingSuppliesStockByUnit(int $suppliesId, ?int $warehouseId = null): array
+    {
+        return (($warehouseId !== null)
+                ? SuppliesStock::withoutGlobalScope('active_warehouse')->where('warehouse_id', $warehouseId)
+                : SuppliesStock::query())
+            ->where('supplies_id', $suppliesId)
+            ->where('status', 1)
+            ->groupBy('unit_id')
+            ->selectRaw('unit_id, SUM(ss_stock) AS qty')
+            ->pluck('qty', 'unit_id')
+            ->map(fn ($q) => (int) $q)
+            ->all();
+    }
+
+    /**
+     * Convenience wrapper: plan a product roll-up restricted to units that already have stock rows,
+     * folding in whatever is already there (GitHub #87) so a credit that's below the ratio on its
+     * own but crosses it combined with an existing leftover still rolls up correctly.
      *
      * @return array<int, array{unit_id: int, qty: int}>
      */
     public static function planProduct(int $productVariantId, int $startUnitId, int $qty, ?int $warehouseId = null): array
     {
+        // One lookup, two uses: its KEYS are exactly allowedProductUnitIds() (units with an active
+        // stock row in this warehouse) and its VALUES are the existing quantities plan() folds in —
+        // issuing both queries separately would just run the same WHERE twice.
+        $existing = self::existingProductStockByUnit($productVariantId, $warehouseId);
+
         return self::plan(
             self::productChain($productVariantId),
             $startUnitId,
             $qty,
-            self::allowedProductUnitIds($productVariantId, $warehouseId)
+            array_keys($existing),
+            $existing
         );
     }
 
     /**
-     * Convenience wrapper: plan a supplies roll-up restricted to units that already have stock rows.
+     * Convenience wrapper: plan a supplies roll-up restricted to units that already have stock rows,
+     * folding in whatever is already there (GitHub #87) — see planProduct()'s docblock.
      *
      * @return array<int, array{unit_id: int, qty: int}>
      */
     public static function planSupplies(int $suppliesId, int $startUnitId, int $qty, ?int $warehouseId = null): array
     {
+        $existing = self::existingSuppliesStockByUnit($suppliesId, $warehouseId);
+
         return self::plan(
             self::suppliesChain($suppliesId),
             $startUnitId,
             $qty,
-            self::allowedSuppliesUnitIds($suppliesId, $warehouseId)
+            array_keys($existing),
+            $existing
+        );
+    }
+
+    /**
+     * Production's own output-crediting policy: unlike planProduct(), this may roll into EVERY unit
+     * in the product's ladder, not just ones that already have an active ProductStock row —
+     * accProduction() auto-provisions missing rows on demand (behind a user confirmation, see
+     * this class's "Design notes" above and ladderUnitIds()), so no allowedProductUnitIds() gate
+     * applies. Existing-aware (GitHub #87) via existingProductStockByUnit(), same as planProduct().
+     *
+     * @return array<int, array{unit_id: int, qty: int}>
+     */
+    public static function planProductOutput(int $productVariantId, int $startUnitId, int $qty, ?int $warehouseId = null): array
+    {
+        return self::plan(
+            self::productChain($productVariantId),
+            $startUnitId,
+            $qty,
+            self::ladderUnitIds($productVariantId),
+            self::existingProductStockByUnit($productVariantId, $warehouseId)
         );
     }
 }

--- a/docs/audit-stuck-unit-rollup-github87.sql
+++ b/docs/audit-stuck-unit-rollup-github87.sql
@@ -1,0 +1,246 @@
+-- Audit: stock stuck under-rolled from before GitHub #87 (unit roll-up fix, PR #88)
+-- ============================================================================
+-- READ-ONLY. Every statement below is a SELECT. Nothing is written, nothing is locked beyond a
+-- normal read. Safe to run directly against production in any SQL client (phpMyAdmin, Adminer,
+-- TablePlus, `mysql` CLI, ...) -- no artisan/PHP access required.
+--
+-- Why this exists: GitHub #87 fixed the unit roll-up logic (App\Support\UnitRollUp) going forward,
+-- but the fix is pure code -- it never touches a stock row on its own. It only changes what happens
+-- the NEXT TIME a stock-in transaction (production ACC, PO receipt, product-issue restore, Sales
+-- Order revert) credits that specific row, or the next time a Stock Opname recomputes it. Any
+-- product/bahan that was ALREADY stuck over-ratio before the fix, and hasn't been touched by one of
+-- those since, stays wrong indefinitely and silently. This finds every one of those rows right now.
+--
+-- What "stuck" means, concretely: e.g. 1 DOS = 24 Piece, but a product's Piece-level row shows 24
+-- (or more) while its DOS-level row never absorbed it -- the exact SKU HKCP60P bug that prompted
+-- #87 (11 DOS + 20 Piece, +4 Piece production should have become 12 DOS + 0 Piece, stayed
+-- 11 DOS + 24 Piece).
+--
+-- ⚠️ WAREHOUSE-SCOPED (fase2/main only -- differs from `main`'s copy of this file).
+-- `main` has no warehouse concept for stock, so its version groups purely by
+-- product_variant_id/supplies_id. On this branch product_stocks/supplies_stocks DO carry
+-- warehouse_id, and a roll-up is always per-warehouse: stock in warehouse A can never roll into a
+-- unit row belonging to warehouse B. Every CTE below therefore partitions/joins on
+-- (item, warehouse_id), not item alone. Without that, a variant holding one perfectly healthy
+-- single-unit row in each of two warehouses would be pooled together and reported as "stuck" --
+-- a pure false positive. See app/Console/Commands/AuditStuckUnitRollUpCommand.php, which applies
+-- the same scoping (and its regression test, which pins exactly this case).
+--
+-- How it decides "should_be": mirrors App\Support\UnitRollUp::collapse() -- the SAME primitive
+-- Stock Opname already uses to decide a product's canonical unit breakdown -- not a separate,
+-- independently-invented rule. Cross-validated against UnitRollUp::collapseProduct()/
+-- collapseSupplies() on several constructed scenarios (a simple 2-unit combine, a full 3-level
+-- cascade, and the trickiest case: an entered top-level unit that must stay UNTOUCHED because an
+-- intermediate unit has no active stock row at all -- rolling up can only ever move stock into a
+-- unit that already has its own row, same policy as every other roll-up call site); all matched
+-- exactly. See PR #89 (main) / the fase2 Batch 12 PR for the full history.
+--
+-- Reading the output: `current_qty` is what's stored right now; `should_be_qty` is what
+-- UnitRollUp's own logic says it should be. A row only appears here if those two differ -- i.e.
+-- every row returned is currently wrong. Nothing is flagged for an (item, warehouse) with only one
+-- active stock row (there's nothing to roll into) or where an intermediate unit has no active row
+-- in that same warehouse (rolling up cannot reach past that gap, by the same design as every other
+-- roll-up call site).
+--
+-- This is a diagnostic only. It deliberately does NOT fix anything -- decide what to do with the
+-- results (an intentional --fix mode in a future artisan command, a manual correction, or leaving
+-- it for the next transaction/opname to self-heal) as a separate step.
+-- ============================================================================
+
+
+-- ============================================================================
+-- PART 1: PRODUCTS (product_stocks / product_relations)
+-- ============================================================================
+WITH RECURSIVE
+chain AS (
+    SELECT product_variant_id, pr_unit_id_2 AS small_unit, pr_unit_id_1 AS big_unit, pr_unit_value_2 AS ratio
+    FROM product_relations WHERE status = 1
+),
+entered AS (
+    -- warehouse_id carried through everywhere below: a roll-up is per-warehouse.
+    SELECT product_variant_id, warehouse_id, unit_id, ps_stock AS qty
+    FROM product_stocks WHERE status = 1
+),
+multipliers AS (
+    -- Base case: units that are a "small" unit somewhere in their product's ladder but NEVER a
+    -- "big" one -- the true bottom of that product's own ladder, multiplier 1. (The ladder itself
+    -- is warehouse-independent -- product_relations has no warehouse_id -- so this CTE doesn't
+    -- need the scope; it gets joined onto warehouse-scoped rows below.)
+    SELECT DISTINCT c.product_variant_id, c.small_unit AS unit_id, 1 AS multiplier
+    FROM chain c
+    WHERE NOT EXISTS (
+        SELECT 1 FROM chain c2
+        WHERE c2.product_variant_id = c.product_variant_id AND c2.big_unit = c.small_unit
+    )
+    UNION ALL
+    -- Recursive case: walk upward, each level's multiplier is the level below's times this hop's ratio.
+    SELECT m.product_variant_id, c.big_unit, m.multiplier * c.ratio
+    FROM multipliers m
+    JOIN chain c ON c.product_variant_id = m.product_variant_id AND c.small_unit = m.unit_id
+),
+entered_with_mult AS (
+    SELECT e.product_variant_id, e.warehouse_id, e.unit_id, e.qty, mu.multiplier
+    FROM entered e
+    JOIN multipliers mu ON mu.product_variant_id = e.product_variant_id AND mu.unit_id = e.unit_id
+),
+start_point AS (
+    -- The smallest unit that ACTUALLY has an active stock row IN THIS WAREHOUSE -- collapse()'s
+    -- starting point is never the ladder's absolute bottom, it's the smallest unit really touched
+    -- (GitHub #78 rule: never fabricate a value for a unit smaller than the smallest one actually
+    -- filled).
+    SELECT product_variant_id, warehouse_id, start_unit, start_qty FROM (
+        SELECT ewm.product_variant_id, ewm.warehouse_id, ewm.unit_id AS start_unit, ewm.qty AS start_qty,
+               ROW_NUMBER() OVER (PARTITION BY ewm.product_variant_id, ewm.warehouse_id ORDER BY ewm.multiplier ASC, ewm.unit_id ASC) AS rn
+        FROM entered_with_mult ewm
+    ) t WHERE rn = 1
+),
+walk AS (
+    SELECT sp.product_variant_id, sp.warehouse_id, sp.start_unit AS unit_id, sp.start_qty AS carry, 0 AS depth
+    FROM start_point sp
+
+    UNION ALL
+
+    -- Can only continue to the next unit up if IT has an active row in the SAME WAREHOUSE too
+    -- (INNER JOIN to `entered`, matched on warehouse_id as well) -- this is the exact condition
+    -- that stops the walk dead at a gap, leaving anything above it (even if entered) completely
+    -- untouched, matching UnitRollUp::plan()/collapse()'s `isset($allowed[...])` gate precisely
+    -- (and that gate is itself warehouse-scoped, via allowedProductUnitIds($id, $warehouseId)).
+    SELECT w.product_variant_id, w.warehouse_id, c.big_unit AS unit_id,
+           FLOOR(w.carry / c.ratio) + big_stock.qty AS carry,
+           w.depth + 1
+    FROM walk w
+    JOIN chain c ON c.product_variant_id = w.product_variant_id AND c.small_unit = w.unit_id
+    JOIN entered big_stock ON big_stock.product_variant_id = w.product_variant_id
+                          AND big_stock.warehouse_id = w.warehouse_id
+                          AND big_stock.unit_id = c.big_unit
+    WHERE c.ratio > 0 AND w.carry >= c.ratio AND w.depth < 20 -- 20-hop guard, same bound as the PHP walkers
+),
+walk_with_next AS (
+    SELECT w.*,
+           ch.ratio AS ratio_up,
+           EXISTS (
+               SELECT 1 FROM walk w2
+               WHERE w2.product_variant_id = w.product_variant_id
+                 AND w2.warehouse_id = w.warehouse_id
+                 AND w2.depth = w.depth + 1
+           ) AS has_next
+    FROM walk w
+    LEFT JOIN chain ch ON ch.product_variant_id = w.product_variant_id AND ch.small_unit = w.unit_id
+),
+result AS (
+    -- If the walk continued past this level, the remainder stays; if this was the last level it
+    -- reached, everything carried into it stays here in full.
+    SELECT product_variant_id, warehouse_id, unit_id,
+           CASE WHEN has_next THEN carry % ratio_up ELSE carry END AS canonical_qty
+    FROM walk_with_next
+)
+SELECT
+    e.product_variant_id,
+    e.warehouse_id,
+    w.warehouse_name,
+    pv.product_variant_sku AS sku,
+    TRIM(CONCAT(COALESCE(p.product_name, ''), ' ', COALESCE(pv.product_variant_name, ''))) AS product_name,
+    u.unit_name,
+    e.unit_id,
+    e.qty AS current_qty,
+    r.canonical_qty AS should_be_qty
+FROM entered e
+JOIN result r ON r.product_variant_id = e.product_variant_id
+             AND r.warehouse_id = e.warehouse_id
+             AND r.unit_id = e.unit_id
+LEFT JOIN product_variants pv ON pv.product_variant_id = e.product_variant_id
+LEFT JOIN products p ON p.product_id = pv.product_id
+LEFT JOIN units u ON u.unit_id = e.unit_id
+LEFT JOIN warehouses w ON w.id = e.warehouse_id
+WHERE e.qty <> r.canonical_qty
+ORDER BY e.warehouse_id, e.product_variant_id, e.unit_id;
+
+
+-- ============================================================================
+-- PART 2: BAHAN / SUPPLIES (supplies_stocks / supplies_relations)
+-- Identical logic to Part 1, mirrored onto the supplies-side tables.
+-- ============================================================================
+WITH RECURSIVE
+chain AS (
+    SELECT supplies_id, su_id_2 AS small_unit, su_id_1 AS big_unit, sr_value_2 AS ratio
+    FROM supplies_relations WHERE status = 1
+),
+entered AS (
+    SELECT supplies_id, warehouse_id, unit_id, ss_stock AS qty
+    FROM supplies_stocks WHERE status = 1
+),
+multipliers AS (
+    SELECT DISTINCT c.supplies_id, c.small_unit AS unit_id, 1 AS multiplier
+    FROM chain c
+    WHERE NOT EXISTS (
+        SELECT 1 FROM chain c2
+        WHERE c2.supplies_id = c.supplies_id AND c2.big_unit = c.small_unit
+    )
+    UNION ALL
+    SELECT m.supplies_id, c.big_unit, m.multiplier * c.ratio
+    FROM multipliers m
+    JOIN chain c ON c.supplies_id = m.supplies_id AND c.small_unit = m.unit_id
+),
+entered_with_mult AS (
+    SELECT e.supplies_id, e.warehouse_id, e.unit_id, e.qty, mu.multiplier
+    FROM entered e
+    JOIN multipliers mu ON mu.supplies_id = e.supplies_id AND mu.unit_id = e.unit_id
+),
+start_point AS (
+    SELECT supplies_id, warehouse_id, start_unit, start_qty FROM (
+        SELECT ewm.supplies_id, ewm.warehouse_id, ewm.unit_id AS start_unit, ewm.qty AS start_qty,
+               ROW_NUMBER() OVER (PARTITION BY ewm.supplies_id, ewm.warehouse_id ORDER BY ewm.multiplier ASC, ewm.unit_id ASC) AS rn
+        FROM entered_with_mult ewm
+    ) t WHERE rn = 1
+),
+walk AS (
+    SELECT sp.supplies_id, sp.warehouse_id, sp.start_unit AS unit_id, sp.start_qty AS carry, 0 AS depth
+    FROM start_point sp
+
+    UNION ALL
+
+    SELECT w.supplies_id, w.warehouse_id, c.big_unit AS unit_id,
+           FLOOR(w.carry / c.ratio) + big_stock.qty AS carry,
+           w.depth + 1
+    FROM walk w
+    JOIN chain c ON c.supplies_id = w.supplies_id AND c.small_unit = w.unit_id
+    JOIN entered big_stock ON big_stock.supplies_id = w.supplies_id
+                          AND big_stock.warehouse_id = w.warehouse_id
+                          AND big_stock.unit_id = c.big_unit
+    WHERE c.ratio > 0 AND w.carry >= c.ratio AND w.depth < 20
+),
+walk_with_next AS (
+    SELECT w.*,
+           ch.ratio AS ratio_up,
+           EXISTS (
+               SELECT 1 FROM walk w2
+               WHERE w2.supplies_id = w.supplies_id
+                 AND w2.warehouse_id = w.warehouse_id
+                 AND w2.depth = w.depth + 1
+           ) AS has_next
+    FROM walk w
+    LEFT JOIN chain ch ON ch.supplies_id = w.supplies_id AND ch.small_unit = w.unit_id
+),
+result AS (
+    SELECT supplies_id, warehouse_id, unit_id,
+           CASE WHEN has_next THEN carry % ratio_up ELSE carry END AS canonical_qty
+    FROM walk_with_next
+)
+SELECT
+    e.supplies_id,
+    e.warehouse_id,
+    w.warehouse_name,
+    s.supplies_name,
+    u.unit_name,
+    e.unit_id,
+    e.qty AS current_qty,
+    r.canonical_qty AS should_be_qty
+FROM entered e
+JOIN result r ON r.supplies_id = e.supplies_id
+             AND r.warehouse_id = e.warehouse_id
+             AND r.unit_id = e.unit_id
+LEFT JOIN supplies s ON s.supplies_id = e.supplies_id
+LEFT JOIN units u ON u.unit_id = e.unit_id
+LEFT JOIN warehouses w ON w.id = e.warehouse_id
+WHERE e.qty <> r.canonical_qty
+ORDER BY e.warehouse_id, e.supplies_id, e.unit_id;

--- a/tests/DatabaseTransaction/StockOpnameApprovalAtomicityTest.php
+++ b/tests/DatabaseTransaction/StockOpnameApprovalAtomicityTest.php
@@ -50,8 +50,6 @@ class StockOpnameApprovalAtomicityTest extends TestCase
         $this->actingAsSuperAdminStaff();
 
         [$stockA, $stockB] = $this->pickTwoFixtureStocks();
-        $startingA = $stockA->ps_stock;
-        $startingB = $stockB->ps_stock;
         $bogusUnitId = 999999; // guaranteed to match no product_stocks row for stockB's variant
 
         $insertResponse = $this->post('/insertStockOpname', [
@@ -87,6 +85,18 @@ class StockOpnameApprovalAtomicityTest extends TestCase
         ]);
         $insertResponse->assertStatus(200);
         $stoId = (int) $insertResponse->json('sto_id');
+
+        // Baseline taken AFTER the insert on purpose (GitHub #91, 2026-08-31): inserting a
+        // non-draft opname now also heals live stock that was stuck under-rolled from before
+        // GitHub #87 (OpnameLifecycle::healUntouchedSystemStock()), and this fixture picks REAL
+        // okeh8644 rows -- variant 2 genuinely is stuck, so the heal legitimately rewrites both
+        // rows here before ACC is ever called. That heal is a separate, already-committed step; it
+        // is NOT part of the accStockOpname() transaction this test is about, so the post-insert
+        // state is the correct baseline for "did the rejected approval touch anything".
+        $stockA->refresh();
+        $stockB->refresh();
+        $startingA = $stockA->ps_stock;
+        $startingB = $stockB->ps_stock;
 
         $logCountBefore = DB::table('log_stocks')->count();
 

--- a/tests/Regression/AuditStuckUnitRollUpCommandTest.php
+++ b/tests/Regression/AuditStuckUnitRollUpCommandTest.php
@@ -1,0 +1,288 @@
+<?php
+
+namespace Tests\Regression;
+
+use App\Models\Category;
+use App\Models\Product;
+use App\Models\ProductRelation;
+use App\Models\ProductStock;
+use App\Models\ProductVariant;
+use App\Models\Supplies;
+use App\Models\SuppliesRelation;
+use App\Models\SuppliesStock;
+use Illuminate\Support\Facades\Artisan;
+use Tests\TestCase;
+
+/**
+ * `stock:audit-rollup`, ported from main's `349841b` (PR #89), born from a direct question,
+ * 2026-08-29, after GitHub #87 shipped: "if the DB is never touched by this fix, does the bug
+ * recur?" — answer: no NEW instances, but any row already stuck over-ratio from BEFORE the fix
+ * stays wrong until something transacts against it again. This locks in that the command finds a
+ * stuck row, leaves a healthy one alone, and — since it may run directly against production —
+ * never writes anything.
+ *
+ * Grouped by (variant/supplies, warehouse) rather than main's global grouping — see
+ * AuditStuckUnitRollUpCommand's own docblock for why main's version would false-positive on
+ * fase2's warehouse-scoped stock (two healthy single-unit rows for the same variant in two
+ * DIFFERENT warehouses is not "stuck", it's just two independent warehouses).
+ */
+class AuditStuckUnitRollUpCommandTest extends TestCase
+{
+    private const PIECE_UNIT_ID = 9;
+    private const DOS_UNIT_ID = 7;
+    private const WAREHOUSE_ID = 1;
+    private const OTHER_WAREHOUSE_ID = 13;
+
+    public function test_finds_a_stuck_product_row_and_leaves_a_healthy_one_out_of_the_report(): void
+    {
+        $category = new Category();
+        $category->category_name = 'Audit Command Regression Category';
+        $category->status = 1;
+        $category->save();
+
+        // --- STUCK fixture: 24 Piece sitting there, 1 DOS = 24 Piece, DOS row already exists at 11.
+        $stuckProduct = new Product();
+        $stuckProduct->product_name = 'Audit Command Stuck Product';
+        $stuckProduct->category_id = $category->category_id;
+        $stuckProduct->product_unit = json_encode([self::PIECE_UNIT_ID]);
+        $stuckProduct->unit_id = self::PIECE_UNIT_ID;
+        $stuckProduct->status = 1;
+        $stuckProduct->save();
+
+        $stuckVariant = new ProductVariant();
+        $stuckVariant->product_id = $stuckProduct->product_id;
+        $stuckVariant->product_variant_name = 'Audit Command Stuck Variant';
+        $stuckVariant->product_variant_sku = 'WF-AUDIT-STUCK-'.uniqid();
+        $stuckVariant->product_variant_price = 0;
+        $stuckVariant->status = 1;
+        $stuckVariant->save();
+
+        $stuckPiece = new ProductStock();
+        $stuckPiece->product_id = $stuckProduct->product_id;
+        $stuckPiece->product_variant_id = $stuckVariant->product_variant_id;
+        $stuckPiece->unit_id = self::PIECE_UNIT_ID;
+        $stuckPiece->warehouse_id = self::WAREHOUSE_ID;
+        $stuckPiece->ps_stock = 24; // stuck: should have rolled into 1 more DOS
+        $stuckPiece->status = 1;
+        $stuckPiece->save();
+
+        $stuckDos = new ProductStock();
+        $stuckDos->product_id = $stuckProduct->product_id;
+        $stuckDos->product_variant_id = $stuckVariant->product_variant_id;
+        $stuckDos->unit_id = self::DOS_UNIT_ID;
+        $stuckDos->warehouse_id = self::WAREHOUSE_ID;
+        $stuckDos->ps_stock = 11;
+        $stuckDos->status = 1;
+        $stuckDos->save();
+
+        $stuckRelation = new ProductRelation();
+        $stuckRelation->product_variant_id = $stuckVariant->product_variant_id;
+        $stuckRelation->pr_unit_id_1 = self::DOS_UNIT_ID;
+        $stuckRelation->pr_unit_value_1 = 1;
+        $stuckRelation->pr_unit_id_2 = self::PIECE_UNIT_ID;
+        $stuckRelation->pr_unit_value_2 = 24;
+        $stuckRelation->pr_default = 0;
+        $stuckRelation->status = 1;
+        $stuckRelation->save();
+
+        // --- HEALTHY control fixture: already correctly rolled up, must NOT be reported.
+        $healthyProduct = new Product();
+        $healthyProduct->product_name = 'Audit Command Healthy Product';
+        $healthyProduct->category_id = $category->category_id;
+        $healthyProduct->product_unit = json_encode([self::PIECE_UNIT_ID]);
+        $healthyProduct->unit_id = self::PIECE_UNIT_ID;
+        $healthyProduct->status = 1;
+        $healthyProduct->save();
+
+        $healthyVariant = new ProductVariant();
+        $healthyVariant->product_id = $healthyProduct->product_id;
+        $healthyVariant->product_variant_name = 'Audit Command Healthy Variant';
+        $healthyVariant->product_variant_sku = 'WF-AUDIT-HEALTHY-'.uniqid();
+        $healthyVariant->product_variant_price = 0;
+        $healthyVariant->status = 1;
+        $healthyVariant->save();
+
+        $healthyPiece = new ProductStock();
+        $healthyPiece->product_id = $healthyProduct->product_id;
+        $healthyPiece->product_variant_id = $healthyVariant->product_variant_id;
+        $healthyPiece->unit_id = self::PIECE_UNIT_ID;
+        $healthyPiece->warehouse_id = self::WAREHOUSE_ID;
+        $healthyPiece->ps_stock = 5; // below the ratio, correctly left at Piece
+        $healthyPiece->status = 1;
+        $healthyPiece->save();
+
+        $healthyDos = new ProductStock();
+        $healthyDos->product_id = $healthyProduct->product_id;
+        $healthyDos->product_variant_id = $healthyVariant->product_variant_id;
+        $healthyDos->unit_id = self::DOS_UNIT_ID;
+        $healthyDos->warehouse_id = self::WAREHOUSE_ID;
+        $healthyDos->ps_stock = 3;
+        $healthyDos->status = 1;
+        $healthyDos->save();
+
+        $healthyRelation = new ProductRelation();
+        $healthyRelation->product_variant_id = $healthyVariant->product_variant_id;
+        $healthyRelation->pr_unit_id_1 = self::DOS_UNIT_ID;
+        $healthyRelation->pr_unit_value_1 = 1;
+        $healthyRelation->pr_unit_id_2 = self::PIECE_UNIT_ID;
+        $healthyRelation->pr_unit_value_2 = 24;
+        $healthyRelation->pr_default = 0;
+        $healthyRelation->status = 1;
+        $healthyRelation->save();
+
+        Artisan::call('stock:audit-rollup', ['--json' => true]);
+        $output = json_decode(Artisan::output(), true);
+
+        $stuckIds = array_column($output['products'], 'id');
+        $this->assertContains($stuckVariant->product_variant_id, $stuckIds, 'the stuck product must be reported');
+        $this->assertNotContains($healthyVariant->product_variant_id, $stuckIds, 'the already-correct product must NOT be reported');
+
+        $stuckEntry = collect($output['products'])->firstWhere('id', $stuckVariant->product_variant_id);
+        $this->assertSame(self::WAREHOUSE_ID, $stuckEntry['warehouse_id']);
+        $this->assertSame(24, $stuckEntry['before']['Piece']);
+        $this->assertSame(11, $stuckEntry['before']['DOS']);
+        $this->assertSame(0, $stuckEntry['after']['Piece']);
+        $this->assertSame(12, $stuckEntry['after']['DOS']);
+
+        // The whole point: this is a diagnostic. It must never write anything, anywhere.
+        $stuckPiece->refresh();
+        $stuckDos->refresh();
+        $healthyPiece->refresh();
+        $healthyDos->refresh();
+        $this->assertSame(24, $stuckPiece->ps_stock, 'read-only command must not touch the stuck row');
+        $this->assertSame(11, $stuckDos->ps_stock, 'read-only command must not touch the stuck row');
+        $this->assertSame(5, $healthyPiece->ps_stock);
+        $this->assertSame(3, $healthyDos->ps_stock);
+    }
+
+    public function test_finds_a_stuck_supplies_row(): void
+    {
+        $liter = 3;
+        $drum = 5;
+
+        $supplies = new Supplies();
+        $supplies->supplies_name = 'Audit Command Stuck Supplies';
+        $supplies->supplies_unit = json_encode([$liter, $drum]);
+        $supplies->supplies_default_unit = $liter;
+        $supplies->status = 1;
+        $supplies->save();
+
+        $literStock = new SuppliesStock();
+        $literStock->supplies_id = $supplies->supplies_id;
+        $literStock->unit_id = $liter;
+        $literStock->warehouse_id = self::WAREHOUSE_ID;
+        $literStock->ss_stock = 250; // stuck: 1 Drum = 200 Liter, this should be 1 Drum + 50 Liter
+        $literStock->status = 1;
+        $literStock->save();
+
+        $drumStock = new SuppliesStock();
+        $drumStock->supplies_id = $supplies->supplies_id;
+        $drumStock->unit_id = $drum;
+        $drumStock->warehouse_id = self::WAREHOUSE_ID;
+        $drumStock->ss_stock = 2;
+        $drumStock->status = 1;
+        $drumStock->save();
+
+        $relation = new SuppliesRelation();
+        $relation->supplies_id = $supplies->supplies_id;
+        $relation->su_id_1 = $drum;
+        $relation->su_id_2 = $liter;
+        $relation->sr_value_1 = 1;
+        $relation->sr_value_2 = 200;
+        $relation->status = 1;
+        $relation->save();
+
+        Artisan::call('stock:audit-rollup', ['--json' => true]);
+        $output = json_decode(Artisan::output(), true);
+
+        $entry = collect($output['supplies'])->firstWhere('id', $supplies->supplies_id);
+        $this->assertNotNull($entry, 'the stuck supplies row must be reported');
+        $this->assertSame(self::WAREHOUSE_ID, $entry['warehouse_id']);
+        $this->assertSame(250, $entry['before']['Liter']);
+        $this->assertSame(2, $entry['before']['Drum']);
+        $this->assertSame(50, $entry['after']['Liter']);
+        $this->assertSame(3, $entry['after']['Drum']);
+
+        $literStock->refresh();
+        $drumStock->refresh();
+        $this->assertSame(250, $literStock->ss_stock, 'read-only command must not touch the stuck row');
+        $this->assertSame(2, $drumStock->ss_stock, 'read-only command must not touch the stuck row');
+    }
+
+    /**
+     * fase2-specific: a variant with ONE unit's row in warehouse A and a DIFFERENT unit's row in
+     * warehouse B is two entirely independent, healthy stock positions — not "stuck". main's
+     * version of this command (no warehouse concept at all) would have grouped these two rows
+     * together globally and seen ">1 row for this variant", producing a false positive. Grouping by
+     * (variant, warehouse) instead must leave this alone.
+     */
+    public function test_two_healthy_single_unit_rows_in_different_warehouses_are_not_falsely_reported(): void
+    {
+        $category = new Category();
+        $category->category_name = 'Audit Command Multi-Warehouse Regression Category';
+        $category->status = 1;
+        $category->save();
+
+        $product = new Product();
+        $product->product_name = 'Audit Command Multi-Warehouse Product';
+        $product->category_id = $category->category_id;
+        $product->product_unit = json_encode([self::PIECE_UNIT_ID]);
+        $product->unit_id = self::PIECE_UNIT_ID;
+        $product->status = 1;
+        $product->save();
+
+        $variant = new ProductVariant();
+        $variant->product_id = $product->product_id;
+        $variant->product_variant_name = 'Audit Command Multi-Warehouse Variant';
+        $variant->product_variant_sku = 'WF-AUDIT-MULTIWAREHOUSE-'.uniqid();
+        $variant->product_variant_price = 0;
+        $variant->status = 1;
+        $variant->save();
+
+        // Warehouse A: only a Piece row, well below the ratio -- healthy on its own.
+        $pieceInWarehouseA = new ProductStock();
+        $pieceInWarehouseA->product_id = $product->product_id;
+        $pieceInWarehouseA->product_variant_id = $variant->product_variant_id;
+        $pieceInWarehouseA->unit_id = self::PIECE_UNIT_ID;
+        $pieceInWarehouseA->warehouse_id = self::WAREHOUSE_ID;
+        $pieceInWarehouseA->ps_stock = 5;
+        $pieceInWarehouseA->status = 1;
+        $pieceInWarehouseA->save();
+
+        // Warehouse B: only a DOS row -- healthy on its own, and MUST NOT be pooled with warehouse
+        // A's Piece row just because they share a product_variant_id.
+        $dosInWarehouseB = new ProductStock();
+        $dosInWarehouseB->product_id = $product->product_id;
+        $dosInWarehouseB->product_variant_id = $variant->product_variant_id;
+        $dosInWarehouseB->unit_id = self::DOS_UNIT_ID;
+        $dosInWarehouseB->warehouse_id = self::OTHER_WAREHOUSE_ID;
+        $dosInWarehouseB->ps_stock = 7;
+        $dosInWarehouseB->status = 1;
+        $dosInWarehouseB->save();
+
+        $relation = new ProductRelation();
+        $relation->product_variant_id = $variant->product_variant_id;
+        $relation->pr_unit_id_1 = self::DOS_UNIT_ID;
+        $relation->pr_unit_value_1 = 1;
+        $relation->pr_unit_id_2 = self::PIECE_UNIT_ID;
+        $relation->pr_unit_value_2 = 24;
+        $relation->pr_default = 0;
+        $relation->status = 1;
+        $relation->save();
+
+        Artisan::call('stock:audit-rollup', ['--json' => true]);
+        $output = json_decode(Artisan::output(), true);
+
+        $reportedIds = array_column($output['products'], 'id');
+        $this->assertNotContains(
+            $variant->product_variant_id,
+            $reportedIds,
+            'each warehouse only has ONE row for this variant -- neither is stuck, and they must not be pooled together as if they were'
+        );
+
+        $pieceInWarehouseA->refresh();
+        $dosInWarehouseB->refresh();
+        $this->assertSame(5, $pieceInWarehouseA->ps_stock);
+        $this->assertSame(7, $dosInWarehouseB->ps_stock);
+    }
+}

--- a/tests/Regression/GetLogGatedByWrongModuleTest.php
+++ b/tests/Regression/GetLogGatedByWrongModuleTest.php
@@ -20,53 +20,57 @@ use Tests\TestCase;
  * middleware string could express "either Stok Produk or Stok Bahan Mentah" without hitting the
  * check.access.any first-module-only bug (see memory `pegasus-check-access-any-bug`).
  *
- * Fix, round 2 (per explicit product decision): the module actually required is `Daftar Produk`
- * for product history (`log_type=1`) and `Daftar Bahan Mentah` for bahan mentah history
- * (`log_type=2`) — not the Stok Produk/Stok Bahan Mentah page-view modules. Since the module needed
- * depends on a *request parameter* (`log_type`), not a fixed route, no `check.access` middleware
- * string can express it either — `GeneralController::getLog()` now validates inline via
- * `RoleAccess::can()`, keyed off `log_type`, and aborts 403 for a missing/unrecognized `log_type`
- * or a staff member lacking the corresponding module's `view` ability.
+ * Fix, round 2 (2026-08-21, since SUPERSEDED): keyed the module off `Daftar Produk`/`Daftar Bahan
+ * Mentah` instead — turned out to be a mistaken assumption, not the real answer (see below).
  *
- * See cdocs/testing/KNOWN_ISSUES.md.
+ * Fix, round 3 — the actual correction (2026-08-29, `c217531`, "mistaken getLogs access fix"): the
+ * module this endpoint's own history modal actually lives behind is `Stok Produk`/`Stok Bahan
+ * Mentah` (the SAME pages the modal opens from), not `Daftar Produk`/`Daftar Bahan Mentah` — round
+ * 2's module names were themselves the mistake. `GeneralController::getLog()` still validates
+ * inline via `RoleAccess::can()`, keyed off `log_type` (no static `check.access` string can express
+ * "either Stok Produk or Stok Bahan Mentah depending on a request parameter"), just against the
+ * corrected module names.
+ *
+ * See cdocs/testing/KNOWN_ISSUES.md and memory `pegasus-log-access-prefix-correction`.
  */
 class GetLogGatedByWrongModuleTest extends TestCase
 {
     use ActingAsStaff;
 
-    public function test_staff_with_daftar_produk_access_can_view_product_history(): void
+    public function test_staff_with_stok_produk_access_can_view_product_history(): void
     {
-        $this->actingAsStaffWithOnlyPermission('Daftar Produk', ['view']);
+        $this->actingAsStaffWithOnlyPermission('Stok Produk', ['view']);
 
         $this->get('/getLog?log_type=1&log_item_id=1')->assertOk();
     }
 
-    public function test_staff_with_daftar_produk_access_cannot_view_bahan_mentah_history(): void
+    public function test_staff_with_stok_produk_access_cannot_view_bahan_mentah_history(): void
     {
-        $this->actingAsStaffWithOnlyPermission('Daftar Produk', ['view']);
+        $this->actingAsStaffWithOnlyPermission('Stok Produk', ['view']);
 
         $this->get('/getLog?log_type=2&log_item_id=1')->assertForbidden();
     }
 
-    public function test_staff_with_daftar_bahan_mentah_access_can_view_bahan_mentah_history(): void
+    public function test_staff_with_stok_bahan_mentah_access_can_view_bahan_mentah_history(): void
     {
-        $this->actingAsStaffWithOnlyPermission('Daftar Bahan Mentah', ['view']);
+        $this->actingAsStaffWithOnlyPermission('Stok Bahan Mentah', ['view']);
 
         $this->get('/getLog?log_type=2&log_item_id=1')->assertOk();
     }
 
-    public function test_staff_with_daftar_bahan_mentah_access_cannot_view_product_history(): void
+    public function test_staff_with_stok_bahan_mentah_access_cannot_view_product_history(): void
     {
-        $this->actingAsStaffWithOnlyPermission('Daftar Bahan Mentah', ['view']);
+        $this->actingAsStaffWithOnlyPermission('Stok Bahan Mentah', ['view']);
 
         $this->get('/getLog?log_type=1&log_item_id=1')->assertForbidden();
     }
 
-    public function test_staff_with_only_stok_produk_page_access_cannot_view_product_history(): void
+    public function test_staff_with_only_daftar_produk_access_cannot_view_product_history(): void
     {
-        // Confirms the fix really keys off 'Daftar Produk', not 'Stok Produk' (the page itself) --
-        // a role granted only the stock-page module must still be denied.
-        $this->actingAsStaffWithOnlyPermission('Stok Produk', ['view']);
+        // Confirms the fix really keys off 'Stok Produk', not 'Daftar Produk' (round 2's mistaken
+        // module, sharing the same real-sounding "produk master data" area) -- a role granted only
+        // that module must still be denied.
+        $this->actingAsStaffWithOnlyPermission('Daftar Produk', ['view']);
 
         $this->get('/getLog?log_type=1&log_item_id=1')->assertForbidden();
     }
@@ -80,7 +84,7 @@ class GetLogGatedByWrongModuleTest extends TestCase
 
     public function test_missing_log_type_is_blocked_even_for_a_privileged_staff(): void
     {
-        $this->actingAsStaffWithOnlyPermission('Daftar Produk', ['view']);
+        $this->actingAsStaffWithOnlyPermission('Stok Produk', ['view']);
 
         $this->get('/getLog?log_item_id=1')->assertForbidden();
     }

--- a/tests/Regression/ProductionOutputCascadesThroughAMissingMiddleUnitTest.php
+++ b/tests/Regression/ProductionOutputCascadesThroughAMissingMiddleUnitTest.php
@@ -1,0 +1,217 @@
+<?php
+
+namespace Tests\Regression;
+
+use App\Models\Bom;
+use App\Models\BomDetail;
+use App\Models\Category;
+use App\Models\Product;
+use App\Models\ProductRelation;
+use App\Models\ProductStock;
+use App\Models\ProductVariant;
+use App\Models\Production;
+use App\Models\Supplies;
+use App\Models\SuppliesStock;
+use Tests\Support\ActingAsStaff;
+use Tests\TestCase;
+
+/**
+ * Ported from main's `d416aba` (GitHub #87 follow-up). Confirms two things about a 3-level output
+ * ladder (Piece -> DOS -> Sak) where NEITHER the middle (DOS) nor the top (Sak) `ProductStock` row
+ * exists yet, and the produced quantity is an EXACT multiple of the whole ladder (24 Piece = 2 DOS
+ * = 1 Sak) — so DOS's own net credit lands on exactly 0 (everything that reaches it immediately
+ * carries on up to Sak, nothing stays behind):
+ *
+ * 1. The roll-up still reaches the TOP level correctly even though the row it passes THROUGH
+ *    (DOS) never existed at all — walking `UnitRollUp::plan()`'s chain only ever depends on
+ *    whether a level's combined total crosses ITS ratio, never on what credit that level nets to,
+ *    so a middle level netting to 0 does not stop the cascade.
+ * 2. The pre-check that asks the user to confirm "a new stock row will be created at 0" only lists
+ *    DOS/Sak-style levels that will ACTUALLY be created. fase2's pre-check already guarded this
+ *    correctly (`if ($credit['qty'] <= 0) continue;`) before this batch — this test locks that
+ *    behavior in explicitly rather than leaving it unverified, now that the planner underneath it
+ *    (`UnitRollUp::planProductOutput()`) is existing-aware (GitHub #87).
+ */
+class ProductionOutputCascadesThroughAMissingMiddleUnitTest extends TestCase
+{
+    use ActingAsStaff;
+
+    private const PIECE_UNIT_ID = 9;
+    private const DOS_UNIT_ID = 7;
+    private const SAK_UNIT_ID = 25;
+    private const WAREHOUSE_ID = 1;
+
+    public function test_a_middle_level_with_no_stock_row_and_a_zero_net_credit_does_not_block_the_cascade_or_get_falsely_promised(): void
+    {
+        $this->actingAsSuperAdminStaff();
+        // Wajib: insertProduction()/accProduction() menolak kalau gudang aktif sesi bukan gudang
+        // utama -- lihat memory pegasus-testing-db-multiwarehouse-drift.
+        $this->withActiveWarehouse(self::WAREHOUSE_ID);
+
+        $category = new Category();
+        $category->category_name = 'Missing Middle Cascade Regression Category';
+        $category->status = 1;
+        $category->save();
+
+        $product = new Product();
+        $product->product_name = 'Missing Middle Cascade Regression Product';
+        $product->category_id = $category->category_id;
+        $product->product_unit = json_encode([self::PIECE_UNIT_ID]);
+        $product->unit_id = self::PIECE_UNIT_ID;
+        $product->status = 1;
+        $product->save();
+
+        $variant = new ProductVariant();
+        $variant->product_id = $product->product_id;
+        $variant->product_variant_name = 'Missing Middle Cascade Regression Variant';
+        $variant->product_variant_sku = 'WF-CASCADE-MISSING-MID-'.uniqid();
+        $variant->product_variant_price = 0;
+        $variant->status = 1;
+        $variant->save();
+
+        // Only the Piece-level row exists. DOS and Sak are both missing entirely — not just zero.
+        $pieceStock = new ProductStock();
+        $pieceStock->product_id = $product->product_id;
+        $pieceStock->product_variant_id = $variant->product_variant_id;
+        $pieceStock->unit_id = self::PIECE_UNIT_ID;
+        $pieceStock->warehouse_id = self::WAREHOUSE_ID;
+        $pieceStock->ps_stock = 0;
+        $pieceStock->status = 1;
+        $pieceStock->save();
+
+        // Level 1: 1 DOS = 12 Piece
+        $relationDos = new ProductRelation();
+        $relationDos->product_variant_id = $variant->product_variant_id;
+        $relationDos->pr_unit_id_1 = self::DOS_UNIT_ID;
+        $relationDos->pr_unit_value_1 = 1;
+        $relationDos->pr_unit_id_2 = self::PIECE_UNIT_ID;
+        $relationDos->pr_unit_value_2 = 12;
+        $relationDos->pr_default = 0;
+        $relationDos->status = 1;
+        $relationDos->save();
+
+        // Level 2: 1 Sak = 2 DOS (= 24 Piece)
+        $relationSak = new ProductRelation();
+        $relationSak->product_variant_id = $variant->product_variant_id;
+        $relationSak->pr_unit_id_1 = self::SAK_UNIT_ID;
+        $relationSak->pr_unit_value_1 = 1;
+        $relationSak->pr_unit_id_2 = self::DOS_UNIT_ID;
+        $relationSak->pr_unit_value_2 = 2;
+        $relationSak->pr_default = 0;
+        $relationSak->status = 1;
+        $relationSak->save();
+
+        $supplies = new Supplies();
+        $supplies->supplies_name = 'Missing Middle Cascade Regression Ingredient';
+        $supplies->supplies_unit = json_encode([self::PIECE_UNIT_ID]);
+        $supplies->supplies_default_unit = self::PIECE_UNIT_ID;
+        $supplies->status = 1;
+        $supplies->save();
+
+        $suppliesStock = new SuppliesStock();
+        $suppliesStock->supplies_id = $supplies->supplies_id;
+        $suppliesStock->unit_id = self::PIECE_UNIT_ID;
+        $suppliesStock->warehouse_id = self::WAREHOUSE_ID;
+        $suppliesStock->ss_stock = 1000;
+        $suppliesStock->status = 1;
+        $suppliesStock->save();
+
+        $bom = new Bom();
+        $bom->product_id = $variant->product_variant_id;
+        $bom->bom_qty = 1;
+        $bom->unit_id = self::PIECE_UNIT_ID;
+        $bom->status = 1;
+        $bom->save();
+
+        $bomDetail = new BomDetail();
+        $bomDetail->bom_id = $bom->bom_id;
+        $bomDetail->supplies_id = $supplies->supplies_id;
+        $bomDetail->bom_detail_qty = 1;
+        $bomDetail->unit_id = self::PIECE_UNIT_ID;
+        $bomDetail->status = 1;
+        $bomDetail->save();
+
+        $pdQty = 24; // exact multiple all the way up: DOS's own net credit lands on exactly 0
+
+        $insertResponse = $this->post('/insertProduction', [
+            'production_date' => now()->toDateString(),
+            'production_desc' => 'Missing middle cascade regression test',
+            'detail' => json_encode([[
+                'bom_id' => $bom->bom_id,
+                'product_variant_id' => $variant->product_variant_id,
+                'pd_qty' => $pdQty,
+                'unit_id' => self::PIECE_UNIT_ID,
+            ]]),
+            'list_bahan' => json_encode([[
+                'supplies_id' => $supplies->supplies_id,
+                'bom_detail_qty' => 1,
+                'unit_id' => self::PIECE_UNIT_ID,
+            ]]),
+        ]);
+        $insertResponse->assertStatus(200);
+        $production = Production::orderByDesc('production_id')->firstOrFail();
+
+        // First call: no confirmation flag. Must be blocked, and must ONLY ask about Sak — DOS's
+        // own net credit is 0 so it will never actually be created, and must not be promised here.
+        $firstResponse = $this->post('/accProduction', ['production_id' => $production->production_id]);
+        $firstResponse->assertStatus(200);
+        $firstResponse->assertJson(['status' => -3, 'header' => 'Konfirmasi Diperlukan']);
+        $firstResponse->assertJsonFragment([
+            'product_variant_id' => $variant->product_variant_id,
+            'unit_id' => self::SAK_UNIT_ID,
+        ]);
+        $missingStock = $firstResponse->json('missing_stock');
+        $this->assertCount(1, $missingStock, 'only Sak should be listed — DOS nets to 0 and will never actually be created');
+        $this->assertSame(self::SAK_UNIT_ID, $missingStock[0]['unit_id']);
+
+        $production->refresh();
+        $this->assertSame(1, (int) $production->status, 'blocked pending confirmation — must not be approved yet');
+        $this->assertNull(
+            ProductStock::where('product_variant_id', $variant->product_variant_id)
+                ->where('unit_id', self::SAK_UNIT_ID)
+                ->where('status', 1)
+                ->first(),
+            'blocked pending confirmation — the Sak row must not be created yet either'
+        );
+
+        // Second call: confirmed. The cascade must still reach Sak even though it walks THROUGH a
+        // DOS row that never existed and never gets created (its own net credit is 0).
+        $secondResponse = $this->post('/accProduction', [
+            'production_id' => $production->production_id,
+            'confirm_create_stock' => 1,
+        ]);
+        $secondResponse->assertStatus(200);
+
+        $production->refresh();
+        $this->assertSame(2, (int) $production->status);
+
+        $pieceStock->refresh();
+        $this->assertEquals(0, $pieceStock->ps_stock, '24 is an exact multiple of the whole ladder — nothing left over at Piece');
+
+        $dosStock = ProductStock::where('product_variant_id', $variant->product_variant_id)
+            ->where('unit_id', self::DOS_UNIT_ID)
+            ->where('status', 1)
+            ->first();
+        $this->assertNull($dosStock, 'DOS nets to a 0 credit — it is a pure pass-through and is never actually provisioned');
+
+        $sakStock = ProductStock::where('product_variant_id', $variant->product_variant_id)
+            ->where('unit_id', self::SAK_UNIT_ID)
+            ->where('status', 1)
+            ->first();
+        $this->assertNotNull($sakStock, 'the cascade reached all the way past the missing DOS row to Sak');
+        $this->assertEquals(1, $sakStock->ps_stock, '24 Piece = 2 DOS = 1 Sak, credited directly at the top');
+
+        $this->assertDatabaseHas('log_stocks', [
+            'log_type' => 1,
+            'log_category' => 1,
+            'log_item_id' => $variant->product_variant_id,
+            'unit_id' => self::SAK_UNIT_ID,
+            'log_jumlah' => 1,
+        ]);
+        // No log at all for DOS — nothing was ever credited there to log.
+        $this->assertDatabaseMissing('log_stocks', [
+            'log_item_id' => $variant->product_variant_id,
+            'unit_id' => self::DOS_UNIT_ID,
+        ]);
+    }
+}

--- a/tests/Regression/ProductionOutputRollUpIgnoredExistingStockTest.php
+++ b/tests/Regression/ProductionOutputRollUpIgnoredExistingStockTest.php
@@ -1,0 +1,190 @@
+<?php
+
+namespace Tests\Regression;
+
+use App\Models\Bom;
+use App\Models\BomDetail;
+use App\Models\Category;
+use App\Models\Product;
+use App\Models\ProductRelation;
+use App\Models\ProductStock;
+use App\Models\ProductVariant;
+use App\Models\Production;
+use App\Models\Supplies;
+use App\Models\SuppliesStock;
+use Tests\Support\ActingAsStaff;
+use Tests\TestCase;
+
+/**
+ * ✅ FIXED (2026-08-30, GitHub #87, ported from main's `d416aba`). Reported directly by the user
+ * against a real SKU (HKCP60P): stock before production was 11 DOS + 20 Piece (1 DOS = 24 Piece
+ * there); a production run credited 4 more Piece. Expected result: 20 + 4 = 24 = exactly 1 more
+ * DOS, ending at 12 DOS + 0 Piece. Actual result: 11 DOS + 24 Piece — the DOS row was never
+ * touched.
+ *
+ * `App\Support\UnitRollUp::plan()` decided whether to roll a credited quantity up a level using
+ * ONLY the newly credited amount, completely ignoring whatever was already sitting in that unit's
+ * stock row:
+ *
+ *   if ($rel === null || ... || $remaining < $rel['ratio'] || ...) { break; } // $remaining was $qty alone
+ *
+ * For this fixture: qty=4, ratio=24. Since 4 < 24 the loop broke immediately without ever checking
+ * whether the EXISTING 20 Piece plus this credit's 4 reaches the ratio. The credit then fell
+ * through to a flat `ps_stock += 4` (via `ProductUnitStock::addQty()`), leaving the DOS row
+ * untouched forever — this is why the existing
+ * `ProductionUnitConversionFlowTest`/`ProductionOutputConversionDoesNotCascadeMultipleLevelsTest`
+ * suite never caught it: every one of those fixtures starts the smallest unit's stock at 0, so
+ * "existing stock plus new credit" and "new credit alone" always happened to be the same number.
+ *
+ * Fixed by making `UnitRollUp::plan()` (and every `plan*()` wrapper, including
+ * `planProductOutput()` used by `accProduction()`'s pre-check, and `ProductUnitStock::addQty()`'s
+ * internal roll-up call used by the actual credit) existing-aware — see
+ * `tests/Unit/UnitRollUpTest.php`'s `$existingByUnitId` section for the pure-logic proof.
+ */
+class ProductionOutputRollUpIgnoredExistingStockTest extends TestCase
+{
+    use ActingAsStaff;
+
+    private const PIECE_UNIT_ID = 9;
+    private const DOS_UNIT_ID = 7;
+    private const WAREHOUSE_ID = 1;
+
+    public function test_a_below_ratio_production_credit_still_rolls_up_when_combined_with_existing_leftover_stock(): void
+    {
+        $this->actingAsSuperAdminStaff();
+        // Wajib: insertProduction()/accProduction() menolak kalau gudang aktif sesi bukan gudang
+        // utama -- lihat memory pegasus-testing-db-multiwarehouse-drift.
+        $this->withActiveWarehouse(self::WAREHOUSE_ID);
+
+        $category = new Category();
+        $category->category_name = 'Existing Stock Roll-Up Regression Category';
+        $category->status = 1;
+        $category->save();
+
+        $product = new Product();
+        $product->product_name = 'Existing Stock Roll-Up Regression Product';
+        $product->category_id = $category->category_id;
+        $product->product_unit = json_encode([self::PIECE_UNIT_ID]);
+        $product->unit_id = self::PIECE_UNIT_ID;
+        $product->status = 1;
+        $product->save();
+
+        $variant = new ProductVariant();
+        $variant->product_id = $product->product_id;
+        $variant->product_variant_name = 'Existing Stock Roll-Up Regression Variant';
+        $variant->product_variant_sku = 'WF-ROLLUP-EXISTING-'.uniqid();
+        $variant->product_variant_price = 0;
+        $variant->status = 1;
+        $variant->save();
+
+        // Stock BEFORE production: 20 Piece, 11 DOS — this is the whole point of the test.
+        $pieceStock = new ProductStock();
+        $pieceStock->product_id = $product->product_id;
+        $pieceStock->product_variant_id = $variant->product_variant_id;
+        $pieceStock->unit_id = self::PIECE_UNIT_ID;
+        $pieceStock->warehouse_id = self::WAREHOUSE_ID;
+        $pieceStock->ps_stock = 20;
+        $pieceStock->status = 1;
+        $pieceStock->save();
+
+        $dosStock = new ProductStock();
+        $dosStock->product_id = $product->product_id;
+        $dosStock->product_variant_id = $variant->product_variant_id;
+        $dosStock->unit_id = self::DOS_UNIT_ID;
+        $dosStock->warehouse_id = self::WAREHOUSE_ID;
+        $dosStock->ps_stock = 11;
+        $dosStock->status = 1;
+        $dosStock->save();
+
+        // 1 DOS = 24 Piece, matching the real HKCP60P ladder.
+        $relationDos = new ProductRelation();
+        $relationDos->product_variant_id = $variant->product_variant_id;
+        $relationDos->pr_unit_id_1 = self::DOS_UNIT_ID;
+        $relationDos->pr_unit_value_1 = 1;
+        $relationDos->pr_unit_id_2 = self::PIECE_UNIT_ID;
+        $relationDos->pr_unit_value_2 = 24;
+        $relationDos->pr_default = 0;
+        $relationDos->status = 1;
+        $relationDos->save();
+
+        $supplies = new Supplies();
+        $supplies->supplies_name = 'Existing Stock Roll-Up Regression Ingredient';
+        $supplies->supplies_unit = json_encode([self::PIECE_UNIT_ID]);
+        $supplies->supplies_default_unit = self::PIECE_UNIT_ID;
+        $supplies->status = 1;
+        $supplies->save();
+
+        $suppliesStock = new SuppliesStock();
+        $suppliesStock->supplies_id = $supplies->supplies_id;
+        $suppliesStock->unit_id = self::PIECE_UNIT_ID;
+        $suppliesStock->warehouse_id = self::WAREHOUSE_ID;
+        $suppliesStock->ss_stock = 1000;
+        $suppliesStock->status = 1;
+        $suppliesStock->save();
+
+        $bom = new Bom();
+        $bom->product_id = $variant->product_variant_id;
+        $bom->bom_qty = 1;
+        $bom->unit_id = self::PIECE_UNIT_ID;
+        $bom->status = 1;
+        $bom->save();
+
+        $bomDetail = new BomDetail();
+        $bomDetail->bom_id = $bom->bom_id;
+        $bomDetail->supplies_id = $supplies->supplies_id;
+        $bomDetail->bom_detail_qty = 1;
+        $bomDetail->unit_id = self::PIECE_UNIT_ID;
+        $bomDetail->status = 1;
+        $bomDetail->save();
+
+        $pdQty = 4; // below the 24-Piece ratio on its own — only reaches it combined with the 20 already in stock
+
+        $insertResponse = $this->post('/insertProduction', [
+            'production_date' => now()->toDateString(),
+            'production_desc' => 'Existing stock roll-up regression test',
+            'detail' => json_encode([[
+                'bom_id' => $bom->bom_id,
+                'product_variant_id' => $variant->product_variant_id,
+                'pd_qty' => $pdQty,
+                'unit_id' => self::PIECE_UNIT_ID,
+            ]]),
+            'list_bahan' => json_encode([[
+                'supplies_id' => $supplies->supplies_id,
+                'bom_detail_qty' => 1,
+                'unit_id' => self::PIECE_UNIT_ID,
+            ]]),
+        ]);
+        $insertResponse->assertStatus(200);
+        $production = Production::orderByDesc('production_id')->firstOrFail();
+
+        $accResponse = $this->post('/accProduction', ['production_id' => $production->production_id]);
+        $accResponse->assertStatus(200);
+
+        $production->refresh();
+        $this->assertSame(2, (int) $production->status);
+
+        $pieceStock->refresh();
+        $dosStock->refresh();
+
+        $this->assertEquals(0, $pieceStock->ps_stock, '20 existing + 4 produced = 24 = exactly 1 DOS, none left over at the Piece level');
+        $this->assertEquals(12, $dosStock->ps_stock, '11 existing + 1 rolled up from the combined Piece total = 12 DOS');
+
+        // The 20 pre-existing Piece leaving this row is logged as a unit conversion (OUT here),
+        // not silently vanishing from the ledger.
+        $this->assertDatabaseHas('log_stocks', [
+            'log_type' => 1,
+            'log_category' => 2,
+            'log_item_id' => $variant->product_variant_id,
+            'unit_id' => self::PIECE_UNIT_ID,
+            'log_jumlah' => 20,
+        ]);
+        // ... and its reappearance as 1 new DOS is logged as the production result (IN here).
+        $this->assertDatabaseHas('log_stocks', [
+            'log_type' => 1,
+            'log_category' => 1,
+            'log_item_id' => $variant->product_variant_id,
+            'unit_id' => self::DOS_UNIT_ID,
+            'log_jumlah' => 1,
+        ]);
+    }
+}

--- a/tests/Unit/UnitRollUpTest.php
+++ b/tests/Unit/UnitRollUpTest.php
@@ -127,6 +127,116 @@ class UnitRollUpTest extends TestCase
         $this->assertLessThanOrEqual(21, count($plan));
     }
 
+    // ============================================================ $existingByUnitId (GitHub #87)
+
+    /**
+     * The exact reported bug (GitHub #87): SKU HKCP60P had 11 DOS + 20 Piece in stock (1 DOS =
+     * 24 Piece there), a production run credited 4 more Piece. 4 alone never reaches the ratio, but
+     * 20 + 4 does — the old existing-blind plan() left this at 11 DOS + 24 Piece forever instead of
+     * rolling into a 12th DOS.
+     */
+    public function test_an_existing_leftover_plus_a_below_ratio_credit_rolls_up_together(): void
+    {
+        $hkcp60pLadder = [['small' => self::PIECE, 'big' => self::DOS, 'ratio' => 24]];
+
+        $plan = UnitRollUp::plan(
+            $hkcp60pLadder,
+            self::PIECE,
+            4,
+            [self::PIECE, self::DOS],
+            [self::PIECE => 20]
+        );
+
+        $this->assertSame([
+            ['unit_id' => self::PIECE, 'qty' => -20], // the old 20 Piece leaves this row entirely
+            ['unit_id' => self::DOS, 'qty' => 1],      // ... and reappears as 1 new DOS (11 -> 12)
+        ], $plan);
+    }
+
+    /** Existing + credit landing exactly on the ratio still counts as reaching it (not "below"). */
+    public function test_existing_plus_credit_exactly_on_the_ratio_still_rolls_up(): void
+    {
+        $plan = UnitRollUp::plan($this->twoLevelLadder(), self::PIECE, 12, [self::PIECE, self::DOS], [self::PIECE => 0]);
+        $this->assertSame([
+            ['unit_id' => self::PIECE, 'qty' => 0],
+            ['unit_id' => self::DOS, 'qty' => 1],
+        ], $plan);
+
+        // Same combined total (12), split differently between existing and new — same result.
+        $plan2 = UnitRollUp::plan($this->twoLevelLadder(), self::PIECE, 5, [self::PIECE, self::DOS], [self::PIECE => 7]);
+        $this->assertSame([
+            ['unit_id' => self::PIECE, 'qty' => -7],
+            ['unit_id' => self::DOS, 'qty' => 1],
+        ], $plan2);
+    }
+
+    /** Existing + credit still short of the ratio: nothing rolls, existing stock is left alone. */
+    public function test_existing_plus_credit_still_below_the_ratio_stays_put(): void
+    {
+        $plan = UnitRollUp::plan($this->twoLevelLadder(), self::PIECE, 4, [self::PIECE, self::DOS], [self::PIECE => 5]);
+
+        $this->assertSame([['unit_id' => self::PIECE, 'qty' => 4]], $plan);
+    }
+
+    /**
+     * A pre-existing leftover can cascade through MULTIPLE levels too, not just the level it's
+     * sitting at — 20 existing Piece + 4 new Piece rolls to 2 new DOS, and those 2 DOS combined
+     * with 5 ALREADY-existing DOS (7 total, ratio 2) roll again into 3 Sak + 1 DOS remainder.
+     */
+    public function test_an_existing_leftover_can_cascade_up_more_than_one_level(): void
+    {
+        $plan = UnitRollUp::plan(
+            $this->ladder(),
+            self::PIECE,
+            4,
+            $this->allUnits(),
+            [self::PIECE => 20, self::DOS => 5]
+        );
+
+        $this->assertSame([
+            ['unit_id' => self::PIECE, 'qty' => -20],
+            ['unit_id' => self::DOS, 'qty' => -4], // 5 existing - 1 remainder = 4 also leave, folded into the Sak
+            ['unit_id' => self::SAK, 'qty' => 3],
+        ], $plan);
+
+        // Conservation: -20*1 + -4*12 + 3*24 = 4, exactly the credited qty — see the dedicated
+        // conservation test below for why this must always hold.
+    }
+
+    /** Omitting $existingByUnitId reproduces the pre-fix, existing-blind behaviour exactly. */
+    public function test_omitting_existing_stock_defaults_to_the_old_existing_blind_behaviour(): void
+    {
+        $withDefault = UnitRollUp::plan($this->twoLevelLadder(), self::PIECE, 4, [self::PIECE, self::DOS]);
+        $withExplicitZero = UnitRollUp::plan($this->twoLevelLadder(), self::PIECE, 4, [self::PIECE, self::DOS], [self::PIECE => 0]);
+
+        $this->assertSame([['unit_id' => self::PIECE, 'qty' => 4]], $withDefault);
+        $this->assertSame($withDefault, $withExplicitZero);
+    }
+
+    /**
+     * Conservation still holds with a nonzero existing balance: summed back down to the base unit,
+     * the plan's credits always add up to exactly $qty — existing stock elsewhere is only ever
+     * repositioned by the plan, never counted as part of what's being credited.
+     */
+    public function test_conservation_holds_even_when_existing_stock_is_folded_in(): void
+    {
+        $plan = UnitRollUp::plan(
+            $this->ladder(),
+            self::PIECE,
+            4,
+            $this->allUnits(),
+            [self::PIECE => 20, self::DOS => 5]
+        );
+
+        $pieceEquivalent = [self::PIECE => 1, self::DOS => 12, self::SAK => 24];
+        $total = 0;
+        foreach ($plan as $credit) {
+            $total += $credit['qty'] * $pieceEquivalent[$credit['unit_id']];
+        }
+
+        $this->assertSame(4, $total, 'the plan only ever accounts for the newly credited 4 Piece, not the existing stock it repositions');
+    }
+
     // ================================================================== collapse()
 
     /**

--- a/tests/Workflow/StockOpnameFlowTest.php
+++ b/tests/Workflow/StockOpnameFlowTest.php
@@ -91,7 +91,6 @@ class StockOpnameFlowTest extends TestCase
         $stock = $this->pickFixtureStock();
         $startingStock = $stock->ps_stock;
         $realQty = $startingStock - 5; // simulate a shrinkage found during the count
-        $logCountBefore = DB::table('log_stocks')->count();
 
         $stoId = $this->insertStockOpname($stock, realQty: $realQty);
 
@@ -108,9 +107,17 @@ class StockOpnameFlowTest extends TestCase
         ]);
         $this->assertDatabaseMissing('stock_opname_details', ['sto_id' => $stoId]);
 
+        // NB (GitHub #91, 2026-08-31): inserting a non-draft opname now ALSO heals live stock that
+        // was stuck under-rolled from before GitHub #87 (see OpnameLifecycle::
+        // healUntouchedSystemStock()) -- and this fixture picks a REAL okeh8644 row, which for
+        // variant 2 genuinely is stuck (19 DOS + 30 Piece, 1 DOS = 24 Piece). So neither "stock is
+        // byte-identical to before" nor "no log row at all" is a valid invariant here any more.
+        // What this test actually cares about is unchanged and still asserted: inserting must not
+        // apply the COUNT itself -- that only happens at approval, below.
         $stock->refresh();
-        $this->assertSame($startingStock, $stock->ps_stock, 'inserting an opname must not touch stock before approval');
-        $this->assertSame($logCountBefore, DB::table('log_stocks')->count(), 'inserting an opname must not write a log_stocks row');
+        $this->assertNotSame($realQty, $stock->ps_stock, 'inserting an opname must not apply the counted real_qty to stock -- that is approval\'s job');
+        $stockAfterInsert = $stock->ps_stock;
+        $logCountAfterInsert = DB::table('log_stocks')->count();
 
         $accResponse = $this->post('/accStockOpname', $this->approvalPayload($stock, $stoId, $realQty));
         $accResponse->assertStatus(200);
@@ -121,12 +128,13 @@ class StockOpnameFlowTest extends TestCase
 
         $stock->refresh();
         $this->assertSame($realQty, $stock->ps_stock, 'approval must OVERWRITE stock with the counted real_qty, not add/subtract a delta');
+        $this->assertGreaterThan($logCountAfterInsert, DB::table('log_stocks')->count(), 'approval must write its own log_stocks rows');
 
         $this->assertDatabaseHas('log_stocks', [
             'log_type' => 1,
             'log_category' => 2,
             'log_item_id' => $stock->product_variant_id,
-            'log_jumlah' => $startingStock,
+            'log_jumlah' => $stockAfterInsert,
         ]);
         $this->assertDatabaseHas('log_stocks', [
             'log_type' => 1,

--- a/tests/Workflow/StockOpnameSystemStockHealTest.php
+++ b/tests/Workflow/StockOpnameSystemStockHealTest.php
@@ -1,0 +1,290 @@
+<?php
+
+namespace Tests\Workflow;
+
+use App\Models\Category;
+use App\Models\LogStock;
+use App\Models\Product;
+use App\Models\ProductRelation;
+use App\Models\ProductStock;
+use App\Models\ProductVariant;
+use App\Models\StockOpname;
+use App\Models\StockOpnameLine;
+use App\Models\Unit;
+use App\Support\StockOpname\OpnameLifecycle;
+use App\Support\StockOpname\OpnameLineReader;
+use Illuminate\Support\Facades\DB;
+use Tests\Support\ActingAsStaff;
+use Tests\TestCase;
+
+/**
+ * Permintaan user 2026-08-31 (GitHub #91, di-port dari main `aabafe2`): kalau stok LIVE sudah stuck
+ * under-rolled dari sebelum GitHub #87 (mis. HKCP60P: 12 DOS + 24 Piece padahal 1 DOS = 24 Piece,
+ * seharusnya 13 DOS + 0 Piece), membuat Stock Opname harus ikut menyembuhkan angka live itu untuk
+ * satuan yang TIDAK dihitung di dokumennya -- bukan cuma menggulung nilai hitungan di dalam dokumen
+ * (rollUpUnits(), yang sudah ada lebih dulu dan tidak menyentuh ps_stock sama sekali).
+ *
+ * Dipicu di dua titik (lihat StockController): insertStockOpname() (dokumen baru langsung
+ * menunggu) dan submitStockOpname() (draft -> menunggu). TIDAK dipicu selama masih draft.
+ *
+ * BEDA DARI VERSI MAIN: di sini penyembuhannya dipin ke gudang DOKUMEN, bukan gudang aktif sesi --
+ * main tidak punya konsep gudang untuk stok sama sekali. Lihat
+ * test_only_heals_stock_in_the_documents_own_warehouse() di bawah, yang mengunci justru kasus itu.
+ */
+class StockOpnameSystemStockHealTest extends TestCase
+{
+    use ActingAsStaff;
+
+    private const WAREHOUSE_ID = 1;
+    private const OTHER_WAREHOUSE_ID = 13;
+
+    private function staffId(): int
+    {
+        return (int) DB::table('staffs')->where('status', 1)->value('staff_id');
+    }
+
+    /** @return array{0: ProductVariant, 1: ProductStock, 2: ProductStock, 3: Unit, 4: Unit} */
+    private function makeFixtureWithLadder(int $dosStock, int $pcsStock, int $ratio = 24, int $warehouseId = self::WAREHOUSE_ID): array
+    {
+        $units = Unit::where('status', 1)->limit(2)->get();
+        $this->assertGreaterThanOrEqual(2, $units->count(), 'fixture butuh minimal 2 satuan aktif');
+        [$dosUnit, $pcsUnit] = $units->all();
+
+        $category = new Category();
+        $category->category_name = 'Opname Heal Test Category';
+        $category->status = 1;
+        $category->save();
+
+        $product = new Product();
+        $product->product_name = 'Opname Heal Test Product '.uniqid();
+        $product->category_id = $category->category_id;
+        $product->product_unit = json_encode([$dosUnit->unit_id, $pcsUnit->unit_id]);
+        $product->unit_id = $dosUnit->unit_id;
+        $product->status = 1;
+        $product->save();
+
+        $variant = new ProductVariant();
+        $variant->product_id = $product->product_id;
+        $variant->product_variant_name = 'Varian Uji Heal';
+        $variant->product_variant_sku = 'HEAL-'.uniqid();
+        $variant->product_variant_price = 0;
+        $variant->status = 1;
+        $variant->save();
+
+        $relation = new ProductRelation();
+        $relation->product_variant_id = $variant->product_variant_id;
+        $relation->pr_unit_id_1 = $dosUnit->unit_id; // besar
+        $relation->pr_unit_value_1 = 1;
+        $relation->pr_unit_id_2 = $pcsUnit->unit_id; // kecil
+        $relation->pr_unit_value_2 = $ratio;
+        $relation->status = 1;
+        $relation->save();
+
+        $stocks = [];
+        foreach ([[$dosUnit, $dosStock], [$pcsUnit, $pcsStock]] as [$unit, $qty]) {
+            $s = new ProductStock();
+            $s->product_id = $product->product_id;
+            $s->product_variant_id = $variant->product_variant_id;
+            $s->unit_id = $unit->unit_id;
+            $s->warehouse_id = $warehouseId;
+            $s->ps_stock = $qty;
+            $s->status = 1;
+            $s->save();
+            $stocks[] = $s;
+        }
+
+        return [$variant, $stocks[0], $stocks[1], $dosUnit, $pcsUnit];
+    }
+
+    /**
+     * Baca ulang satu baris stok TANPA global scope `active_warehouse` -- assertion di test ini
+     * harus melihat baris yang memang dimaksud, bukan baris gudang aktif sesi yang kebetulan
+     * berjalan. (Di main tidak perlu: tidak ada scope-nya sama sekali di sana.)
+     */
+    private function freshStock(ProductStock $stock): ProductStock
+    {
+        return ProductStock::withoutGlobalScope('active_warehouse')->findOrFail($stock->ps_id);
+    }
+
+    private function makeDocument(bool $isDraft, int $warehouseId = self::WAREHOUSE_ID): StockOpname
+    {
+        $sto = new StockOpname();
+        $sto->sto_date = now()->toDateString();
+        $sto->sto_code = 'H'.substr((string) microtime(true), -5);
+        $sto->staff_id = $this->staffId();
+        $sto->category_id = -1;
+        $sto->warehouse_id = $warehouseId;
+        $sto->status = OpnameLineReader::STATUS_MENUNGGU;
+        $sto->is_draft = $isDraft;
+        $sto->is_old_version = false;
+        $sto->save();
+
+        return $sto;
+    }
+
+    /** @param array<int, int|null> $countedByUnitId */
+    private function addLines(StockOpname $sto, ProductVariant $variant, array $countedByUnitId): void
+    {
+        foreach ($countedByUnitId as $unitId => $counted) {
+            StockOpnameLine::upsertLine([
+                'sto_id' => $sto->sto_id,
+                'product_id' => $variant->product_id,
+                'product_variant_id' => $variant->product_variant_id,
+                'unit_id' => $unitId,
+                'sol_counted_qty' => $counted,
+                'sol_notes' => null,
+            ]);
+        }
+    }
+
+    /** Persis contoh user: 12 DOS + 24 Piece (1 DOS = 24 Piece) -> 13 DOS + 0 Piece, kedua satuan tak dihitung. */
+    public function test_heals_untouched_stuck_under_rolled_stock_on_a_pending_document(): void
+    {
+        $this->actingAsSuperAdminStaff();
+        [$variant, $dos, $pcs] = $this->makeFixtureWithLadder(dosStock: 12, pcsStock: 24, ratio: 24);
+        $sto = $this->makeDocument(isDraft: false);
+        $this->addLines($sto, $variant, [$dos->unit_id => null, $pcs->unit_id => null]);
+
+        (new OpnameLifecycle())->healUntouchedSystemStock($sto);
+
+        $this->assertSame(13, (int) $this->freshStock($dos)->ps_stock);
+        $this->assertSame(0, (int) $this->freshStock($pcs)->ps_stock);
+    }
+
+    /** Satuan yang SEDANG dihitung staf tidak boleh disentuh -- ACC yang menimpanya langsung. */
+    public function test_does_not_touch_a_unit_currently_being_counted(): void
+    {
+        $this->actingAsSuperAdminStaff();
+        [$variant, $dos, $pcs] = $this->makeFixtureWithLadder(dosStock: 12, pcsStock: 24, ratio: 24);
+        $sto = $this->makeDocument(isDraft: false);
+        // Piece sedang dihitung staf (5) -- DOS dibiarkan kosong.
+        $this->addLines($sto, $variant, [$dos->unit_id => null, $pcs->unit_id => 5]);
+
+        (new OpnameLifecycle())->healUntouchedSystemStock($sto);
+
+        $this->assertSame(24, (int) $this->freshStock($pcs)->ps_stock, 'satuan yang sedang dihitung tidak boleh disembuhkan di sini');
+    }
+
+    /** Draft tidak boleh memicu penyembuhan sama sekali. */
+    public function test_does_nothing_while_still_draft(): void
+    {
+        [$variant, $dos, $pcs] = $this->makeFixtureWithLadder(dosStock: 12, pcsStock: 24, ratio: 24);
+        $sto = $this->makeDocument(isDraft: true);
+        $this->addLines($sto, $variant, [$dos->unit_id => null, $pcs->unit_id => null]);
+
+        (new OpnameLifecycle())->healUntouchedSystemStock($sto);
+
+        $this->assertSame(12, (int) $this->freshStock($dos)->ps_stock);
+        $this->assertSame(24, (int) $this->freshStock($pcs)->ps_stock);
+    }
+
+    /** Stok yang sudah benar tidak boleh berubah dan tidak boleh menulis log apa pun. */
+    public function test_is_a_no_op_when_stock_is_already_canonical(): void
+    {
+        [$variant, $dos, $pcs] = $this->makeFixtureWithLadder(dosStock: 13, pcsStock: 0, ratio: 24);
+        $sto = $this->makeDocument(isDraft: false);
+        $this->addLines($sto, $variant, [$dos->unit_id => null, $pcs->unit_id => null]);
+
+        $before = LogStock::count();
+        (new OpnameLifecycle())->healUntouchedSystemStock($sto);
+
+        $this->assertSame(13, (int) $this->freshStock($dos)->ps_stock);
+        $this->assertSame(0, (int) $this->freshStock($pcs)->ps_stock);
+        $this->assertSame($before, LogStock::count(), 'stok yang sudah kanonik tidak boleh menulis log');
+    }
+
+    /** Berjalan berkali-kali tidak boleh mengubah apa pun lagi setelah sembuh sekali. */
+    public function test_is_idempotent(): void
+    {
+        $this->actingAsSuperAdminStaff();
+        [$variant, $dos, $pcs] = $this->makeFixtureWithLadder(dosStock: 12, pcsStock: 24, ratio: 24);
+        $sto = $this->makeDocument(isDraft: false);
+        $this->addLines($sto, $variant, [$dos->unit_id => null, $pcs->unit_id => null]);
+
+        $lifecycle = new OpnameLifecycle();
+        $lifecycle->healUntouchedSystemStock($sto);
+        $lifecycle->healUntouchedSystemStock($sto);
+
+        $this->assertSame(13, (int) $this->freshStock($dos)->ps_stock);
+        $this->assertSame(0, (int) $this->freshStock($pcs)->ps_stock);
+    }
+
+    /**
+     * fase2-only, tidak ada di main: dokumen milik gudang A tidak boleh menyembuhkan (atau bahkan
+     * MEMBACA) stok gudang B. Kalau lookup-nya lupa dipin ke gudang dokumen, stok kedua gudang
+     * akan tergabung jadi satu kolam dan gudang B ikut ditulis ulang -- korupsi diam-diam persis
+     * seperti yang sudah diperbaiki di seluruh alur Stock Opname pada Batch 11.
+     */
+    public function test_only_heals_stock_in_the_documents_own_warehouse(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        // Gudang A: stuck (12 DOS + 24 Piece) -- ini yang dimiliki dokumen.
+        [$variant, $dosA, $pcsA, $dosUnit, $pcsUnit] = $this->makeFixtureWithLadder(
+            dosStock: 12, pcsStock: 24, ratio: 24, warehouseId: self::WAREHOUSE_ID
+        );
+
+        // Gudang B: varian yang SAMA, juga stuck, tapi bukan urusan dokumen ini sama sekali.
+        $dosB = new ProductStock();
+        $dosB->product_id = $variant->product_id;
+        $dosB->product_variant_id = $variant->product_variant_id;
+        $dosB->unit_id = $dosUnit->unit_id;
+        $dosB->warehouse_id = self::OTHER_WAREHOUSE_ID;
+        $dosB->ps_stock = 7;
+        $dosB->status = 1;
+        $dosB->save();
+
+        $pcsB = new ProductStock();
+        $pcsB->product_id = $variant->product_id;
+        $pcsB->product_variant_id = $variant->product_variant_id;
+        $pcsB->unit_id = $pcsUnit->unit_id;
+        $pcsB->warehouse_id = self::OTHER_WAREHOUSE_ID;
+        $pcsB->ps_stock = 48; // 48 Piece = 2 DOS -- juga stuck, tapi harus DIBIARKAN
+        $pcsB->status = 1;
+        $pcsB->save();
+
+        $sto = $this->makeDocument(isDraft: false, warehouseId: self::WAREHOUSE_ID);
+        $this->addLines($sto, $variant, [$dosUnit->unit_id => null, $pcsUnit->unit_id => null]);
+
+        (new OpnameLifecycle())->healUntouchedSystemStock($sto);
+
+        // Gudang A disembuhkan...
+        $this->assertSame(13, (int) $this->freshStock($dosA)->ps_stock);
+        $this->assertSame(0, (int) $this->freshStock($pcsA)->ps_stock);
+
+        // ...gudang B sama sekali tidak tersentuh, meski sama-sama stuck dan varian yang sama.
+        $this->assertSame(7, (int) $this->freshStock($dosB)->ps_stock, 'stok gudang lain tidak boleh ikut disembuhkan');
+        $this->assertSame(48, (int) $this->freshStock($pcsB)->ps_stock, 'stok gudang lain tidak boleh ikut disembuhkan');
+    }
+
+    /** Menembus insertStockOpname() sungguhan -- dokumen baru langsung menunggu memicu penyembuhan. */
+    public function test_wired_into_insert_stock_opname_endpoint(): void
+    {
+        $this->actingAsSuperAdminStaff();
+        $this->withActiveWarehouse(self::WAREHOUSE_ID);
+
+        [$variant, $dos, $pcs] = $this->makeFixtureWithLadder(dosStock: 12, pcsStock: 24, ratio: 24);
+
+        $items = json_encode([[
+            'product_id' => $variant->product_id,
+            'product_variant_id' => $variant->product_variant_id,
+            'units' => [
+                ['unit_id' => $dos->unit_id, 'real_qty' => null],
+                ['unit_id' => $pcs->unit_id, 'real_qty' => null],
+            ],
+        ]]);
+
+        $response = $this->post('/insertStockOpname', [
+            'sto_date' => now()->toDateString(),
+            'staff_id' => $this->staffId(),
+            'category_id' => -1,
+            'is_draft' => 0,
+            'item' => $items,
+        ]);
+
+        $response->assertStatus(200);
+
+        $this->assertSame(13, (int) $this->freshStock($dos)->ps_stock);
+        $this->assertSame(0, (int) $this->freshStock($pcs)->ps_stock);
+    }
+}


### PR DESCRIPTION
## Ringkasan

Batch 12 dari proses merge berkelanjutan `main` → `fase2/main` (lihat `cdocs/docs/fase2-merge-plan.md`). `main` bertambah 6 commit sejak Batch 11 dipotong: `c217531`, `d416aba` (#87/#88), `4d756d8` (sempat kepush langsung ke `main`, di-revert sebagai `d32d80a`), `349841b` (#89), dan `aabafe2` (#91). Bersihnya ada 4 pekerjaan — semuanya satu lingkup (keluarga roll-up GH #87), jadi digabung di sini alih-alih membuka Batch 13:

### 1. Perbaikan kecil — modul `getLog` yang salah (`c217531`)

`GeneralController::getLog()` sempat mengecek modul `Daftar Produk`/`Daftar Bahan Mentah` — itu sendiri koreksi yang keliru dari putaran sebelumnya (GH #68). Dibetulkan jadi `Stok Produk`/`Stok Bahan Mentah`. Test regresinya (`GetLogGatedByWrongModuleTest`) yang sebelumnya menganggap nama modul "Daftar" itu benar ikut diperbaiki.

### 2. GH #87 — roll-up satuan sekarang menggabungkan stok lama, bukan cuma kredit baru

Bug nyata yang dilaporkan user atas SKU HKCP60P: stok 11 DOS + 20 Piece, produksi menambah 4 Piece (1 DOS = 24 Piece) — seharusnya jadi 12 DOS + 0 Piece, kenyataannya tetap 11 DOS + 24 Piece selamanya. `UnitRollUp::plan()` memutuskan naik satuan hanya berdasarkan qty transaksi ini saja, tanpa pernah membaca stok yang sudah ada di baris itu.

**Porting ini jauh lebih ringkas dibanding diff aslinya di `main`**, karena arsitektur `fase2/main` (hasil Batch 11) sudah men-sentralkan semua kredit roll-up lewat `UnitRollUp::plan()`/`ProductUnitStock::addQty()` — duplikat privat `main` (`ProductionController::creditProductOutputUpChain()`, bagian terbesar dari diff aslinya) sudah tidak ada di sini, sudah dihapus di Batch 11 (`0863203`). Porting sesungguhnya:

- `UnitRollUp::plan()` dapat parameter `$existingByUnitId` + logika existing-aware-nya, sama persis dengan `main`.
- `existingProductStockByUnit()`/`existingSuppliesStockByUnit()` baru — **sadar-gudang sejak awal** (`?int $warehouseId`), beda dengan versi `main` yang tidak punya konsep gudang sama sekali dan secara eksplisit menandai SUM lintas-gudangnya sebagai jebakan untuk nanti. `fase2` sudah punya modul gudang itu, jadi langsung dibuat benar dari awal.
- `planProduct()`/`planSupplies()` diperbarui untuk menggabungkan stok existing (satu query melayani allow-list sekaligus peta existing). `planProductOutput()` baru meniru versi `main`, sadar-gudang.
- Kredit roll-up internal `ProductUnitStock::addQty()` diperbarui dengan cara yang sama — **tidak ada perubahan signature, tidak ada perubahan pemanggil** di kedua titik panggil `accProduction()`. Inilah hasil dari sentralisasi Batch 11: perbaikannya mendarat di SATU tempat, bukan empat.
- `ProductIssuesDetail`/`PurchaseOrderDeliveryDetail` memanggil `UnitRollUp::planSupplies()` langsung (tidak lewat `addQty()`) — perbaikan guard (`qty <= 0` → `qty === 0`) dan pencatatan log kredit negatif di-port persis seperti `main`.
- `CustomerController::updateSalesOrder()` TAHAP 1 — satu-satunya bagian diff `main` yang TIDAK berlaku di sini. `fase2` sudah mengganti jalur revert itu lewat `SalesOrderStock::executeRestore($rollUp=true)` → `ProductUnitStock::addQty()` sejak Batch 11, jadi bug urutan "tambah flat dulu baru dibatalkan" yang diperbaiki `main` memang tidak pernah ada di branch ini.

Test follow-up `main` (konfirmasi pembuatan baris stok baru hanya menyebut baris yang benar-benar akan dibuat) juga di-port sebagai test kunci — pre-check `fase2` sudah benar dari awal, jadi tidak perlu perbaikan kode, cuma menambah bukti test.

### 3. GH #89 — `stock:audit-rollup`, perintah diagnostik read-only

Menjawab pertanyaan "apakah #87 memperbaiki data yang sudah terlanjur stuck?" — tidak, cuma transaksi BERIKUTNYA yang memperbaiki baris itu. Perintah ini memindai semua baris dan melaporkan yang masih salah, tanpa menulis apa pun.

Ada dua bentuk, keduanya read-only:
- `php artisan stock:audit-rollup` (`--json` opsional)
- `docs/audit-stuck-unit-rollup-github87.sql` — versi SQL murni untuk dijalankan langsung di produksi lewat phpMyAdmin/Adminer/TablePlus/`mysql` CLI, tanpa perlu akses artisan/PHP.

**Diadaptasi, bukan sekadar di-port**: versi `main` mengelompokkan berdasarkan `product_variant_id`/`supplies_id` saja (tidak ada konsep gudang) — kalau ditempel apa adanya ke `fase2`, ini akan salah-lapor untuk varian yang punya satu baris sehat di gudang A dan satu baris sehat lain di gudang B (dua gudang independen, bukan kasus stuck). Dikelompokkan ulang jadi `(varian, gudang)`/`(bahan, gudang)`, memindai lewat `withoutGlobalScope('active_warehouse')`. Test baru mengunci bahwa kasus lintas-gudang ini TIDAK salah-dilaporkan — risiko yang murni spesifik ke `fase2`, tidak ada di test suite `main`. Versi SQL-nya mendapat perlakuan yang sama (setiap CTE kini mempartisi/join pada `(item, warehouse_id)`, output menyertakan `warehouse_id` + `warehouse_name`).

**Kedua implementasi diverifikasi silang terhadap data nyata (`okeh8644`), bukan diasumsikan setara**: keduanya secara independen menandai 3 item yang sama persis dengan angka before/after identik, termasuk kasus multi-hop yang tidak sepele (HIKARI SUPER GREASE: 5102 Piece + 0 DOS → 212 DOS + 14 Piece).

### 4. GH #91 — sembuhkan stok live yang stuck under-rolled saat Stock Opname mulai menunggu

`rollUpUnits()` selama ini cuma menggulung nilai HITUNGAN di dalam dokumen Stock Opname — tidak pernah menyentuh `product_stocks`/`supplies_stocks`. Akibatnya stok live yang sudah terlanjur stuck under-rolled dari sebelum #87 tetap salah selamanya, kecuali kebetulan ada transaksi stok-masuk lain yang menyentuhnya. `OpnameLifecycle::healUntouchedSystemStock()` baru (plus kembarannya di `BahanOpnameLifecycle`) menyembuhkan baris live-nya tepat saat dokumen berhenti jadi draft — persis momen staf mulai mempercayai angka itu. Hanya menyentuh satuan yang TIDAK sedang dihitung di dokumen itu (satuan yang dihitung toh akan ditimpa hasil hitungnya sendiri saat ACC). Dipasang di keempat pintu: `insertStockOpname()`/`insertStockOpnameBahan()` dan `submitStockOpname()`/`submitStockOpnameBahan()`.

**Adaptasi fase2 — lagi-lagi soal scoping gudang.** Versi `main` membaca `ProductStock::where('product_variant_id', ...)` tanpa filter gudang dan memanggil `collapseProduct($id, $qty)` tanpa `$warehouseId` — benar di sana (tidak ada konsep gudang untuk stok), tapi diam-diam merusak di sini: dokumen milik gudang A akan ikut menarik dan menulis ulang baris gudang B. Dipin ke `warehouse_id` dokumennya sendiri, persis seperti tetangganya `freezeSystemQty()`/`rollUpUnits()` (perbaikan yang sama sudah diterapkan Batch 11 ke seluruh alur ini). Baris log juga dapat `warehouse_id` + `log_saldo`, mengikuti konvensi `insertLog()` di branch ini.

Test baru `StockOpnameSystemStockHealTest` mem-port 6 kasus dari `main` plus 1 yang tidak ada di sana: `test_only_heals_stock_in_the_documents_own_warehouse()`. **Dipastikan test ini benar-benar menangkap bug-nya**, bukan lolos kosong — dengan sementara mengembalikan lookup-nya ke bentuk `main` yang tidak ter-scope: test gagal (gudang A tertinggal di 12 DOS karena 48 Piece gudang B ikut tergabung), lalu hijau lagi setelah dikembalikan.

**Dua test lama ikut berubah — di-baseline ulang, bukan ditutupi.** Keduanya memakai baris okeh8644 NYATA dan sama-sama kena varian 2, yang memang benar-benar stuck (19 DOS + 30 Piece) — baris yang sama persis dengan yang dilaporkan `stock:audit-rollup`. Jadi heal-nya memang benar menulis ulang baris itu saat insert, dan asumsi lama yang ditulis sebelum fitur ini ada jadi tidak berlaku:
- `StockOpnameFlowTest::test_insert_then_approve_overwrites_stock_and_writes_log` mengasumsikan "insert tidak boleh menyentuh stok / tidak boleh menulis log". Keduanya bukan invarian yang sahih lagi. Diganti dengan yang memang jadi inti test-nya dan masih benar: insert tidak boleh menerapkan HASIL HITUNG (itu tugas approval), dan approval harus menulis log-nya sendiri.
- `StockOpnameApprovalAtomicityTest` mengambil baseline sebelum insert. Dipindah ke sesudah insert: heal adalah langkah terpisah yang sudah ter-commit, BUKAN bagian dari transaksi `accStockOpname()` yang jadi pokok test itu.

## Testing

**742 test (naik dari 724), 0 gagal**, 10 skip (tidak terkait, sudah ada sebelumnya). Dijalankan 2x berturut-turut untuk memastikan stabil.

Closes #87
Closes #89
Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)
