### PR TITLE
fix: gulung Stock Opname melipat stok lama, gudang eceran hanya tampilkan satuan eceran

### DIFF
--- a/app/Models/ProductVariant.php
+++ b/app/Models/ProductVariant.php
@@ -72,6 +72,20 @@ class ProductVariant extends Model
 
         $variants = $result->get();
 
+        // Gudang eceran cuma boleh menghitung/menerima satuan eceran varian ini -- kembaran
+        // persis aturan StockController::getStock() (list Stok Produk), supaya konsumen endpoint
+        // ini (a.l. CreateStockOpname.js lewat /getProductVariant) tidak menawarkan satuan gudang
+        // utama (mis. DOS) di gudang yang memang hanya menyimpan eceran (mis. Piece).
+        $warehouseId = ProductStock::resolveWarehouseId(null);
+        $isMainWarehouse = true;
+        if ($warehouseId) {
+            $warehouse = Warehouse::query()
+                ->with(['type' => fn ($q) => $q->select('id', 'warehouse_type_name', 'is_main_warehouse')])
+                ->find($warehouseId);
+            $isMainWarehouse = ! $warehouse || ! $warehouse->type || (int) $warehouse->type->is_main_warehouse === 1;
+        }
+        $hasRetailUnitColumn = Schema::hasColumn('product_variants', 'retail_unit');
+
         // Menambahkan nama produk dari relasi
         foreach ($variants as $variant) {
             $p = Product::find($variant->product_id);
@@ -87,6 +101,13 @@ class ProductVariant extends Model
                 "product_variant_id" => $variant->product_variant_id,
                 "relations" => $variant->relasi,
             ]);
+
+            if (! $isMainWarehouse) {
+                $retailUnitId = $hasRetailUnitColumn ? (int) ($variant->retail_unit ?? 0) : 0;
+                $variant->stock = $retailUnitId > 0
+                    ? $variant->stock->filter(fn ($s) => (int) $s->unit_id === $retailUnitId)->values()
+                    : collect();
+            }
 
             // Get nama unit default
 

--- a/app/Support/UnitRollUp.php
+++ b/app/Support/UnitRollUp.php
@@ -110,14 +110,27 @@ class UnitRollUp
      * Satuan yang diisi tapi sama sekali tidak terhubung ke $chain (relasi tidak dikenal untuk
      * satuan itu) TIDAK ikut dihitung/ditulis di sini -- tetap seperti aslinya.
      *
+     * $existingByUnitId (perbaikan bug dilaporkan user, multi-gudang): stok LIVE yang sudah ada di
+     * satuan yang TIDAK diisi, dipakai sebagai bawaan default saat carry naik melewati satuan itu.
+     * Tanpa ini, "84 DOS (sudah benar) + isi Piece 1000 sendirian (1 DOS = 12 pcs)" tergulung jadi
+     * 83 DOS + 4 Piece -- DOS yang sudah ada 84 lenyap diam-diam digantikan angka yang cuma berasal
+     * dari perhitungan Piece, dan angka itu ikut tertulis ke ps_stock saat ACC karena tidak lagi
+     * NULL. Dengan bawaan ini, satuan yang tidak diisi menyumbang stok live-nya sendiri ke carry
+     * (84 + 83 = 167 DOS), match kekekalan jumlah fisik (84*12 + 1000 = 167*12 + 4). Kalau satuan
+     * itu MEMANG diisi eksplisit oleh staf, bawaan itu diabaikan (dianggap koreksi baru, bukan
+     * ditambah ke yang lama) -- lihat pemakaian `??` di bawah, entered selalu menang lebih dulu.
+     * Default [] mereproduksi perilaku lama persis (satuan pemanggil yang tidak pernah memberi ini).
+     *
      * @param  array<int, array{small: int, big: int, ratio: int}>  $chain
      * @param  array<int, int|null>  $qtyByUnitId  null = satuan ini TIDAK diisi
      * @param  array<int, int>  $allowedUnitIds
