### PR TITLE
fix: sembuhkan stok live yang stuck under-rolled saat Stock Opname mulai menunggu

### DIFF
--- a/app/Http/Controllers/StockController.php
+++ b/app/Http/Controllers/StockController.php
@@ -83,6 +83,12 @@ class StockController extends Controller
             // untuk draft: publish() sendiri yang menolak selama is_draft masih true.
             $lifecycle->publish(StockOpname::find($id));
 
+            // Sembuhkan stok live yang stuck under-rolled (mis. dari sebelum GitHub #87) untuk
+            // satuan yang TIDAK dihitung di dokumen ini -- lihat OpnameLifecycle::
+            // healUntouchedSystemStock(). Aman untuk draft: method-nya sendiri yang menolak
+            // selama is_draft masih true.
+            $lifecycle->healUntouchedSystemStock(StockOpname::find($id));
+
             return response()->json(['status' => 1, 'sto_id' => $id]);
         });
     }
@@ -137,7 +143,11 @@ class StockController extends Controller
         // Dokumen keluar dari draft di sini -- inilah saat snapshot identitas dibekukan untuk
         // alur draft (tombol .btn-ajukan). Idempoten, jadi tidak masalah kalau dokumen ini
         // ternyata sudah pernah publish lewat insert.
-        (new OpnameLifecycle())->publish(StockOpname::find($id));
+        $lifecycle = new OpnameLifecycle();
+        $lifecycle->publish(StockOpname::find($id));
+        // Draft -> menunggu adalah momen yang sama seperti insert langsung non-draft: sembuhkan
+        // stok live yang stuck under-rolled untuk satuan yang tidak dihitung di dokumen ini.
+        $lifecycle->healUntouchedSystemStock(StockOpname::find($id));
 
         return $id;
     }
@@ -741,6 +751,9 @@ class StockController extends Controller
             // draft ataupun langsung menunggu, sebelum publish() membekukan identitasnya.
             $lifecycle->rollUpUnits(StockOpnameBahan::find($id));
             $lifecycle->publish(StockOpnameBahan::find($id));
+            // Kembaran keputusan PM di insertStockOpname() Produk -- sembuhkan stok bahan yang
+            // stuck under-rolled untuk satuan yang tidak dihitung di dokumen ini.
+            $lifecycle->healUntouchedSystemStock(StockOpnameBahan::find($id));
 
             return response()->json(['status' => 1, 'stob_id' => $id]);
         });
@@ -782,7 +795,9 @@ class StockController extends Controller
     {
         $data = $req->all();
         $id = (new StockOpnameBahan())->submitStockOpnameBahan($data);
-        (new BahanOpnameLifecycle())->publish(StockOpnameBahan::find($id));
+        $lifecycle = new BahanOpnameLifecycle();
+        $lifecycle->publish(StockOpnameBahan::find($id));
+        $lifecycle->healUntouchedSystemStock(StockOpnameBahan::find($id));
 
         return $id;
     }

--- a/app/Support/StockOpname/BahanOpnameLifecycle.php
+++ b/app/Support/StockOpname/BahanOpnameLifecycle.php
@@ -2,6 +2,7 @@
 
 namespace App\Support\StockOpname;
 
+use App\Models\LogStock;
 use App\Models\Staff;
 use App\Models\StockOpnameBahanLine;
 use App\Models\Supplies;
@@ -113,6 +114,69 @@ class BahanOpnameLifecycle
                     'unit_id' => $credit['unit_id'],
                     'sobl_counted_qty' => $credit['qty'],
                     'sobl_notes' => $first->sobl_notes,
