### PR TITLE
Batch 13: merge main → fase2/main — mode maintenance aplikasi (toggle logout semua user)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,11 @@ APP_FAKER_LOCALE=en_US
 APP_MAINTENANCE_DRIVER=file
 # APP_MAINTENANCE_STORE=database
 
+# Toggle maintenance Pegasus (logout semua user, blokir login & akses):
+# APP_MAINTENANCE_MODE=true
+# APP_MAINTENANCE_MESSAGE="Sistem sedang dalam pemeliharaan. Silakan coba lagi nanti."
+# Atau di server: php artisan app:maintenance on|off|status
+
 PHP_CLI_SERVER_WORKERS=4
 
 BCRYPT_ROUNDS=12

--- a/app/Console/Commands/AppMaintenanceCommand.php
+++ b/app/Console/Commands/AppMaintenanceCommand.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Support\AppMaintenance;
+use Illuminate\Console\Command;
+
+class AppMaintenanceCommand extends Command
+{
+    protected $signature = 'app:maintenance {action : on|off|status}';
+
+    protected $description = 'Toggle maintenance mode (logout semua user, blokir login & akses)';
+
+    public function handle(): int
+    {
+        $action = strtolower(trim((string) $this->argument('action')));
+
+        if ($action === 'status') {
+            $this->line('Maintenance: '.(AppMaintenance::enabled() ? 'ON' : 'OFF'));
+            $this->line('ENV APP_MAINTENANCE_MODE: '.(filter_var(config('maintenance.enabled'), FILTER_VALIDATE_BOOLEAN) ? 'true' : 'false'));
+            $this->line('File flag: '.(AppMaintenance::fileFlagEnabled() ? 'ada' : 'tidak ada'));
+
+            return self::SUCCESS;
+        }
+
+        if ($action === 'on') {
+            AppMaintenance::enableFileFlag();
+            $this->info('Maintenance ON — semua pengguna akan di-logout dan tidak bisa akses.');
+
+            return self::SUCCESS;
+        }
+
+        if ($action === 'off') {
+            AppMaintenance::disableFileFlag();
+            $this->info('Maintenance OFF (file flag dihapus). Matikan juga APP_MAINTENANCE_MODE di .env bila masih true.');
+
+            return self::SUCCESS;
+        }
+
+        $this->error('Action tidak dikenal. Pakai: on, off, atau status.');
+
+        return self::FAILURE;
+    }
+}

--- a/app/Http/Middleware/EnforceAppMaintenance.php
+++ b/app/Http/Middleware/EnforceAppMaintenance.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Support\AppMaintenance;
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Session;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Maintenance aplikasi — logout semua session & blokir akses (login termasuk).
+ * Toggle: APP_MAINTENANCE_MODE di .env atau `php artisan app:maintenance on|off`.
+ */
+class EnforceAppMaintenance
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (! AppMaintenance::enabled()) {
+            return $next($request);
+        }
+
+        if ($request->is('up')) {
+            return $next($request);
+        }
+
+        if (Session::isStarted()) {
+            Session::invalidate();
+            Session::regenerateToken();
+        }
+
+        $message = AppMaintenance::message();
+
+        if ($request->expectsJson() || $request->ajax()) {
+            return response()->json([
+                'status' => -1,
+                'message' => $message,
+                'maintenance' => true,
+            ], 503);
+        }
+
+        return response()->view('maintenance', [
+            'message' => $message,
+        ], 503);
+    }
+}