+     * @param  array<int, int>  $existingByUnitId  stok live per satuan, dipakai HANYA untuk satuan
+     *         yang tidak diisi di $qtyByUnitId (lihat penjelasan di atas)
      * @return array<int, array{unit_id: int, qty: int}>  hanya satuan yang benar-benar
      *         disentuh/dihasilkan gulungan ini -- satuan yang tidak diisi dan tidak ikut tergulung
      *         TIDAK muncul di sini sama sekali (biarkan tetap NULL, jangan ditulis ulang).
      */
-    public static function collapse(array $chain, array $qtyByUnitId, array $allowedUnitIds): array
+    public static function collapse(array $chain, array $qtyByUnitId, array $allowedUnitIds, array $existingByUnitId = []): array
     {
         $entered = array_filter($qtyByUnitId, fn ($q) => $q !== null);
         if ($entered === [] || $chain === []) {
@@ -165,8 +178,10 @@ class UnitRollUp
             $credits[] = ['unit_id' => $current, 'qty' => $carry % $rel['ratio']];
             // Lipat nilai yang staf isi SENDIRI di tingkat ini (kalau ada) ke dalam bawaan naik --
             // inilah yang membuat "DOS diisi 1 DAN pcs diisi 15" digabung benar (bukan cuma
-            // menggulung salah satu lalu mengabaikan yang lain).
-            $carry = (int) floor($carry / $rel['ratio']) + (int) ($enteredInChain[$rel['big']] ?? 0);
+            // menggulung salah satu lalu mengabaikan yang lain). Kalau TIDAK diisi, lipat stok
+            // LIVE yang sudah ada di satuan itu (bukan 0) -- lihat docblock $existingByUnitId di
+            // atas untuk alasan lengkap (satuan yang tidak disentuh tidak boleh lenyap).
+            $carry = (int) floor($carry / $rel['ratio']) + (int) ($enteredInChain[$rel['big']] ?? $existingByUnitId[$rel['big']] ?? 0);
             $current = $rel['big'];
             $visited[$current] = true;
         }
@@ -206,7 +221,8 @@ class UnitRollUp
         return self::collapse(
             self::productChain($productVariantId),
             $qtyByUnitId,
-            self::allowedProductUnitIds($productVariantId, $warehouseId)
+            self::allowedProductUnitIds($productVariantId, $warehouseId),
+            self::existingProductStockByUnit($productVariantId, $warehouseId)
         );
     }
 
@@ -223,8 +239,46 @@ class UnitRollUp
         return self::collapse(
             self::suppliesChain($suppliesId),
             $qtyByUnitId,
-            self::allowedSuppliesUnitIds($suppliesId, $warehouseId)
+            self::allowedSuppliesUnitIds($suppliesId, $warehouseId),
+            self::existingSuppliesStockByUnit($suppliesId, $warehouseId)
         );