+                ]);
+            }
+        }
+    }
+
+    /**
+     * Kembaran persis OpnameLifecycle::healUntouchedSystemStock() (Produk), untuk Supplies. Lihat
+     * kelas itu untuk alasan lengkap.
+     */
+    public function healUntouchedSystemStock($stob): void
+    {
+        if (! $stob || $stob->is_draft || $stob->is_old_version) {
+            return;
+        }
+
+        $lines = StockOpnameBahanLine::getLines($stob->stob_id)->groupBy('supplies_id');
+
+        foreach ($lines as $suppliesId => $group) {
+            if (! $suppliesId) {
+                continue;
+            }
+
+            $touchedUnitIds = $group->filter(fn ($l) => $l->sobl_counted_qty !== null)
+                ->pluck('unit_id')->map(fn ($u) => (int) $u)->all();
+
+            $stocks = SuppliesStock::where('supplies_id', $suppliesId)
+                ->where('status', 1)
+                ->get();
+
+            $qtyByUnit = $stocks->pluck('ss_stock', 'unit_id')->map(fn ($q) => (int) $q)->all();
+            $collapsed = UnitRollUp::collapseSupplies((int) $suppliesId, $qtyByUnit);
+            if ($collapsed === []) {
+                continue;
+            }
+
+            $stocksByUnit = $stocks->keyBy('unit_id');
+
+            foreach ($collapsed as $credit) {
+                $unitId = (int) $credit['unit_id'];
+                if (in_array($unitId, $touchedUnitIds, true)) {
+                    continue;
+                }
+
+                $stock = $stocksByUnit->get($unitId);
+                $before = $stock ? (int) $stock->ss_stock : 0;
+                $after = (int) $credit['qty'];
+                if (! $stock || $before === $after) {
+                    continue;
+                }
+
+                $delta = $after - $before;
+                $stock->ss_stock = $after;
+                $stock->save();
+
+                (new LogStock())->insertLog([
+                    'log_date' => now(),
+                    'log_kode' => $stob->stob_code,
+                    'log_type' => 2,
+                    'log_category' => $delta > 0 ? 1 : 2,
+                    'log_item_id' => $suppliesId,
+                    'log_notes' => 'Konversi unit dari Stock Opname Bahan (perbaikan stok tergulung) '.LogStock::actorSuffix(),
+                    'log_jumlah' => abs($delta),
+                    'unit_id' => $unitId,
                 ]);
             }
         }

--- a/app/Support/StockOpname/OpnameLifecycle.php
+++ b/app/Support/StockOpname/OpnameLifecycle.php
@@ -2,6 +2,7 @@
 
 namespace App\Support\StockOpname;
 
+use App\Models\LogStock;
 use App\Models\Product;
 use App\Models\ProductStock;
 use App\Models\ProductVariant;
@@ -160,6 +161,83 @@ class OpnameLifecycle
                     'unit_id' => $credit['unit_id'],
                     'sol_counted_qty' => $credit['qty'],
                     'sol_notes' => $first->sol_notes,
+                ]);
+            }
+        }
+    }
+
+    /**
+     * Sembuhkan LIVE ps_stock produk yang ikut di dokumen ini SEBELUM dokumen mulai dipercaya --
+     * keputusan PM 2026-08-31: stok yang stuck under-rolled dari sebelum GitHub #87 (mis. 12 DOS +
+     * 24 Piece padahal 1 DOS = 24 Piece, seharusnya 13 DOS + 0 Piece) tetap salah selamanya kalau
+     * tidak ada transaksi stok-masuk lain yang kebetulan menyentuhnya (lihat docblock
+     * AuditStuckUnitRollUpCommand). Membuat Stock Opname adalah persis momen staf akan MEMPERCAYAI
+     * angka live itu, jadi sembuhkan di sini juga -- primitif yang sama (UnitRollUp::
+     * collapseProduct()) yang dipakai command audit itu dan rollUpUnits() di atas.
+     *
+     * HANYA menyentuh satuan yang TIDAK dihitung di dokumen ini (sol_counted_qty === null).
+     * Satuan yang sedang diisi staf akan ditimpa langsung oleh hasil hitungnya sendiri saat ACC
+     * (lihat accStockOpnameV2()), jadi menyembuhkannya di sini cuma kerja ganda yang percuma --
+     * dan tidak menyentuhnya menjaga efek method ini persis sebatas satuan yang memang diminta.
+     *
+     * Dipanggil dari insertStockOpname() (dokumen baru langsung menunggu) dan submitStockOpname()
+     * (draft -> menunggu). TIDAK dipanggil selama masih draft (dijaga is_draft di bawah) --
+     * idempoten, memanggilnya lagi pada produk yang sudah sembuh tidak mengubah apa pun lagi.
+     */
+    public function healUntouchedSystemStock($sto): void
+    {
+        if (! $sto || $sto->is_draft || $sto->is_old_version) {
+            return;
+        }
+
+        $lines = StockOpnameLine::getLines($sto->sto_id)->groupBy('product_variant_id');
+
+        foreach ($lines as $productVariantId => $group) {
+            if (! $productVariantId) {
+                continue;
+            }
+
+            $touchedUnitIds = $group->filter(fn ($l) => $l->sol_counted_qty !== null)
+                ->pluck('unit_id')->map(fn ($u) => (int) $u)->all();
+
+            $stocks = ProductStock::where('product_variant_id', $productVariantId)
+                ->where('status', 1)
+                ->get();
+
+            $qtyByUnit = $stocks->pluck('ps_stock', 'unit_id')->map(fn ($q) => (int) $q)->all();
+            $collapsed = UnitRollUp::collapseProduct((int) $productVariantId, $qtyByUnit);
+            if ($collapsed === []) {
+                continue;
+            }
+
+            $stocksByUnit = $stocks->keyBy('unit_id');
+
+            foreach ($collapsed as $credit) {
+                $unitId = (int) $credit['unit_id'];
+                if (in_array($unitId, $touchedUnitIds, true)) {
+                    continue;
+                }
+
+                $stock = $stocksByUnit->get($unitId);
+                $before = $stock ? (int) $stock->ps_stock : 0;
+                $after = (int) $credit['qty'];
+                if (! $stock || $before === $after) {
+                    continue;
+                }
+
+                $delta = $after - $before;
+                $stock->ps_stock = $after;
+                $stock->save();
+
+                (new LogStock())->insertLog([
+                    'log_date' => now(),
+                    'log_kode' => $sto->sto_code,
+                    'log_type' => 1,
+                    'log_category' => $delta > 0 ? 1 : 2,
+                    'log_item_id' => $productVariantId,
+                    'log_notes' => 'Konversi unit dari Stock Opname (perbaikan stok tergulung) '.LogStock::actorSuffix(),
+                    'log_jumlah' => abs($delta),
+                    'unit_id' => $unitId,
                 ]);
             }
         }

--- a/tests/Workflow/StockOpnameSystemStockHealTest.php
+++ b/tests/Workflow/StockOpnameSystemStockHealTest.php
@@ -1,0 +1,223 @@
+<?php
+
+namespace Tests\Workflow;
+
+use App\Models\Category;
+use App\Models\LogStock;
+use App\Models\Product;
+use App\Models\ProductRelation;
+use App\Models\ProductStock;
+use App\Models\ProductVariant;
+use App\Models\StockOpname;
+use App\Models\StockOpnameLine;
+use App\Models\Unit;
+use App\Support\StockOpname\OpnameLifecycle;
+use App\Support\StockOpname\OpnameLineReader;
+use Illuminate\Support\Facades\DB;
+use Tests\Support\ActingAsStaff;
+use Tests\TestCase;
+
+/**
+ * Permintaan user 2026-08-31: kalau stok LIVE sudah stuck under-rolled dari sebelum GitHub #87
+ * (mis. HKCP60P: 12 DOS + 24 Piece padahal 1 DOS = 24 Piece, seharusnya 13 DOS + 0 Piece), membuat
+ * Stock Opname harus ikut menyembuhkan angka live itu untuk satuan yang TIDAK dihitung di
+ * dokumennya -- bukan cuma menggulung nilai hitungan di dalam dokumen (rollUpUnits(), yang sudah
+ * ada lebih dulu dan tidak menyentuh ps_stock sama sekali).
+ *
+ * Dipicu di dua titik (lihat StockController): insertStockOpname() (dokumen baru langsung
+ * menunggu) dan submitStockOpname() (draft -> menunggu). TIDAK dipicu selama masih draft.
+ */
+class StockOpnameSystemStockHealTest extends TestCase
+{
+    use ActingAsStaff;
+
+    private function staffId(): int
+    {
+        return (int) DB::table('staffs')->where('status', 1)->value('staff_id');
+    }
+
+    /** @return array{0: ProductVariant, 1: ProductStock, 2: ProductStock, 3: Unit, 4: Unit} */
+    private function makeFixtureWithLadder(int $dosStock, int $pcsStock, int $ratio = 24): array
+    {
+        $units = Unit::where('status', 1)->limit(2)->get();
+        $this->assertGreaterThanOrEqual(2, $units->count(), 'fixture butuh minimal 2 satuan aktif');
+        [$dosUnit, $pcsUnit] = $units->all();
+
+        $category = new Category();
+        $category->category_name = 'Opname Heal Test Category';
+        $category->status = 1;
+        $category->save();
+
+        $product = new Product();
+        $product->product_name = 'Opname Heal Test Product '.uniqid();
+        $product->category_id = $category->category_id;
+        $product->product_unit = json_encode([$dosUnit->unit_id, $pcsUnit->unit_id]);
+        $product->unit_id = $dosUnit->unit_id;
+        $product->status = 1;
+        $product->save();
+
+        $variant = new ProductVariant();
+        $variant->product_id = $product->product_id;
+        $variant->product_variant_name = 'Varian Uji Heal';
+        $variant->product_variant_sku = 'HEAL-'.uniqid();
+        $variant->product_variant_price = 0;
+        $variant->status = 1;
+        $variant->save();
+
+        $relation = new ProductRelation();
+        $relation->product_variant_id = $variant->product_variant_id;
+        $relation->pr_unit_id_1 = $dosUnit->unit_id; // besar
+        $relation->pr_unit_value_1 = 1;
+        $relation->pr_unit_id_2 = $pcsUnit->unit_id; // kecil
+        $relation->pr_unit_value_2 = $ratio;
+        $relation->status = 1;
+        $relation->save();
+
+        $stocks = [];
+        foreach ([[$dosUnit, $dosStock], [$pcsUnit, $pcsStock]] as [$unit, $qty]) {
+            $s = new ProductStock();
+            $s->product_id = $product->product_id;
+            $s->product_variant_id = $variant->product_variant_id;
+            $s->unit_id = $unit->unit_id;
+            $s->warehouse_id = 1;
+            $s->ps_stock = $qty;
+            $s->status = 1;
+            $s->save();
+            $stocks[] = $s;
+        }
+
+        return [$variant, $stocks[0], $stocks[1], $dosUnit, $pcsUnit];
+    }
+
+    private function makeDocument(bool $isDraft): StockOpname
+    {
+        $sto = new StockOpname();
+        $sto->sto_date = now()->toDateString();
+        $sto->sto_code = 'H'.substr((string) microtime(true), -5);
+        $sto->staff_id = $this->staffId();
+        $sto->category_id = -1;
+        $sto->status = OpnameLineReader::STATUS_MENUNGGU;
+        $sto->is_draft = $isDraft;
+        $sto->is_old_version = false;
+        $sto->save();
+
+        return $sto;
+    }
+
+    /** @param array<int, int|null> $countedByUnitId */
+    private function addLines(StockOpname $sto, ProductVariant $variant, array $countedByUnitId): void
+    {
+        foreach ($countedByUnitId as $unitId => $counted) {
+            StockOpnameLine::upsertLine([
+                'sto_id' => $sto->sto_id,
+                'product_id' => $variant->product_id,
+                'product_variant_id' => $variant->product_variant_id,
+                'unit_id' => $unitId,
+                'sol_counted_qty' => $counted,
+                'sol_notes' => null,
+            ]);
+        }
+    }
+
+    /** Persis contoh user: 12 DOS + 24 Piece (1 DOS = 24 Piece) -> 13 DOS + 0 Piece, kedua satuan tak dihitung. */
+    public function test_heals_untouched_stuck_under_rolled_stock_on_a_pending_document(): void
+    {
+        $this->actingAsSuperAdminStaff();
+        [$variant, $dos, $pcs] = $this->makeFixtureWithLadder(dosStock: 12, pcsStock: 24, ratio: 24);
+        $sto = $this->makeDocument(isDraft: false);
+        $this->addLines($sto, $variant, [$dos->unit_id => null, $pcs->unit_id => null]);
+
+        (new OpnameLifecycle())->healUntouchedSystemStock($sto);
+
+        $this->assertSame(13, (int) ProductStock::find($dos->ps_id)->ps_stock);
+        $this->assertSame(0, (int) ProductStock::find($pcs->ps_id)->ps_stock);
+    }
+
+    /** Satuan yang SEDANG dihitung staf tidak boleh disentuh -- ACC yang menimpanya langsung. */
+    public function test_does_not_touch_a_unit_currently_being_counted(): void
+    {
+        $this->actingAsSuperAdminStaff();
+        [$variant, $dos, $pcs] = $this->makeFixtureWithLadder(dosStock: 12, pcsStock: 24, ratio: 24);
+        $sto = $this->makeDocument(isDraft: false);
+        // Piece sedang dihitung staf (5) -- DOS dibiarkan kosong.
+        $this->addLines($sto, $variant, [$dos->unit_id => null, $pcs->unit_id => 5]);
+
+        (new OpnameLifecycle())->healUntouchedSystemStock($sto);
+
+        $this->assertSame(24, (int) ProductStock::find($pcs->ps_id)->ps_stock, 'satuan yang sedang dihitung tidak boleh disembuhkan di sini');
+    }
+
+    /** Draft tidak boleh memicu penyembuhan sama sekali. */
+    public function test_does_nothing_while_still_draft(): void
+    {
+        [$variant, $dos, $pcs] = $this->makeFixtureWithLadder(dosStock: 12, pcsStock: 24, ratio: 24);
+        $sto = $this->makeDocument(isDraft: true);
+        $this->addLines($sto, $variant, [$dos->unit_id => null, $pcs->unit_id => null]);
+
+        (new OpnameLifecycle())->healUntouchedSystemStock($sto);
+
+        $this->assertSame(12, (int) ProductStock::find($dos->ps_id)->ps_stock);
+        $this->assertSame(24, (int) ProductStock::find($pcs->ps_id)->ps_stock);
+    }
+
+    /** Stok yang sudah benar tidak boleh berubah dan tidak boleh menulis log apa pun. */
+    public function test_is_a_no_op_when_stock_is_already_canonical(): void
+    {
+        [$variant, $dos, $pcs] = $this->makeFixtureWithLadder(dosStock: 13, pcsStock: 0, ratio: 24);
+        $sto = $this->makeDocument(isDraft: false);
+        $this->addLines($sto, $variant, [$dos->unit_id => null, $pcs->unit_id => null]);
+
+        $before = LogStock::count();
+        (new OpnameLifecycle())->healUntouchedSystemStock($sto);
+
+        $this->assertSame(13, (int) ProductStock::find($dos->ps_id)->ps_stock);
+        $this->assertSame(0, (int) ProductStock::find($pcs->ps_id)->ps_stock);
+        $this->assertSame($before, LogStock::count(), 'stok yang sudah kanonik tidak boleh menulis log');
+    }
+
+    /** Berjalan berkali-kali tidak boleh mengubah apa pun lagi setelah sembuh sekali. */
+    public function test_is_idempotent(): void
+    {
+        $this->actingAsSuperAdminStaff();
+        [$variant, $dos, $pcs] = $this->makeFixtureWithLadder(dosStock: 12, pcsStock: 24, ratio: 24);
+        $sto = $this->makeDocument(isDraft: false);
+        $this->addLines($sto, $variant, [$dos->unit_id => null, $pcs->unit_id => null]);
+
+        $lifecycle = new OpnameLifecycle();
+        $lifecycle->healUntouchedSystemStock($sto);
+        $lifecycle->healUntouchedSystemStock($sto);
+
+        $this->assertSame(13, (int) ProductStock::find($dos->ps_id)->ps_stock);
+        $this->assertSame(0, (int) ProductStock::find($pcs->ps_id)->ps_stock);
+    }
+
+    /** Menembus insertStockOpname() sungguhan -- dokumen baru langsung menunggu memicu penyembuhan. */
+    public function test_wired_into_insert_stock_opname_endpoint(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        [$variant, $dos, $pcs, , $pcsUnit] = $this->makeFixtureWithLadder(dosStock: 12, pcsStock: 24, ratio: 24);
+
+        $items = json_encode([[
+            'product_id' => $variant->product_id,
+            'product_variant_id' => $variant->product_variant_id,
+            'units' => [
+                ['unit_id' => $dos->unit_id, 'real_qty' => null],
+                ['unit_id' => $pcs->unit_id, 'real_qty' => null],
+            ],
+        ]]);
+
+        $response = $this->post('/insertStockOpname', [
+            'sto_date' => now()->toDateString(),
+            'staff_id' => $this->staffId(),
+            'category_id' => -1,
+            'is_draft' => 0,
+            'item' => $items,
+        ]);
+
+        $response->assertStatus(200);
+
+        $this->assertSame(13, (int) ProductStock::find($dos->ps_id)->ps_stock);
+        $this->assertSame(0, (int) ProductStock::find($pcs->ps_id)->ps_stock);
+    }
+}


### PR DESCRIPTION
## Masalah

Kalau stok di database sudah dalam kondisi salah (belum tergulung ke satuan besarnya) -- misalnya HKCP60P punya 12 DOS + 24 Piece, padahal 1 DOS = 24 Piece sehingga seharusnya sudah jadi 13 DOS + 0 Piece -- kondisi itu **tidak pernah otomatis sembuh** kalau tidak ada transaksi stok-masuk lain yang kebetulan menyentuh produk tersebut. `AuditStuckUnitRollUpCommand` (read-only) sudah bisa mendeteksi kasus ini, tapi tidak ada yang memperbaikinya.

`OpnameLifecycle::rollUpUnits()` yang sudah ada sebelumnya (dari GitHub #87) juga tidak menyelesaikan ini -- ia cuma menggulung nilai HITUNGAN di dalam dokumen Stock Opname itu sendiri (`sol_counted_qty`), sama sekali tidak menyentuh stok live (`ps_stock`/`ss_stock`).

## Perbaikan

Menambahkan `OpnameLifecycle::healUntouchedSystemStock()` (dan kembarannya `BahanOpnameLifecycle::healUntouchedSystemStock()` untuk Bahan/Supplies) yang:

- Memakai primitif yang sama dengan command audit di atas (`UnitRollUp::collapseProduct()`/`collapseSupplies()`) untuk menghitung breakdown kanonik stok live saat ini.
- Menulis ulang `ps_stock`/`ss_stock` **hanya untuk satuan yang TIDAK sedang dihitung** di dokumen tersebut -- satuan yang sedang dihitung staf akan ditimpa langsung oleh hasil hitungnya sendiri saat dokumen di-ACC, jadi menyembuhkannya di sini cuma kerja ganda yang percuma.
- Mencatat setiap koreksi ke `log_stocks` sebagai jejak audit ("Konversi unit dari Stock Opname (perbaikan stok tergulung)").
- Idempoten dan aman dipanggil berkali-kali (tidak menulis apa pun kalau stok sudah kanonik).

Dipicu di dua titik sesuai permintaan:
- `insertStockOpname()` / `insertStockOpnameBahan()` -- dokumen baru yang langsung berstatus "menunggu".
- `submitStockOpname()` / `submitStockOpnameBahan()` -- transisi draft -> menunggu.

Tidak dipicu selama dokumen masih draft.

## Testing

Menambahkan `tests/Workflow/StockOpnameSystemStockHealTest.php` (6 test): mereplikasi persis skenario 12 DOS + 24 Piece -> 13 DOS + 0 Piece, memastikan satuan yang sedang dihitung tidak ikut disentuh, draft tidak memicu apa pun, no-op kalau stok sudah kanonik (termasuk tidak menulis log), idempotensi, dan uji end-to-end lewat endpoint `/insertStockOpname" sungguhan.

Seluruh suite Stock Opname yang sudah ada (74 test) tetap hijau.

🤖 Generated with [Claude Code](https://claude.com/claude-code)