--- a/app/Support/AppMaintenance.php
+++ b/app/Support/AppMaintenance.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Support;
+
+class AppMaintenance
+{
+    public static function enabled(): bool
+    {
+        if (filter_var(config('maintenance.enabled'), FILTER_VALIDATE_BOOLEAN)) {
+            return true;
+        }
+
+        $file = (string) config('maintenance.file');
+
+        return $file !== '' && is_file($file);
+    }
+
+    public static function message(): string
+    {
+        return (string) config('maintenance.message');
+    }
+
+    public static function flagPath(): string
+    {
+        return (string) config('maintenance.file');
+    }
+
+    public static function enableFileFlag(): void
+    {
+        $path = self::flagPath();
+        if ($path === '') {
+            return;
+        }
+
+        $dir = dirname($path);
+        if (! is_dir($dir)) {
+            mkdir($dir, 0755, true);
+        }
+
+        file_put_contents($path, now()->toIso8601String());
+    }
+
+    public static function disableFileFlag(): void
+    {
+        $path = self::flagPath();
+        if ($path !== '' && is_file($path)) {
+            @unlink($path);
+        }
+    }
+
+    public static function fileFlagEnabled(): bool
+    {
+        $path = self::flagPath();
+
+        return $path !== '' && is_file($path);
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -32,6 +32,7 @@ return Application::configure(basePath: dirname(__DIR__))
         ]);
         $middleware->web(append: [
             \App\Http\Middleware\LogDashboardActivity::class,
+            \App\Http\Middleware\EnforceAppMaintenance::class,
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {

--- a/config/maintenance.php
+++ b/config/maintenance.php
@@ -1,0 +1,25 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Maintenance mode (toggle)
+    |--------------------------------------------------------------------------
+    |
+    | Aktif jika APP_MAINTENANCE_MODE=true di .env ATAU file flag ada
+    | (php artisan app:maintenance on). Semua pengguna di-logout dan tidak
+    | bisa login sampai dimatikan lagi.
+    |
+    */
+
+    'enabled' => env('APP_MAINTENANCE_MODE', false),
+
+    'message' => env(
+        'APP_MAINTENANCE_MESSAGE',
+        'Sistem sedang dalam pemeliharaan. Silakan coba lagi beberapa saat lagi.'
+    ),
+
+    'file' => storage_path('framework/app-maintenance.on'),
+
+];

--- a/resources/views/maintenance.blade.php
+++ b/resources/views/maintenance.blade.php
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="id">
+<head>
+    <meta charset="utf-8">
+    <title>Pemeliharaan Sistem — Pegasus</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="robots" content="noindex, nofollow">
+    <style>
+        body {
+            margin: 0;
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: 24px;
+            box-sizing: border-box;
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Arial, sans-serif;
+            background: linear-gradient(160deg, #082a58 0%, #0f3d7a 45%, #1e4a8c 100%);
+            color: #0f172a;
+        }
+        .card {
+            width: 100%;
+            max-width: 480px;
+            background: #fff;
+            border-radius: 16px;
+            box-shadow: 0 20px 50px rgba(0, 0, 0, 0.25);
+            padding: 40px 32px 32px;
+            text-align: center;
+        }
+        .logo {
+            max-width: 220px;
+            height: auto;
+            margin: 0 auto 24px;
+            display: block;
+        }
+        .icon {
+            width: 56px;
+            height: 56px;
+            margin: 0 auto 16px;
+            border-radius: 50%;
+            background: #eff6ff;
+            color: #2563eb;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 28px;
+        }
+        h1 {
+            margin: 0 0 12px;
+            font-size: 1.35rem;
+            font-weight: 700;
+            color: #0f172a;
+        }
+        p {
+            margin: 0;
+            line-height: 1.6;
+            color: #475569;
+            font-size: 15px;
+        }
+        .hint {
+            margin-top: 24px;
+            padding-top: 20px;
+            border-top: 1px solid #e2e8f0;
+            font-size: 13px;
+            color: #94a3b8;
+        }
+    </style>
+</head>
+<body>
+    <div class="card">
+        <img class="logo" src="{{ asset('assets/pegasus_banner_small.png') }}" alt="Pegasus">
+        <div class="icon" aria-hidden="true">&#9881;</div>
+        <h1>Sedang Dalam Pemeliharaan</h1>
+        <p>{{ $message ?? 'Sistem sedang dalam pemeliharaan. Silakan coba lagi beberapa saat lagi.' }}</p>
+        <p class="hint">Anda telah keluar dari sistem. Akses sementara tidak tersedia.</p>
+    </div>
+</body>
+</html>

--- a/tests/Regression/AppMaintenanceModeTest.php
+++ b/tests/Regression/AppMaintenanceModeTest.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Tests\Regression;
+
+use App\Support\AppMaintenance;
+use Illuminate\Support\Facades\Artisan;
+use Tests\Support\ActingAsExternalApiClient;
+use Tests\Support\ActingAsStaff;
+use Tests\TestCase;
+
+/**
+ * Ported from main `a0a7019` (rubenyw, no tests added upstream): a global toggle
+ * (`APP_MAINTENANCE_MODE` in `.env` or `php artisan app:maintenance on|off|status`) that logs out
+ * every session and blocks all `web`-group access, via `App\Http\Middleware\EnforceAppMaintenance`
+ * appended in `bootstrap/app.php`.
+ *
+ * fase2-specific concern this suite adds (no counterpart on main, which has no External API
+ * platform): the middleware is registered ONLY in the `web` middleware group, never `api` --
+ * confirmed here rather than assumed, since a global toggle silently also blocking third-party
+ * integrations (External API consumers) would be a much bigger incident than a blocked admin
+ * page. See routes/api.php's own docblock: External API routes are deliberately outside the web
+ * session/middleware stack entirely.
+ */
+class AppMaintenanceModeTest extends TestCase
+{
+    use ActingAsStaff;
+    use ActingAsExternalApiClient;
+
+    protected function tearDown(): void
+    {
+        config(['maintenance.enabled' => false]);
+        AppMaintenance::disableFileFlag();
+        parent::tearDown();
+    }
+
+    public function test_web_requests_pass_through_normally_when_maintenance_is_off(): void
+    {
+        config(['maintenance.enabled' => false]);
+        $this->actingAsSuperAdminStaff();
+
+        $response = $this->get('/');
+
+        $response->assertStatus(200);
+    }
+
+    public function test_a_normal_web_page_is_blocked_with_503_when_maintenance_is_on(): void
+    {
+        $this->actingAsSuperAdminStaff();
+        config(['maintenance.enabled' => true]);
+
+        $response = $this->get('/');
+
+        $response->assertStatus(503);
+        $response->assertViewIs('maintenance');
+    }
+
+    public function test_an_ajax_request_gets_a_json_503_instead_of_the_html_view(): void
+    {
+        $this->actingAsSuperAdminStaff();
+        config(['maintenance.enabled' => true]);
+
+        $response = $this->get('/', ['X-Requested-With' => 'XMLHttpRequest']);
+
+        $response->assertStatus(503);
+        $response->assertJson(['status' => -1, 'maintenance' => true]);
+    }
+
+    public function test_the_health_check_route_is_never_blocked(): void
+    {
+        config(['maintenance.enabled' => true]);
+
+        $response = $this->get('/up');
+
+        $response->assertStatus(200);
+    }
+
+    public function test_maintenance_invalidates_the_active_session(): void
+    {
+        $this->actingAsSuperAdminStaff();
+        $this->assertNotNull(session('user'));
+
+        config(['maintenance.enabled' => true]);
+        $this->get('/');
+
+        $this->assertNull(session('user'), 'the session must be logged out, not just refused access to the current page');
+    }
+
+    /**
+     * fase2-specific: External API routes live in the `api` middleware group (routes/api.php),
+     * never `web` -- EnforceAppMaintenance is only appended to `web` in bootstrap/app.php, so a
+     * global maintenance toggle must NOT reach third-party integrations at all.
+     */
+    public function test_external_api_routes_are_not_affected_by_maintenance_mode(): void
+    {
+        config(['maintenance.enabled' => true]);
+
+        $headers = $this->externalApiHeaders();
+        $response = $this->get('/api/external/v1/master/units', $headers);
+
+        $response->assertStatus(200);
+        $this->assertFalse(
+            str_contains((string) $response->getContent(), '"maintenance":true'),
+            'External API must never see the maintenance response shape'
+        );
+    }
+
+    public function test_artisan_command_toggles_the_file_flag(): void
+    {
+        AppMaintenance::disableFileFlag();
+        $this->assertFalse(AppMaintenance::fileFlagEnabled());
+
+        Artisan::call('app:maintenance', ['action' => 'on']);
+        $this->assertTrue(AppMaintenance::fileFlagEnabled());
+        $this->assertTrue(AppMaintenance::enabled());
+
+        Artisan::call('app:maintenance', ['action' => 'off']);
+        $this->assertFalse(AppMaintenance::fileFlagEnabled());
+    }
+
+    public function test_artisan_command_status_action_does_not_change_anything(): void
+    {
+        AppMaintenance::disableFileFlag();
+
+        $exitCode = Artisan::call('app:maintenance', ['action' => 'status']);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertFalse(AppMaintenance::fileFlagEnabled());
+    }
+}


### PR DESCRIPTION
## Ringkasan

Batch 13 dari proses merge berkelanjutan `main` → `fase2/main` (lihat `cdocs/docs/fase2-merge-plan.md`). `main` bertambah 1 commit sejak Batch 12 dipotong: `a0a7019` — fitur baru, di luar lingkup keluarga roll-up GH #87, jadi dibuka sebagai batch tersendiri.

## Yang di-port

Toggle maintenance mode global: `APP_MAINTENANCE_MODE` di `.env` atau `php artisan app:maintenance on|off|status`. Kalau aktif, **semua sesi di-logout** dan **semua akses `web` diblokir** (503 + halaman/JSON maintenance), lewat middleware baru `EnforceAppMaintenance` yang ditambahkan di `bootstrap/app.php`. Cherry-pick bersih, tidak perlu adaptasi kode untuk fase2 — tidak menyentuh apa pun yang sudah diubah batch-batch sebelumnya.

Commit aslinya tidak menyertakan test. Ditambahkan di sini:
- Normal tembus saat mode mati, 503 (halaman HTML untuk request biasa, JSON untuk AJAX) saat aktif.
- `/up` (health check) tidak pernah ikut diblokir.
- Sesi benar-benar di-invalidate, bukan cuma halaman saat itu yang ditolak.
- Perintah artisan `on`/`off`/`status` teruji.

## Temuan spesifik-fase2 (tidak ada padanannya di `main`)

`main` tidak punya platform External API, jadi tidak ada yang perlu dicek di sisi itu. Di sini, `EnforceAppMaintenance` HANYA didaftarkan di grup middleware `web`, bukan `api` — dan itu memang harus begitu, karena `routes/api.php` sendiri menegaskan seluruh rute External API sengaja berada di luar stack session/middleware `web`. Toggle maintenance yang diam-diam ikut memblokir integrasi pihak ketiga akan jadi insiden yang jauh lebih besar daripada sekadar halaman admin ke-block.

**Dipastikan test isolasinya benar-benar menangkap regresi**, bukan lolos kosong — dengan sementara memindahkan middleware ke grup `api`: test gagal (503) seperti yang diharapkan, lalu hijau lagi setelah dikembalikan.

## Testing

**732 test (naik dari 724), 0 gagal**, 10 skip (tidak terkait, sudah ada sebelumnya).