+    }
+
+    /**
+     * Stok live saat ini per satuan -- dipakai collapseProduct() untuk melipat satuan yang TIDAK
+     * diisi ke dalam carry gulungan (lihat docblock collapse()'s $existingByUnitId). $warehouseId
+     * berperilaku persis seperti allowedProductUnitIds() -- dipin ke SATU gudang, bukan scope
+     * gudang aktif sesi, karena di multi-gudang (product_stocks, unit) bukan lagi baris tunggal.
+     *
+     * @return array<int, int> unit_id => ps_stock
+     */
+    public static function existingProductStockByUnit(int $productVariantId, ?int $warehouseId = null): array
+    {
+        return (($warehouseId !== null)
+                ? ProductStock::withoutGlobalScope('active_warehouse')->where('warehouse_id', $warehouseId)
+                : ProductStock::query())
+            ->where('product_variant_id', $productVariantId)
+            ->where('status', 1)
+            ->pluck('ps_stock', 'unit_id')
+            ->map(fn ($q) => (int) $q)
+            ->all();
+    }
+
+    /**
+     * Kembaran existingProductStockByUnit() untuk Bahan/Supplies -- lihat docblock itu.
+     *
+     * @return array<int, int> unit_id => ss_stock
+     */
+    public static function existingSuppliesStockByUnit(int $suppliesId, ?int $warehouseId = null): array
+    {
+        return (($warehouseId !== null)
+                ? SuppliesStock::withoutGlobalScope('active_warehouse')->where('warehouse_id', $warehouseId)
+                : SuppliesStock::query())
+            ->where('supplies_id', $suppliesId)
+            ->where('status', 1)
+            ->pluck('ss_stock', 'unit_id')
+            ->map(fn ($q) => (int) $q)
+            ->all();
     }
 
     /**

--- a/tests/Unit/UnitRollUpTest.php
+++ b/tests/Unit/UnitRollUpTest.php
@@ -313,4 +313,71 @@ class UnitRollUpTest extends TestCase
 
         $this->assertSame(100, $total);
     }
+
+    // ---------------------------------------------------------- collapse() $existingByUnitId
+
+    /**
+     * Bug dilaporkan user (multi-gudang, 2026-08-31): stok live sudah 84 DOS + 0 Piece (sudah
+     * kanonik, 1 DOS = 12 Piece). Staf isi HANYA Piece = 1000, DOS dibiarkan kosong. Tanpa melipat
+     * stok live yang sudah ada di DOS ke dalam carry, hasilnya 83 DOS + 4 Piece -- 84 DOS yang
+     * sudah ada lenyap diam-diam DIGANTIKAN angka yang cuma berasal dari perhitungan Piece
+     * sendirian, dan angka itu ikut tertulis ke ps_stock saat ACC karena tidak lagi NULL.
+     */
+    public function test_collapse_folds_existing_live_stock_of_an_untouched_unit_into_the_carry(): void
+    {
+        $result = UnitRollUp::collapse(
+            $this->ladder(),
+            [self::PIECE => 1000, self::DOS => null, self::SAK => null],
+            $this->allUnits(),
+            [self::DOS => 84] // stok live yang sudah ada, DOS tidak disentuh dokumen ini
+        );
+
+        $this->assertSame([
+            ['unit_id' => self::PIECE, 'qty' => 4],
+            // 84 lama + 83 hasil gulungan 1000 pcs = 167, lalu ikut naik lagi ke SAK (1 Sak = 2 DOS)
+            ['unit_id' => self::DOS, 'qty' => 1],
+            ['unit_id' => self::SAK, 'qty' => 83],
+        ], $result);
+
+        // Kekekalan fisik: 84 DOS lama (1008 pcs) + 1000 pcs baru = 2008, harus sama dengan hasil.
+        $pieceEquivalent = [self::PIECE => 1, self::DOS => 12, self::SAK => 24];
+        $total = 0;
+        foreach ($result as $credit) {
+            $total += $credit['qty'] * $pieceEquivalent[$credit['unit_id']];
+        }
+        $this->assertSame(84 * 12 + 1000, $total);
+    }
+
+    /** Default [] (pemanggil lama yang tidak memberi existingByUnitId) tidak boleh berubah perilakunya. */
+    public function test_collapse_without_existing_by_unit_id_reproduces_the_old_behaviour(): void
+    {
+        $result = UnitRollUp::collapse(
+            $this->ladder(),
+            [self::PIECE => 1000, self::DOS => null, self::SAK => null],
+            $this->allUnits()
+        );
+
+        $this->assertSame([
+            ['unit_id' => self::PIECE, 'qty' => 4],
+            ['unit_id' => self::DOS, 'qty' => 1],
+            ['unit_id' => self::SAK, 'qty' => 41],
+        ], $result);
+    }
+
+    /** Satuan yang DIISI EKSPLISIT oleh staf tidak boleh ikut dilipat dengan stok lamanya -- itu koreksi baru, bukan tambahan. */
+    public function test_collapse_ignores_existing_stock_for_a_unit_the_staff_explicitly_filled(): void
+    {
+        $result = UnitRollUp::collapse(
+            $this->ladder(),
+            [self::PIECE => 15, self::DOS => 1, self::SAK => null],
+            $this->allUnits(),
+            [self::DOS => 84] // harus diabaikan -- DOS diisi eksplisit oleh staf jadi 1
+        );
+
+        $this->assertSame([
+            ['unit_id' => self::PIECE, 'qty' => 3],
+            ['unit_id' => self::DOS, 'qty' => 0],
+            ['unit_id' => self::SAK, 'qty' => 1], // (15 pcs -> 1 DOS + 3 pcs) + DOS diisi 1 = 2 DOS = 1 SAK, BUKAN + 84
+        ], $result);
+    }
 }

