### PR TITLE
fix: perbaikan UI modal Produksi - scroll, tombol tertutup, dan dropdown autocomplete

### DIFF
--- a/.agents/skills/pegasus-modal-dropdown/SKILL.md
+++ b/.agents/skills/pegasus-modal-dropdown/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: pegasus-modal-dropdown
+description: How to make a Bootstrap modal scroll internally (long tables, many rows) without breaking Select2 dropdowns inside it, in the okejob-pegasus Kanakku admin theme. Load before adding modal-dialog-scrollable to any modal, before debugging a modal whose footer is pushed off-screen or won't scroll, or before debugging a Select2/autocomplete dropdown that floats to the wrong place, gets cut off, or renders behind the modal.
+---
+
+# Bootstrap modal scrolling + Select2 dropdowns in Kanakku modals
+
+This app's modals are hand-built Blade partials (`resources/views/components/modals/**`), not a
+component library, so every "make this modal scroll" or "the dropdown is in the wrong place" bug
+has to be solved by hand against Bootstrap 5's CSS + Select2 4.0's positioning JS. Both have sharp
+edges that look like unrelated bugs but are really the same handful of root causes. This was all
+learned the hard way fixing GitHub #101 (Produksi modal) — read this before repeating that work.
+
+## Symptom → root cause map
+
+| Symptom | Root cause |
+|---|---|
+| Footer buttons (Simpan/Terima/Tolak) pushed below viewport, unreachable | Modal has no height cap at all — it just grows with content. |
+| Modal doesn't scroll *at all* after adding `modal-dialog-scrollable` | Bare Bootstrap classes aren't enough once `<form>` wraps `.modal-body`/`.modal-footer` — every flex level between `.modal-content` and `.modal-body` needs explicit `min-height:0`, or `.modal-content`'s `overflow:hidden` just clips instead of letting `.modal-body` scroll. |
+| Modal is full-viewport-tall even with 1-2 rows (empty state wastes space) | `.modal-content`/`.modal-dialog` forced to a fixed `height`, not just capped with `max-height`. |
+| Modal caps/scrolls fine when empty but overflows past the viewport at some medium row count, no scrollbar | `.modal-content { max-height: 100% }` (a *percentage*) depends on `.modal-dialog` resolving a *definite* height. If `.modal-dialog` is `height:auto` (needed for the empty-state fix above), that resolution is ambiguous/unreliable across browsers. Use an absolute cap (`calc(100dvh - Xrem)`) on `.modal-content` instead of a percentage — it doesn't depend on the parent at all. |
+| Select2 dropdown renders far away from its field (e.g. top-left of modal) | `dropdownParent` was set to the outer `.modal` element itself. `.modal` is `position:fixed`, and jQuery's `.offset()` math is unreliable against a `position:fixed` ancestor. Never use the outer `.modal` as `dropdownParent`. |
+| Select2 dropdown drifts further from its field with every row added, only while the modal is scrollable | `dropdownParent` was set to the *scrolling element itself* (`.modal-body`). Select2 computes the dropdown's position from `.offset()` values that don't compensate for how far you've had to scroll to reach the field, so the error grows with scroll distance (which grows with row count if the field is pinned near the bottom of a growing list). Point `dropdownParent` at a non-scrolling ancestor instead — normally `.modal-content` (see below). |
+| Select2 dropdown gets cut off / clipped at the modal's edge near the bottom of a long list | `.modal-content` now needs `overflow:hidden` for the scroll fix above, and the dropdown is a DOM child of `dropdownParent` — if `dropdownParent` is `.modal-content` (or anything inside it), the same `overflow:hidden` clips the dropdown once it grows past that box. |
+| Select2 dropdown renders but appears *behind* the modal, invisible | Only happens once you move `dropdownParent` to `body` (see below): Bootstrap's `.modal` is `z-index:1055`, Select2's dropdown defaults to `z-index:1051` — lower. Once the dropdown is a sibling of `.modal` in the DOM, it needs a z-index bump above 1055 or the modal paints over it. |
+
+## The fix, as a checklist
+
+**1. Making a modal scroll internally (long table / many rows), footer pinned:**
+
+Add `modal-dialog-scrollable` to the `.modal-dialog` class list, then add a scoped `<style>`
+block (see `resources/views/components/modals/warehouse/add-warehouse.blade.php` or the fully
+worked example in `resources/views/components/modals/production/add-production.blade.php`) that:
+
+- Cancels Bootstrap's forced full-height so short content doesn't force a tall empty modal:
+  `#id .modal-dialog { height: auto !important; max-height: calc(100dvh - 2rem) !important; }`
+- Caps `.modal-content` with an **absolute** cap, not a percentage:
+  `#id .modal-content { height: auto !important; max-height: calc(100dvh - 2rem) !important; min-height: 0 !important; display: flex !important; flex-direction: column !important; overflow: hidden !important; }`
+- Forces `min-height: 0 !important` on **every** flex level in between if the modal wraps
+  `.modal-body`/`.modal-footer` in a `<form>` (very common in this codebase) — on the `form` itself
+  and on `.modal-body`, each with `flex: 1 1 auto` so `.modal-body` is the thing that actually
+  scrolls (`overflow-y: auto`), not the whole modal.
+- Pins `.modal-header`/`.modal-footer` with `flex: 0 0 auto`.
+
+Don't skip the `min-height:0` chain — it's the single most common way this half-works ("scrolls a
+little, then clips" or "doesn't scroll at all").
+
+**2. Any Select2/autocomplete `dropdownParent` inside that same modal:**
+
+- Default choice, and what the majority of existing modals in this app already do: point
+  `dropdownParent` at `"#modalId .modal-content"` (a non-scrolling ancestor). This also gets you a
+  free correctness bonus — Select2 locks/freezes the scroll of any scrollable ancestor
+  (`.modal-body`) while its dropdown is open, so the position can't go stale mid-session.
+- **Only** if that modal's `.modal-content` has `overflow:hidden` (i.e. you did step 1 above) AND
+  the field can end up near the bottom of a long scrolled list, `.modal-content` will clip the
+  dropdown. In that case use `dropdownParent: "body"` instead (there's precedent:
+  `Stock_Transfer.js`'s warehouse filter already does this) — and pair it with a z-index bump:
+  `.select2-dropdown { z-index: 1065 !important; }` (anything comfortably above Bootstrap's modal
+  `z-index:1055`) somewhere in that modal's own `<style>` block.
+- Never point `dropdownParent` at the outer `.modal` element, and never at `.modal-body` if
+  `.modal-body` is the actual scrolling container.
+
+## Where to look for a worked example
+
+`resources/views/components/modals/production/add-production.blade.php` +
+`public/Custom_js/Backoffice/Production/Production.js` (the `#product_id` /
+`#production_destination_warehouse_id` autocompletes) is the fully-debugged reference — it hit
+every row in the symptom table above, in the order listed, across GitHub issue #101. Diff its
+`<style>` block and `dropdownParent` calls against a broken modal before re-deriving any of this
+from scratch.

--- a/.claude/skills/pegasus-modal-dropdown/SKILL.md
+++ b/.claude/skills/pegasus-modal-dropdown/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: pegasus-modal-dropdown
+description: How to make a Bootstrap modal scroll internally (long tables, many rows) without breaking Select2 dropdowns inside it, in the okejob-pegasus Kanakku admin theme. Load before adding modal-dialog-scrollable to any modal, before debugging a modal whose footer is pushed off-screen or won't scroll, or before debugging a Select2/autocomplete dropdown that floats to the wrong place, gets cut off, or renders behind the modal.
+---
+
+# Bootstrap modal scrolling + Select2 dropdowns in Kanakku modals
+
+This app's modals are hand-built Blade partials (`resources/views/components/modals/**`), not a
+component library, so every "make this modal scroll" or "the dropdown is in the wrong place" bug
+has to be solved by hand against Bootstrap 5's CSS + Select2 4.0's positioning JS. Both have sharp
+edges that look like unrelated bugs but are really the same handful of root causes. This was all
+learned the hard way fixing GitHub #101 (Produksi modal) — read this before repeating that work.
+
+## Symptom → root cause map
+
+| Symptom | Root cause |
+|---|---|
+| Footer buttons (Simpan/Terima/Tolak) pushed below viewport, unreachable | Modal has no height cap at all — it just grows with content. |
+| Modal doesn't scroll *at all* after adding `modal-dialog-scrollable` | Bare Bootstrap classes aren't enough once `<form>` wraps `.modal-body`/`.modal-footer` — every flex level between `.modal-content` and `.modal-body` needs explicit `min-height:0`, or `.modal-content`'s `overflow:hidden` just clips instead of letting `.modal-body` scroll. |
+| Modal is full-viewport-tall even with 1-2 rows (empty state wastes space) | `.modal-content`/`.modal-dialog` forced to a fixed `height`, not just capped with `max-height`. |
+| Modal caps/scrolls fine when empty but overflows past the viewport at some medium row count, no scrollbar | `.modal-content { max-height: 100% }` (a *percentage*) depends on `.modal-dialog` resolving a *definite* height. If `.modal-dialog` is `height:auto` (needed for the empty-state fix above), that resolution is ambiguous/unreliable across browsers. Use an absolute cap (`calc(100dvh - Xrem)`) on `.modal-content` instead of a percentage — it doesn't depend on the parent at all. |
+| Select2 dropdown renders far away from its field (e.g. top-left of modal) | `dropdownParent` was set to the outer `.modal` element itself. `.modal` is `position:fixed`, and jQuery's `.offset()` math is unreliable against a `position:fixed` ancestor. Never use the outer `.modal` as `dropdownParent`. |
+| Select2 dropdown drifts further from its field with every row added, only while the modal is scrollable | `dropdownParent` was set to the *scrolling element itself* (`.modal-body`). Select2 computes the dropdown's position from `.offset()` values that don't compensate for how far you've had to scroll to reach the field, so the error grows with scroll distance (which grows with row count if the field is pinned near the bottom of a growing list). Point `dropdownParent` at a non-scrolling ancestor instead — normally `.modal-content` (see below). |
+| Select2 dropdown gets cut off / clipped at the modal's edge near the bottom of a long list | `.modal-content` now needs `overflow:hidden` for the scroll fix above, and the dropdown is a DOM child of `dropdownParent` — if `dropdownParent` is `.modal-content` (or anything inside it), the same `overflow:hidden` clips the dropdown once it grows past that box. |
+| Select2 dropdown renders but appears *behind* the modal, invisible | Only happens once you move `dropdownParent` to `body` (see below): Bootstrap's `.modal` is `z-index:1055`, Select2's dropdown defaults to `z-index:1051` — lower. Once the dropdown is a sibling of `.modal` in the DOM, it needs a z-index bump above 1055 or the modal paints over it. |
+
+## The fix, as a checklist
+
+**1. Making a modal scroll internally (long table / many rows), footer pinned:**
+
+Add `modal-dialog-scrollable` to the `.modal-dialog` class list, then add a scoped `<style>`
+block (see `resources/views/components/modals/warehouse/add-warehouse.blade.php` or the fully
+worked example in `resources/views/components/modals/production/add-production.blade.php`) that:
+
+- Cancels Bootstrap's forced full-height so short content doesn't force a tall empty modal:
+  `#id .modal-dialog { height: auto !important; max-height: calc(100dvh - 2rem) !important; }`
+- Caps `.modal-content` with an **absolute** cap, not a percentage:
+  `#id .modal-content { height: auto !important; max-height: calc(100dvh - 2rem) !important; min-height: 0 !important; display: flex !important; flex-direction: column !important; overflow: hidden !important; }`
+- Forces `min-height: 0 !important` on **every** flex level in between if the modal wraps
+  `.modal-body`/`.modal-footer` in a `<form>` (very common in this codebase) — on the `form` itself
+  and on `.modal-body`, each with `flex: 1 1 auto` so `.modal-body` is the thing that actually
+  scrolls (`overflow-y: auto`), not the whole modal.
+- Pins `.modal-header`/`.modal-footer` with `flex: 0 0 auto`.
+
+Don't skip the `min-height:0` chain — it's the single most common way this half-works ("scrolls a
+little, then clips" or "doesn't scroll at all").
+
+**2. Any Select2/autocomplete `dropdownParent` inside that same modal:**
+
+- Default choice, and what the majority of existing modals in this app already do: point
+  `dropdownParent` at `"#modalId .modal-content"` (a non-scrolling ancestor). This also gets you a
+  free correctness bonus — Select2 locks/freezes the scroll of any scrollable ancestor
+  (`.modal-body`) while its dropdown is open, so the position can't go stale mid-session.
+- **Only** if that modal's `.modal-content` has `overflow:hidden` (i.e. you did step 1 above) AND
+  the field can end up near the bottom of a long scrolled list, `.modal-content` will clip the
+  dropdown. In that case use `dropdownParent: "body"` instead (there's precedent:
+  `Stock_Transfer.js`'s warehouse filter already does this) — and pair it with a z-index bump:
+  `.select2-dropdown { z-index: 1065 !important; }` (anything comfortably above Bootstrap's modal
+  `z-index:1055`) somewhere in that modal's own `<style>` block.
+- Never point `dropdownParent` at the outer `.modal` element, and never at `.modal-body` if
+  `.modal-body` is the actual scrolling container.
+
+## Where to look for a worked example
+
+`resources/views/components/modals/production/add-production.blade.php` +
+`public/Custom_js/Backoffice/Production/Production.js` (the `#product_id` /
+`#production_destination_warehouse_id` autocompletes) is the fully-debugged reference — it hit
+every row in the symptom table above, in the order listed, across GitHub issue #101. Diff its
+`<style>` block and `dropdownParent` calls against a broken modal before re-deriving any of this
+from scratch.

--- a/public/Custom_js/Backoffice/Production/Production.js
+++ b/public/Custom_js/Backoffice/Production/Production.js
@@ -1,4 +1,4 @@
-autocompleteBom("#product_id", "#addProduction");
+autocompleteBom("#product_id", "#addProduction .modal-body");
 autocompleteSupplies("#fix_recipe_supplies_id", "#fixRecipeBom .modal-content");
 var mode = 1; // 1 = insert; 2 = edit; 3 = view
 var modeBahan = 1;
@@ -78,7 +78,7 @@ function syncProductionDestinationControl() {
         if (typeof autocompleteWarehouse === "function") {
             autocompleteWarehouse(
                 "#production_destination_warehouse_id",
-                "#addProduction",
+                "#addProduction .modal-body",
                 { placeholder: "Pilih gudang eceran tujuan", retailOnly: true },
             );
         }

--- a/public/Custom_js/Backoffice/Production/Production.js
+++ b/public/Custom_js/Backoffice/Production/Production.js
@@ -1,4 +1,4 @@
-autocompleteBom("#product_id", "#addProduction .modal-body");
+autocompleteBom("#product_id", "#addProduction .modal-content");
 autocompleteSupplies("#fix_recipe_supplies_id", "#fixRecipeBom .modal-content");
 var mode = 1; // 1 = insert; 2 = edit; 3 = view
 var modeBahan = 1;
@@ -78,7 +78,7 @@ function syncProductionDestinationControl() {
         if (typeof autocompleteWarehouse === "function") {
             autocompleteWarehouse(
                 "#production_destination_warehouse_id",
-                "#addProduction .modal-body",
+                "#addProduction .modal-content",
                 { placeholder: "Pilih gudang eceran tujuan", retailOnly: true },
             );
         }

--- a/public/Custom_js/Backoffice/Production/Production.js
+++ b/public/Custom_js/Backoffice/Production/Production.js
@@ -1,4 +1,4 @@
-autocompleteBom("#product_id", "#addProduction .modal-content");
+autocompleteBom("#product_id", "body");
 autocompleteSupplies("#fix_recipe_supplies_id", "#fixRecipeBom .modal-content");
 var mode = 1; // 1 = insert; 2 = edit; 3 = view
 var modeBahan = 1;
@@ -78,7 +78,7 @@ function syncProductionDestinationControl() {
         if (typeof autocompleteWarehouse === "function") {
             autocompleteWarehouse(
                 "#production_destination_warehouse_id",
-                "#addProduction .modal-content",
+                "body",
                 { placeholder: "Pilih gudang eceran tujuan", retailOnly: true },
             );
         }

--- a/resources/views/components/modals/production/add-production.blade.php
+++ b/resources/views/components/modals/production/add-production.blade.php
@@ -7,15 +7,14 @@
     overflow: hidden !important;
   }
   #addProduction .modal-dialog {
-    height: calc(100dvh - 2rem) !important;
+    height: auto !important;
     max-height: calc(100dvh - 2rem) !important;
-    min-height: 0 !important;
     margin: 1rem auto !important;
     display: flex !important;
-    align-items: stretch !important;
+    align-items: center !important;
   }
   #addProduction .modal-content {
-    height: 100% !important;
+    height: auto !important;
     max-height: 100% !important;
     min-height: 0 !important;
     display: flex !important;

--- a/resources/views/components/modals/production/add-production.blade.php
+++ b/resources/views/components/modals/production/add-production.blade.php
@@ -1,7 +1,7 @@
 <div class="modal custom-modal fade pg-modal--form" id="addProduction" aria-modal="true" role="dialog" tabindex="-1"
   data-bs-backdrop="static">
-  <div class="modal-dialog modal-dialog-centered modal-xl">
-    <div class="modal-content">
+  <div class="modal-dialog modal-dialog-centered modal-xl modal-dialog-scrollable">
+    <div class="modal-content d-flex flex-column">
       <div class="modal-header">
         <div class="d-flex align-items-center gap-3">
           <div class="pg-modal-icon">
@@ -16,8 +16,8 @@
         </div>
         <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
-      <form action="#" class="d-flex flex-column h-100" style="margin: 0; min-height: 0;">
-        <div class="modal-body p-0 bg-light d-flex flex-column" style="overflow-y:auto;">
+      <form action="#" class="d-flex flex-column flex-grow-1" style="margin: 0; min-height: 0;">
+        <div class="modal-body p-0 bg-light d-flex flex-column flex-grow-1">
 
           <div class="p-4 border-bottom bg-white shadow-sm" style="flex: 0 0 auto;">
             <div class="row g-4">

--- a/resources/views/components/modals/production/add-production.blade.php
+++ b/resources/views/components/modals/production/add-production.blade.php
@@ -15,7 +15,7 @@
   }
   #addProduction .modal-content {
     height: auto !important;
-    max-height: 100% !important;
+    max-height: calc(100dvh - 2rem) !important;
     min-height: 0 !important;
     display: flex !important;
     flex-direction: column !important;

--- a/resources/views/components/modals/production/add-production.blade.php
+++ b/resources/views/components/modals/production/add-production.blade.php
@@ -40,6 +40,13 @@
     overflow-y: auto !important;
     overflow-x: hidden !important;
   }
+  /* Nama Produk / Gudang Tujuan autocompletes are appended to <body> (not
+     .modal-content) so their dropdown can't get clipped by the modal's own
+     overflow:hidden. Bootstrap's .modal is z-index 1055, above select2's
+     default 1051 - bump it so the dropdown isn't hidden behind the modal. */
+  .select2-dropdown {
+    z-index: 1065 !important;
+  }
 </style>
 <div class="modal custom-modal fade pg-modal--form" id="addProduction" aria-modal="true" role="dialog" tabindex="-1"
   data-bs-backdrop="static">

--- a/resources/views/components/modals/production/add-production.blade.php
+++ b/resources/views/components/modals/production/add-production.blade.php
@@ -1,3 +1,47 @@
+<style>
+  #addProduction.modal {
+    overflow: hidden !important;
+  }
+  html:has(#addProduction.show),
+  body:has(#addProduction.show) {
+    overflow: hidden !important;
+  }
+  #addProduction .modal-dialog {
+    height: calc(100dvh - 2rem) !important;
+    max-height: calc(100dvh - 2rem) !important;
+    min-height: 0 !important;
+    margin: 1rem auto !important;
+    display: flex !important;
+    align-items: stretch !important;
+  }
+  #addProduction .modal-content {
+    height: 100% !important;
+    max-height: 100% !important;
+    min-height: 0 !important;
+    display: flex !important;
+    flex-direction: column !important;
+    overflow: hidden !important;
+  }
+  #addProduction form {
+    flex: 1 1 auto !important;
+    min-height: 0 !important;
+    height: auto !important;
+    max-height: none !important;
+    display: flex !important;
+    flex-direction: column !important;
+    overflow: hidden !important;
+  }
+  #addProduction .modal-header,
+  #addProduction .modal-footer {
+    flex: 0 0 auto !important;
+  }
+  #addProduction .modal-body {
+    flex: 1 1 auto !important;
+    min-height: 0 !important;
+    overflow-y: auto !important;
+    overflow-x: hidden !important;
+  }
+</style>
 <div class="modal custom-modal fade pg-modal--form" id="addProduction" aria-modal="true" role="dialog" tabindex="-1"
   data-bs-backdrop="static">
   <div class="modal-dialog modal-dialog-centered modal-xl modal-dialog-scrollable">