--- a/tests/Workflow/StockOpnameBahanV2LifecycleTest.php
+++ b/tests/Workflow/StockOpnameBahanV2LifecycleTest.php
@@ -342,10 +342,14 @@ class StockOpnameBahanV2LifecycleTest extends TestCase
         return [$supplies, $dos, $pcs, $dosUnit, $pcsUnit];
     }
 
-    /** Contoh persis dari PM: 1 DOS = 12 pcs, isi 30 pcs -> tersimpan 2 DOS + 6 pcs. */
+    /**
+     * Contoh persis dari PM: 1 DOS = 12 pcs, isi 30 pcs -> tersimpan 2 DOS + 6 pcs. DOS live
+     * sengaja 0 di sini -- lihat kembaran Produknya di StockOpnameV2LifecycleTest untuk kasus DOS
+     * yang sudah punya stok live.
+     */
     public function test_roll_up_converts_a_filled_small_unit_into_an_untouched_big_one(): void
     {
-        [$supplies, $dos, $pcs] = $this->makeFixtureWithLadder();
+        [$supplies, $dos, $pcs] = $this->makeFixtureWithLadder(dosStock: 0);
         $stob = $this->makeDocument(isDraft: false);
         $this->addLines($stob, $supplies, [$pcs->unit_id => 30, $dos->unit_id => null]);
 
@@ -360,7 +364,7 @@ class StockOpnameBahanV2LifecycleTest extends TestCase
     public function test_roll_up_applies_equally_to_draft_and_pending_documents(): void
     {
         foreach ([true, false] as $isDraft) {
-            [$supplies, $dos, $pcs] = $this->makeFixtureWithLadder();
+            [$supplies, $dos, $pcs] = $this->makeFixtureWithLadder(dosStock: 0);
             $stob = $this->makeDocument(isDraft: $isDraft);
             $this->addLines($stob, $supplies, [$pcs->unit_id => 30, $dos->unit_id => null]);
 
@@ -415,6 +419,22 @@ class StockOpnameBahanV2LifecycleTest extends TestCase
         $lines = StockOpnameBahanLine::getLines($stob->stob_id)->keyBy('unit_id');
         $this->assertSame(30, (int) $lines[$pcs->unit_id]->sobl_counted_qty);
         $this->assertNull($lines[$dos->unit_id]->sobl_counted_qty);
+    }
+
+    /** Kembaran persis Produk -- lihat StockOpnameV2LifecycleTest untuk alasan lengkap. */
+    public function test_roll_up_folds_existing_live_stock_of_an_untouched_unit_instead_of_erasing_it(): void
+    {
+        [$supplies, $dos, $pcs] = $this->makeFixtureWithLadder(dosStock: 84, pcsStock: 0, ratio: 12);
+        $stob = $this->makeDocument(isDraft: false);
+        $stob->warehouse_id = 1;
+        $stob->save();
+        $this->addLines($stob, $supplies, [$pcs->unit_id => 1000, $dos->unit_id => null]);
+
+        (new BahanOpnameLifecycle())->rollUpUnits($stob);
+
+        $lines = StockOpnameBahanLine::getLines($stob->stob_id)->keyBy('unit_id');
+        $this->assertSame(4, (int) $lines[$pcs->unit_id]->sobl_counted_qty);
+        $this->assertSame(167, (int) $lines[$dos->unit_id]->sobl_counted_qty, '84 DOS lama harus ikut terbawa, bukan digantikan angka dari Piece saja');
     }
 
     public function test_roll_up_does_nothing_on_a_legacy_document(): void

--- a/tests/Workflow/StockOpnameRetailWarehouseUnitVisibilityTest.php
+++ b/tests/Workflow/StockOpnameRetailWarehouseUnitVisibilityTest.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace Tests\Workflow;
+
+use App\Models\Category;
+use App\Models\Product;
+use App\Models\ProductStock;
+use App\Models\ProductVariant;
+use App\Models\Warehouse;
+use Tests\Support\ActingAsStaff;
+use Tests\Support\ResolvesTestWarehouses;
+use Tests\TestCase;
+
+/**
+ * Bug dilaporkan user (multi-gudang, 2026-08-31): saat gudang aktif adalah Gudang Eceran (bukan
+ * Gudang Utama), halaman Buat Stock Opname (CreateStockOpname.js lewat GET /getProductVariant,
+ * ProductVariant::getProductVariant()) menawarkan SEMUA satuan varian (mis. DOS dan Piece),
+ * padahal StockController::getStock() (list Stok Produk) sudah lebih dulu membatasi gudang eceran
+ * hanya ke retail_unit varian itu sendiri. Perbaikannya menyamakan aturan ini di
+ * ProductVariant::getProductVariant().
+ *
+ * Gudang di sini di-resolve dari data snapshot yang sedang dimuat (bisa okeh8644 atau seed
+ * minimal, lihat memory pegasus-testing-db-multiwarehouse-drift) -- bukan id yang di-hardcode --
+ * supaya test ini tidak tergantung dataset mana yang aktif. Route /getProductVariant digerbangi
+ * `check.access:Daftar Produk|view`, jadi gudang yang dipakai harus benar-benar mengizinkan modul
+ * itu di `sidebar_menus`-nya.
+ */
+class StockOpnameRetailWarehouseUnitVisibilityTest extends TestCase
+{
+    use ActingAsStaff;
+    use ResolvesTestWarehouses;
+
+    private const DOS_UNIT_ID = 7;
+    private const PIECE_UNIT_ID = 9;
+
+    private function resolveActiveMainWarehouseId(): int
+    {
+        $id = Warehouse::query()
+            ->where('status', 1)
+            ->whereHas('type', fn ($q) => $q->where('is_main_warehouse', 1))
+            ->get()
+            ->first(fn ($w) => $w->allowsSidebarMenu('Daftar Produk'))
+            ?->id;
+
+        if (! $id) {
+            $this->fail('No active main warehouse allowing "Daftar Produk" exists in the loaded test data.');
+        }
+
+        return (int) $id;
+    }
+
+    /** @return array{0: ProductVariant, 1: int, 2: int} varian, gudang utama id, gudang eceran id */
+    private function makeFixture(): array
+    {
+        $mainWarehouseId = $this->resolveActiveMainWarehouseId();
+        $retailWarehouseId = $this->resolveActiveRetailWarehouseId('Daftar Produk');
+
+        $category = new Category();
+        $category->category_name = 'Opname Retail Visibility Test Category';
+        $category->status = 1;
+        $category->save();
+
+        $product = new Product();
+        $product->product_name = 'Opname Retail Visibility Test Product '.uniqid();
+        $product->category_id = $category->category_id;
+        $product->product_unit = json_encode([self::DOS_UNIT_ID, self::PIECE_UNIT_ID]);
+        $product->unit_id = self::DOS_UNIT_ID;
+        $product->status = 1;
+        $product->save();
+
+        $variant = new ProductVariant();
+        $variant->product_id = $product->product_id;
+        $variant->product_variant_name = 'Varian Uji Retail Visibility';
+        $variant->product_variant_sku = 'RETVIS-'.uniqid();
+        $variant->product_variant_price = 0;
+        $variant->retail_unit = self::PIECE_UNIT_ID;
+        $variant->unit_id = self::DOS_UNIT_ID;
+        $variant->status = 1;
+        $variant->save();
+
+        foreach ([$mainWarehouseId, $retailWarehouseId] as $warehouseId) {
+            foreach ([self::DOS_UNIT_ID, self::PIECE_UNIT_ID] as $unitId) {
+                $s = new ProductStock();
+                $s->product_id = $product->product_id;
+                $s->product_variant_id = $variant->product_variant_id;
+                $s->unit_id = $unitId;
+                $s->warehouse_id = $warehouseId;
+                $s->ps_stock = 10;
+                $s->status = 1;
+                $s->save();
+            }
+        }
+
+        return [$variant, $mainWarehouseId, $retailWarehouseId];
+    }
+
+    public function test_retail_warehouse_only_shows_the_variants_retail_unit(): void
+    {
+        $this->actingAsSuperAdminStaff();
+        [$variant, , $retailWarehouseId] = $this->makeFixture();
+
+        $this->withActiveWarehouse($retailWarehouseId);
+
+        $rows = (new ProductVariant())->getProductVariant(['product_variant_id' => $variant->product_variant_id]);
+        $row = collect($rows)->first();
+
+        $this->assertNotNull($row, 'variant harus tetap muncul di daftar');
+        $unitIds = collect($row->stock)->pluck('unit_id')->map(fn ($u) => (int) $u)->all();
+        $this->assertSame([self::PIECE_UNIT_ID], $unitIds, 'gudang eceran hanya boleh menawarkan retail_unit varian ini');
+    }
+
+    public function test_main_warehouse_shows_every_unit(): void
+    {
+        $this->actingAsSuperAdminStaff();
+        [$variant, $mainWarehouseId] = $this->makeFixture();
+
+        $this->withActiveWarehouse($mainWarehouseId);
+
+        $rows = (new ProductVariant())->getProductVariant(['product_variant_id' => $variant->product_variant_id]);
+        $row = collect($rows)->first();
+
+        $unitIds = collect($row->stock)->pluck('unit_id')->map(fn ($u) => (int) $u)->sort()->values()->all();
+        $this->assertSame([self::DOS_UNIT_ID, self::PIECE_UNIT_ID], $unitIds, 'gudang utama harus menawarkan semua satuan');
+    }
+
+    /** Varian tanpa retail_unit di gudang eceran tidak boleh menawarkan satuan apa pun (bukan malah semuanya). */
+    public function test_retail_warehouse_hides_everything_when_variant_has_no_retail_unit(): void
+    {
+        $this->actingAsSuperAdminStaff();
+        [$variant, , $retailWarehouseId] = $this->makeFixture();
+        $variant->retail_unit = null;
+        $variant->save();
+
+        $this->withActiveWarehouse($retailWarehouseId);
+
+        $rows = (new ProductVariant())->getProductVariant(['product_variant_id' => $variant->product_variant_id]);
+        $row = collect($rows)->first();
+
+        $this->assertCount(0, $row->stock);
+    }
+
+    /** Menembus endpoint sungguhan yang dipakai CreateStockOpname.js. */
+    public function test_wired_into_get_product_variant_endpoint(): void
+    {
+        $this->actingAsSuperAdminStaff();
+        [$variant, , $retailWarehouseId] = $this->makeFixture();
+
+        $this->withActiveWarehouse($retailWarehouseId);
+
+        $response = $this->get('/getProductVariant?search_product='.urlencode($variant->product_variant_sku));
+        $response->assertStatus(200);
+
+        $row = collect($response->json())->first();
+        $this->assertNotNull($row, 'variant harus tetap muncul di daftar');
+        $unitIds = collect($row['stock'])->pluck('unit_id')->map(fn ($u) => (int) $u)->all();
+        $this->assertSame([self::PIECE_UNIT_ID], $unitIds);
+    }
+}

--- a/tests/Workflow/StockOpnameV2LifecycleTest.php
+++ b/tests/Workflow/StockOpnameV2LifecycleTest.php
@@ -386,10 +386,14 @@ class StockOpnameV2LifecycleTest extends TestCase
         return [$variant, $dos, $pcs, $dosUnit, $pcsUnit];
     }
 
-    /** Contoh persis dari PM: 1 DOS = 12 pcs, isi 30 pcs -> tersimpan 2 DOS + 6 pcs. */
+    /**
+     * Contoh persis dari PM: 1 DOS = 12 pcs, isi 30 pcs -> tersimpan 2 DOS + 6 pcs. DOS live
+     * sengaja 0 di sini -- kasus DOS yang SUDAH punya stok live dipegang terpisah oleh
+     * test_roll_up_folds_existing_live_stock_of_an_untouched_unit_instead_of_erasing_it().
+     */
     public function test_roll_up_converts_a_filled_small_unit_into_an_untouched_big_one(): void
     {
-        [$variant, $dos, $pcs] = $this->makeFixtureWithLadder();
+        [$variant, $dos, $pcs] = $this->makeFixtureWithLadder(dosStock: 0);
         $sto = $this->makeDocument(isDraft: false);
         $this->addLines($sto, $variant, [$pcs->unit_id => 30, $dos->unit_id => null]);
 
@@ -404,7 +408,7 @@ class StockOpnameV2LifecycleTest extends TestCase
     public function test_roll_up_applies_equally_to_draft_and_pending_documents(): void
     {
         foreach ([true, false] as $isDraft) {
-            [$variant, $dos, $pcs] = $this->makeFixtureWithLadder();
+            [$variant, $dos, $pcs] = $this->makeFixtureWithLadder(dosStock: 0);
             $sto = $this->makeDocument(isDraft: $isDraft);
             $this->addLines($sto, $variant, [$pcs->unit_id => 30, $dos->unit_id => null]);
 
@@ -464,6 +468,29 @@ class StockOpnameV2LifecycleTest extends TestCase
         $lines = StockOpnameLine::getLines($sto->sto_id)->keyBy('unit_id');
         $this->assertSame(30, (int) $lines[$pcs->unit_id]->sol_counted_qty);
         $this->assertNull($lines[$dos->unit_id]->sol_counted_qty);
+    }
+
+    /**
+     * Bug dilaporkan user (multi-gudang, 2026-08-31): stok live SUDAH kanonik (84 DOS + 0 Piece,
+     * 1 DOS = 12 Piece). Staf isi HANYA Piece = 1000, DOS dibiarkan kosong. Sebelum perbaikan ini,
+     * rollUpUnits() menggulung 1000 pcs SENDIRIAN (buta terhadap 84 DOS yang sudah ada) jadi
+     * cuma 83 DOS + 4 Piece -- 84 DOS lama lenyap diam-diam, dan angka rekaan itu ikut tertulis ke
+     * ps_stock saat ACC karena tidak lagi NULL. Perbaikannya melipat stok live yang sudah ada di
+     * DOS (satuan yang tidak disentuh) ke dalam carry gulungan.
+     */
+    public function test_roll_up_folds_existing_live_stock_of_an_untouched_unit_instead_of_erasing_it(): void
+    {
+        [$variant, $dos, $pcs] = $this->makeFixtureWithLadder(dosStock: 84, pcsStock: 0, ratio: 12);
+        $sto = $this->makeDocument(isDraft: false);
+        $sto->warehouse_id = 1;
+        $sto->save();
+        $this->addLines($sto, $variant, [$pcs->unit_id => 1000, $dos->unit_id => null]);
+
+        (new OpnameLifecycle())->rollUpUnits($sto);
+
+        $lines = StockOpnameLine::getLines($sto->sto_id)->keyBy('unit_id');
+        $this->assertSame(4, (int) $lines[$pcs->unit_id]->sol_counted_qty);
+        $this->assertSame(167, (int) $lines[$dos->unit_id]->sol_counted_qty, '84 DOS lama harus ikut terbawa, bukan digantikan angka dari Piece saja');
     }
 
     /** rollUpUnits() harus keluar lebih dulu untuk dokumen lama, tidak boleh menyentuh apa pun. */


### PR DESCRIPTION
## Masalah 1: gulung satuan Stock Opname menghapus stok lama yang tidak disentuh

Kalau stok live SUDAH kanonik (mis. 84 DOS + 0 Piece, 1 DOS = 12 Piece) dan staf membuat Stock Opname dengan HANYA mengisi Piece = 1000 (DOS dibiarkan kosong), hasilnya jadi **83 DOS + 4 Piece** -- 84 DOS yang sudah ada lenyap diam-diam, digantikan angka yang cuma berasal dari perhitungan Piece sendirian. Angka rekaan ini bukan sekadar tampilan: karena `sol_counted_qty`-nya tidak lagi NULL, angka itu ikut TERTULIS ke `ps_stock` saat dokumen di-ACC.

Akar masalahnya di `UnitRollUp::collapse()` (dipakai `OpnameLifecycle`/`BahanOpnameLifecycle::rollUpUnits()` di setiap simpan) -- rekursif menggulung satuan kecil ke satuan besar TAPI buta terhadap stok live yang sudah ada di satuan yang tidak diisi.

### Perbaikan
`collapse()` sekarang menerima `$existingByUnitId` opsional: stok live per satuan, dipakai sebagai bawaan default carry HANYA untuk satuan yang **tidak diisi** staf. Kalau satuan itu diisi eksplisit, bawaan itu diabaikan (dianggap koreksi baru, bukan tambahan atas yang lama). `collapseProduct()`/`collapseSupplies()` otomatis mengambil stok live gudang dokumen lewat helper baru `existingProductStockByUnit()`/`existingSuppliesStockByUnit()` (dipin ke gudang dokumen, bukan gudang aktif sesi).

Hasil yang benar untuk contoh di atas: **4 Piece + 167 DOS** (84 lama + 83 dari gulungan 1000 pcs) -- kekal secara fisik: 84×12 + 1000 = 167×12 + 4 = 2008.

## Masalah 2: gudang eceran menampilkan semua satuan produk, bukan cuma satuan eceran

Saat gudang aktif adalah tipe **Gudang Eceran** (bukan Gudang Utama), halaman Buat Stock Opname (`CreateStockOpname.js` lewat `GET /getProductVariant`) menawarkan **semua** satuan varian (mis. DOS dan Piece) -- padahal `StockController::getStock()` (list Stok Produk) sudah lebih dulu membatasi gudang eceran hanya ke `retail_unit` varian itu sendiri. Dua endpoint berbeda, dua aturan berbeda, untuk hal yang seharusnya sama.

### Perbaikan
`ProductVariant::getProductVariant()` (sumber `/getProductVariant`, juga dipakai `searchProduct` Sales Order dan halaman Stok Produk legacy) sekarang mengecek tipe gudang aktif: kalau bukan gudang utama, baris stok difilter ke unit_id = `retail_unit` varian tsb saja. Varian tanpa `retail_unit` tidak menampilkan satuan apa pun di gudang eceran (bukan malah menampilkan semuanya).

## Testing

- `tests/Unit/UnitRollUpTest.php`: 3 test baru untuk `$existingByUnitId` (melipat stok lama, perilaku lama tetap sama kalau parameter tidak diberi, satuan yang diisi eksplisit tidak ikut dilipat).
- `tests/Workflow/StockOpnameV2LifecycleTest.php` + kembaran Bahan: regresi persis skenario 84 DOS + 1000 Piece lewat `rollUpUnits()` sungguhan. 2 test lama yang kebetulan memakai stok DOS awal non-nol (12) diubah fixture-nya ke 0 supaya tetap menguji contoh asli PM ("1 DOS = 12 pcs, isi 30 pcs -> 2 DOS + 6 pcs") tanpa tumpang tindih dengan kasus baru.
- `tests/Workflow/StockOpnameRetailWarehouseUnitVisibilityTest.php` (baru, 4 test): gudang eceran hanya retail_unit, gudang utama semua satuan, varian tanpa retail_unit tidak menampilkan apa pun, dan uji end-to-end lewat endpoint `/getProductVariant` sungguhan.

Seluruh `tests/Workflow`, `tests/Unit`, `tests/DatabaseTransaction`, `tests/Regression` (467 test) hijau setelah perubahan ini.

**Catatan terpisah (bukan bagian PR ini):** menjalankan seluruh test suite sekaligus (semua folder) crash duluan karena `app/Models/PurchaseOrdersDetail.php` (duplikat class dari `PurchaseOrderDetail.php`) masih ada di `fase2/main` -- ini sudah pernah diperbaiki di riwayat lain (GitHub #38) tapi filenya balik lagi di branch ini. Dilaporkan terpisah, tidak ikut dibereskan di PR ini karena di luar cakupan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)