### PR DESCRIPTION
## Ringkasan

Memperbaiki UI modal Produksi (`Tambah Produksi` / `Konfirmasi Produksi`) yang rusak ketika daftar produk banyak — sesuai laporan di issue #101.

## Masalah yang diperbaiki

1. **Tombol footer (Terima/Tolak/Simpan) tertutup di bawah layar** saat produk banyak, dan tidak bisa discroll untuk menjangkaunya.
2. **Dropdown autocomplete Nama Produk / Gudang Tujuan melayang jauh dari field-nya** (misal muncul di pojok kiri atas modal) ketika dropdown sedang terbuka.
3. Setelah perbaikan awal: modal jadi **tidak bisa discroll sama sekali**, lalu **modal selalu setinggi layar penuh meski isinya cuma 1-2 baris**, lalu **modal meluber keluar layar lagi untuk jumlah produk menengah (tidak ter-cap, tidak ada scrollbar)** — semua akibat kombinasi flexbox + `modal-dialog-scrollable` Bootstrap yang butuh `min-height:0` di setiap level, dan `max-height` persentase yang butuh tinggi pasti dari parent.
4. **Dropdown autocomplete terpotong di tepi modal** ketika field-nya berada dekat baris paling bawah dari daftar produk yang panjang, karena `overflow:hidden` yang diperlukan untuk perbaikan scroll juga memotong dropdown.

## Perbaikan

- `modal-dialog-scrollable` + override CSS eksplisit (`min-height:0` di setiap level flex, `max-height` absolut bukan persentase) di `add-production.blade.php`, mengikuti pola yang sudah terbukti di `add-warehouse.blade.php`.
- `dropdownParent` select2 untuk Nama Produk / Gudang Tujuan dipindah ke `body` (bukan `.modal-body` atau `.modal` itu sendiri) supaya tidak ikut kepotong `overflow:hidden` modal, ditambah bump `z-index` dropdown select2 di atas z-index modal Bootstrap supaya tidak ketutup modal.
- Sudah dicek langsung di browser oleh reviewer — modal dan dropdown sudah bekerja sesuai ekspektasi.

## Dokumentasi tambahan

Menambahkan skill `pegasus-modal-dropdown` (di `.claude/skills/` dan `.agents/skills/`) yang mencatat peta gejala → akar masalah dan checklist perbaikan modal Bootstrap + dropdown Select2 di codebase ini, supaya masalah serupa di modal lain tidak perlu didebug ulang dari nol.

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)
