### PR TITLE
feat: cek stok bahan mentah tiap tambah produk di modal Produksi, bukan cuma saat submit

### DIFF
--- a/app/Http/Controllers/ProductionController.php
+++ b/app/Http/Controllers/ProductionController.php
@@ -169,6 +169,96 @@ class ProductionController extends Controller
                 'message' => $destinationValidation['message'],
             ]);
         }
+        $validation = $this->validateProductionItems($item);
+        if ($validation) {
+            return response()->json($validation);
+        }
+
+        $p = (new Production())->insertProduction($data);
+        foreach ($item as $key => $value) {
+            $value['production_id'] = $p->production_id;
+            $value['list_bahan'] = json_encode($bahan[$key]);
+            (new ProductionDetails())->insertProductionDetail($value);
+        }
+
+        if ($isRevisionResubmit) {
+            $sourceId = (int) ($req->input('revision_source_production_id') ?? 0);
+            if ($sourceId > 0) {
+                $staffId = (int) (session('user')->staff_id ?? 0);
+                DB::table('dashboard_queue_dismissals')->updateOrInsert(
+                    [
+                        'staff_id' => $staffId,
+                        'queue_section' => 'revision',
+                        'queue_key' => 'pr:' . $sourceId,
+                    ],
+                    [
+                        'status' => 1,
+                        'updated_at' => now(),
+                        'created_at' => now(),
+                    ]
+                );
+            }
+        }
+
+        // Jangan auto-ACC di sini. Simpan = Pending di list Produksi.
+        // Stock Transfer (tujuan eceran) baru dibuat saat Acc produksi manual
+        // (atau lewat production:resolve-overdue).
+
+        return response()->json([
+            "status" => 1,
+            "message" => "Berhasil"
+        ]);
+    }
+
+    /**
+     * Endpoint dipanggil dari JS setiap kali user menambah baris produk ke
+     * "Daftar Produk" pada modal Tambah/Konfirmasi Produksi (bukan cuma saat
+     * klik Tambah Produksi) - lihat GitHub #101. Menerima daftar produk yang
+     * SUDAH termasuk baris yang baru mau ditambahkan (client kirim seluruh
+     * `items` setelah merge/push), supaya validasi & simulasi stok agregat
+     * (dos/pack, dsb.) tetap dihitung dari kondisi akhir yang benar.
+     *
+     * Read-only, tidak memutasi apa pun - dipakai juga oleh insertProduction()
+     * lewat validateProductionItems() supaya keduanya konsisten.
+     */
+    function checkProductionStock(Request $req)
+    {
+        $item = json_decode($req->input('detail'), true) ?: [];
+        if (empty($item)) {
+            return response()->json(['status' => 1]);
+        }
+
+        $destinationValidation = $this->normalizeProductionDestinations($item);
+        if (! $destinationValidation['ok']) {
+            return response()->json([
+                'status' => 0,
+                'header' => 'Tujuan Hasil Produksi Tidak Valid',
+                'message' => $destinationValidation['message'],
+            ]);
+        }
+
+        $validation = $this->validateProductionItems($item);
+        if ($validation) {
+            return response()->json($validation);
+        }
+
+        return response()->json(['status' => 1]);
+    }
+
+    /**
+     * Validasi konsistensi resep (satuan aktif, satuan terkecil, relasi
+     * produk, qty kelipatan resep) + simulasi ketersediaan stok bahan mentah
+     * agregat (termasuk konversi unit "bongkar" & perlakuan khusus dos/pack)
+     * untuk sekumpulan baris produksi. Read-only - tidak memutasi stok/DB.
+     *
+     * Dipakai baik oleh checkProductionStock() (tiap kali user menambah baris
+     * ke daftar produk) maupun insertProduction() (submit akhir), supaya
+     * pesan error & aturan validasinya selalu identik di kedua titik.
+     *
+     * @return array|null null kalau valid; array response (status/header/message/...) kalau tidak.
+     */
+    protected function validateProductionItems(array $item): ?array
+    {
         $cek = -1;
         $bahan_kurang = [];
         $produk_tanpa_relasi = [];
@@ -177,38 +267,38 @@ class ProductionController extends Controller
 
         $bahan_satuan_tidak_aktif = $this->validateProductionBomActiveUnits($item);
         if (count($bahan_satuan_tidak_aktif) > 0) {
-            return response()->json([
+            return [
                 'status' => 0,
                 'header' => 'Satuan Resep Tidak Aktif',
                 'code' => 'recipe_needs_update',
                 'bom_id' => $this->firstBomIdWithInactiveUnits($item),
                 'message' => 'Satuan bahan pada resep sudah tidak aktif. Perbarui resep terlebih dahulu: '
                     . implode(', ', $bahan_satuan_tidak_aktif),
-            ]);
+            ];
         }
 
         $bahan_bukan_satuan_terkecil = $this->validateBomSuppliesSmallestUnit($item);
         if (count($bahan_bukan_satuan_terkecil) > 0) {
-            return response()->json([
+            return [
                 'status' => 0,
                 'header' => 'Gagal Insert',
                 'code' => 'recipe_needs_update',
                 'bom_id' => $this->firstBomIdWithNonSmallestSupplyUnit($item),
                 'message' => 'Satuan bahan mentah pada resep bukan satuan terkecil sesuai relasi. Perbarui resep terlebih dahulu: '
                     . implode(', ', $bahan_bukan_satuan_terkecil),
-            ]);
+            ];
         }
 
         $bom_satuan_produk_bukan_terkecil = $this->validateBomProductSmallestUnit($item);
         if (count($bom_satuan_produk_bukan_terkecil) > 0) {
-            return response()->json([
+            return [
                 'status' => 0,
                 'header' => 'Gagal Insert',
                 'code' => 'recipe_needs_update',
                 'bom_id' => $this->firstBomIdWithNonSmallestProductUnit($item),
                 'message' => 'Satuan produk pada resep bukan satuan terkecil sesuai relasi produk. Perbarui resep terlebih dahulu: '
                     . implode(', ', $bom_satuan_produk_bukan_terkecil),
-            ]);
+            ];
         }
 
         foreach ($item as $value) {
@@ -246,11 +336,11 @@ class ProductionController extends Controller
         }
 
         if (count($produk_qty_tidak_kelipatan) > 0) {
-            return response()->json([
+            return [
                 'status' => 0,
                 'header' => 'Gagal Insert',
                 'message' => 'Qty produksi harus kelipatan resep bahan mentah untuk produk: ' . implode(', ', $produk_qty_tidak_kelipatan),
-            ]);
+            ];
         }
 
         // 1. AGGREGASI: Hitung total kebutuhan bahan mentah dari SEMUA item produksi di awal
@@ -258,11 +348,11 @@ class ProductionController extends Controller
         foreach ($item as $key => $value) {
             $bom = (new Bom())->getBom(['bom_id' => $value['bom_id']])->first();
             if (!isset($bom)) {
-                return response()->json([
+                return [
                     "status" => 0,
                     "header" => "Gagal Insert",
                     "message" => "Mohon cek kembali resep bahan mentah"
-                ]);
+                ];
             }
 
             // Pengecekan unit produksi punya relasi yang tersambung ke satuan resep atau tidak
@@ -362,11 +452,11 @@ class ProductionController extends Controller
         }
 
         if (count($produk_tanpa_relasi) > 0) {
-            return response()->json([
+            return [
                 "status" => 0,
                 "header" => "Gagal Insert",
                 "message" => "Mohon masukkan relasi produk: " . implode(", ", $produk_tanpa_relasi)
-            ]);
+            ];
         }
 
         // 2. PROCESSING: Eksekusi Konversi Stok (Bongkar Satuan Besar) berdasarkan total agregat
@@ -492,46 +582,13 @@ class ProductionController extends Controller
         }
 
         if ($cek == 1) {
-            return response()->json([
+            return [
                 "status"  => -1,
                 "message" => "Bahan baku tidak mencukupi untuk : " . implode(", ", $bahan_kurang)
-            ]);
+            ];
         }
 
-        $p = (new Production())->insertProduction($data);
-        foreach ($item as $key => $value) {
-            $value['production_id'] = $p->production_id;
-            $value['list_bahan'] = json_encode($bahan[$key]);
-            (new ProductionDetails())->insertProductionDetail($value);
-        }
-
-        if ($isRevisionResubmit) {
-            $sourceId = (int) ($req->input('revision_source_production_id') ?? 0);
-            if ($sourceId > 0) {
-                $staffId = (int) (session('user')->staff_id ?? 0);
-                DB::table('dashboard_queue_dismissals')->updateOrInsert(
-                    [
-                        'staff_id' => $staffId,
-                        'queue_section' => 'revision',
-                        'queue_key' => 'pr:' . $sourceId,
-                    ],
-                    [
-                        'status' => 1,
-                        'updated_at' => now(),
-                        'created_at' => now(),
-                    ]
-                );
-            }
-        }
-
-        // Jangan auto-ACC di sini. Simpan = Pending di list Produksi.
-        // Stock Transfer (tujuan eceran) baru dibuat saat Acc produksi manual
-        // (atau lewat production:resolve-overdue).
-
-        return response()->json([
-            "status" => 1,
-            "message" => "Berhasil"
-        ]);
+        return null;
     }
 
     function updateProduction(Request $req) {}

--- a/public/Custom_js/Backoffice/Production/Production.js
+++ b/public/Custom_js/Backoffice/Production/Production.js
@@ -290,6 +290,39 @@ function isRecipeNeedsUpdateError(payload) {
 }
 
 /**
+ * Tangani response error validasi produksi (status != 1) dari
+ * checkProductionStock()/insertProduction() - dipakai baik saat menambah
+ * baris produk (tiap klik +) maupun submit akhir (Tambah/Update Produksi),
+ * supaya penanganannya konsisten di kedua titik. Lihat GitHub #101.
+ */
+function handleProductionValidationError(e, bomIdFallback) {
+    if (!e) {
+        notifikasi("error", "Gagal", "Terjadi kesalahan yang tidak diketahui.");
+        return;
+    }
+    if (e.status == 0) {
+        if (isRecipeNeedsUpdateError(e)) {
+            var bomId = e.bom_id || bomIdFallback || null;
+            if (bomId) {
+                promptRecipeNeedsUpdate(bomId, {
+                    returnToProduction: true,
+                    title: e.header || "Satuan Resep Tidak Aktif",
+                    message: e.message,
+                });
+                return;
+            }
+        }
+        notifikasi("error", e.header, e.message);
+        return;
+    }
+    if (e.status == -1) {
+        notifikasi("error", "Stock Tidak Mencukupi", e.message);
+        return;
+    }
+    notifikasi("error", "Gagal", e.message || "Terjadi kesalahan.");
+}
+
+/**
  * Alert + swap: hide Tambah Produksi, open Update Resep, show brief error Swal.
  * Tutup/dismiss hanya menutup Swal — Update Resep tetap terbuka; restore produksi
  * lewat footer Batal/X di modal Update Resep.
@@ -1009,8 +1042,14 @@ function continueAddProduct(tempBom) {
     var destinationId = isRetailOutput
         ? parseInt($("#production_destination_warehouse_id").val() || 0, 10)
         : productionNonRetailDestinationId();
+
+    // Kerja di atas salinan `items` dulu (bukan `items` asli) - baris baru/gabungan
+    // baru benar-benar masuk ke daftar kalau cek stok di bawah (GitHub #101) lolos.
+    var candidateItems = items.map(function (element) {
+        return $.extend({}, element);
+    });
     var idx = -1;
-    items.forEach(function (element) {
+    candidateItems.forEach(function (element) {
         if (
             element.product_variant_id == temp.product_variant_id &&
             element.unit_id == resolved.unit_id &&
@@ -1023,7 +1062,7 @@ function continueAddProduct(tempBom) {
     });
 
     if (idx == 1) {
-        var mergedItem = items.find(function (element) {
+        var mergedItem = candidateItems.find(function (element) {
             return (
                 element.product_variant_id == temp.product_variant_id &&
                 element.unit_id == resolved.unit_id &&
@@ -1037,7 +1076,6 @@ function continueAddProduct(tempBom) {
             tempBom,
         );
         if (!qtyKelipatanGabung.valid) {
-            mergedItem.pd_qty -= resolved.pd_qty;
             clearPendingProductionAdd();
             notifikasi(
                 "error",
@@ -1075,18 +1113,55 @@ function continueAddProduct(tempBom) {
                     : productionNonRetailDestinationName()),
             bom_id: temp.bom_id,
         };
-        items.push(data);
+        candidateItems.push(data);
     }
-    addRow(items);
 
-    $("#product_id").empty();
-    $("#unit_id").empty();
-    $("#unit_id").append("<option selected>Pilih Satuan</option>");
-    $("#production_qty").val(1);
-    $("#production_pallet_hint").text("");
-    $("#production_destination_warehouse_id").val(null).trigger("change");
-    syncProductionDestinationControl();
-    clearPendingProductionAdd();
+    // Cek stok bahan mentah agregat (termasuk baris ini) SEBELUM baris masuk ke
+    // daftar - dulu cek ini cuma jalan pas klik "Tambah Produksi" di akhir, jadi
+    // user baru tahu stok kurang setelah menyusun seluruh daftar. GitHub #101.
+    LoadingButton(".btn-add-product");
+    $.ajax({
+        url: "/checkProductionStock",
+        method: "post",
+        data: {
+            detail: JSON.stringify(candidateItems),
+            _token: token,
+        },
+        headers: {
+            "X-CSRF-TOKEN": token,
+        },
+        success: function (e) {
+            ResetLoadingButton(".btn-add-product", "+");
+            if (!e || e.status != 1) {
+                handleProductionValidationError(e, temp.bom_id);
+                return;
+            }
+
+            items = candidateItems;
+            addRow(items);
+
+            $("#product_id").empty();
+            $("#unit_id").empty();
+            $("#unit_id").append("<option selected>Pilih Satuan</option>");
+            $("#production_qty").val(1);
+            $("#production_pallet_hint").text("");
+            $("#production_destination_warehouse_id")
+                .val(null)
+                .trigger("change");
+            syncProductionDestinationControl();
+            clearPendingProductionAdd();
+        },
+        error: function (a) {
+            ResetLoadingButton(".btn-add-product", "+");
+            if (handlePermissionError(a)) return;
+            console.log(a);
+            notifikasi(
+                "error",
+                "Gagal Cek Stok",
+                "Terjadi kesalahan saat memeriksa stok. Silakan coba lagi.",
+            );
+        },
+    });
     return true;
 }
 $(document).ready(function () {
@@ -1741,26 +1816,11 @@ $(document).on("click", ".btn-save", function () {
                 ".btn-save",
                 mode == 1 ? "Tambah Produksi" : "Update Produksi",
             );
-            console.log(e.length);
-            if (e.status == 0) {
-                if (isRecipeNeedsUpdateError(e)) {
-                    var bomId =
-                        e.bom_id ||
-                        (items[0] && items[0].bom_id) ||
-                        null;
-                    if (bomId) {
-                        promptRecipeNeedsUpdate(bomId, {
-                            returnToProduction: true,
-                            title: e.header || "Satuan Resep Tidak Aktif",
-                            message: e.message,
-                        });
-                        return false;
-                    }
-                }
-                notifikasi("error", e.header, e.message);
-                return false;
-            } else if (e.status == -1) {
-                notifikasi("error", "Stock Tidak Mencukupi", e.message);
+            if (!e || e.status != 1) {
+                handleProductionValidationError(
+                    e,
+                    items[0] && items[0].bom_id,
+                );
                 return false;
             }
             afterInsert();

--- a/public/Custom_js/Backoffice/Production/Production.js
+++ b/public/Custom_js/Backoffice/Production/Production.js
@@ -297,7 +297,7 @@ function isRecipeNeedsUpdateError(payload) {
  */
 function handleProductionValidationError(e, bomIdFallback) {
     if (!e) {
-        notifikasi("error", "Gagal", "Terjadi kesalahan yang tidak diketahui.");
+        showPgErrorModal("Gagal", "Terjadi kesalahan yang tidak diketahui.");
         return;
     }
     if (e.status == 0) {
@@ -312,14 +312,14 @@ function handleProductionValidationError(e, bomIdFallback) {
                 return;
             }
         }
-        notifikasi("error", e.header, e.message);
+        showPgErrorModal(e.header, e.message);
         return;
     }
     if (e.status == -1) {
-        notifikasi("error", "Stock Tidak Mencukupi", e.message);
+        showPgErrorModal("Stock Tidak Mencukupi", e.message);
         return;
     }
-    notifikasi("error", "Gagal", e.message || "Terjadi kesalahan.");
+    showPgErrorModal("Gagal", e.message || "Terjadi kesalahan.");
 }
 
 /**
@@ -346,11 +346,12 @@ function promptRecipeNeedsUpdate(bomId, options) {
 
     Swal.fire({
         icon: "error",
+        iconColor: "#ef4444",
         title: title,
         text: message,
         confirmButtonText: "Tutup",
         customClass: {
-            confirmButton: "btn btn-light px-4 py-2",
+            confirmButton: "pg-btn-confirm pg-btn-confirm--danger",
             title: "fw-bold fs-4 text-dark",
             popup: "rounded-4",
         },

--- a/resources/views/layout/partials/footer-scripts.blade.php
+++ b/resources/views/layout/partials/footer-scripts.blade.php
@@ -415,6 +415,33 @@ https://cdn.jsdelivr.net/npm/toastr@2.1.4/toastr.min.js
   }
 
   /**
+   * Popup error bertema PG (rounded-16px, tombol pg-btn-confirm--danger, ikon merah) — dipakai
+   * lintas modul supaya konsisten dengan pg-modal--danger, alih-alih notifikasi() polos
+   * (SweetAlert2 default) yang sudah tidak sesuai desain modal sejak redesign Kanakku. Versi
+   * generik dari showSoErrorModal() di Sales_Order.js — lihat commit e90f255. `.swal2-container`
+   * sudah global z-index:2000 (pg-modal-styles.blade.php) jadi popup ini tetap tampil di depan
+   * walau dipanggil sementara modal PG lain (pg-modal--form/--confirm/--danger) masih terbuka.
+   */
+  function showPgErrorModal(header, message) {
+    Swal.fire({
+      icon: "error",
+      iconColor: "#ef4444",
+      title: header || "Gagal",
+      html:
+        '<p class="text-start mb-0" style="font-size:14px;white-space:pre-wrap;">' +
+        $("<div>").text(message || "").html() +
+        "</p>",
+      confirmButtonText: "Tutup",
+      customClass: {
+        confirmButton: "pg-btn-confirm pg-btn-confirm--danger",
+        title: "fw-bold fs-4 text-dark",
+        popup: "rounded-4",
+      },
+      buttonsStyling: false,
+    });
+  }
+
+  /**
    * Panggil ini di awal setiap ajax error callback (terutama di popup) supaya pesan
    * 403 (ditolak middleware permission) konsisten di seluruh aplikasi dan tidak
    * membocorkan modul/permission apa yang kurang ke user.

--- a/routes/web.php
+++ b/routes/web.php
@@ -703,6 +703,7 @@ Route::middleware(checkLogin::class)->group(function () {
     });
     Route::middleware('check.access:Produksi|create')->group(function () {
         Route::post('/insertProduction', [ProductionController::class, 'insertProduction'])->name('insertProduction');
+        Route::post('/checkProductionStock', [ProductionController::class, 'checkProductionStock'])->name('checkProductionStock');
     });
     Route::middleware('check.access:Produksi|edit')->group(function () {
         Route::post('/updateProduction', [ProductionController::class, 'updateProduction'])->name('updateProduction');

--- a/tests/Workflow/ProductionCheckStockOnAddTest.php
+++ b/tests/Workflow/ProductionCheckStockOnAddTest.php
@@ -1,0 +1,221 @@
+<?php
+
+namespace Tests\Workflow;
+
+use App\Models\Bom;
+use App\Models\BomDetail;
+use App\Models\Category;
+use App\Models\Product;
+use App\Models\ProductStock;
+use App\Models\ProductVariant;
+use App\Models\Supplies;
+use App\Models\SuppliesStock;
+use Tests\Support\ActingAsStaff;
+use Tests\TestCase;
+
+/**
+ * GitHub #101: the raw-material stock check used to run only on final "Tambah Produksi"
+ * submit. It now also runs on every "+ Tambah" click via POST /checkProductionStock, so a
+ * user finds out about a shortage as soon as they try to add the offending row instead of
+ * after building the whole list. Both endpoints share the same validation
+ * (ProductionController::validateProductionItems()) so this asserts they agree.
+ *
+ * Same fixture shape as ProductionFlowTest — a fully fresh product/supplies/BOM rather than
+ * seeded data, since real seeded BOMs hit unit-conversion/dos-pack branches out of this
+ * test's scope.
+ */
+class ProductionCheckStockOnAddTest extends TestCase
+{
+    use ActingAsStaff;
+
+    private const UNIT_ID = 9; // "Piece" — real, active, no conversion relations needed
+    private const WAREHOUSE_ID = 1; // Gudang Pusat (main), seeded 2026-08-01
+    private const BOM_QTY = 1;
+    private const BOM_DETAIL_QTY = 2; // 2 units of raw material per 1 unit of BOM output
+    private const STARTING_SUPPLIES_STOCK = 20;
+
+    /**
+     * @return array{variant: ProductVariant, productStock: ProductStock, supplies: Supplies, suppliesStock: SuppliesStock, bom: Bom, bomDetail: BomDetail}
+     */
+    private function createFixture(): array
+    {
+        $category = new Category();
+        $category->category_name = 'Add-time Stock Check Test Category';
+        $category->status = 1;
+        $category->save();
+
+        $product = new Product();
+        $product->product_name = 'Add-time Stock Check Test Product';
+        $product->category_id = $category->category_id;
+        $product->product_unit = json_encode([self::UNIT_ID]);
+        $product->unit_id = self::UNIT_ID;
+        $product->status = 1;
+        $product->save();
+
+        $variant = new ProductVariant();
+        $variant->product_id = $product->product_id;
+        $variant->product_variant_name = 'Add-time Stock Check Test Variant';
+        $variant->product_variant_sku = 'WF-ADDCHECK-'.uniqid();
+        $variant->product_variant_price = 0;
+        $variant->status = 1;
+        $variant->save();
+
+        $productStock = new ProductStock();
+        $productStock->product_id = $product->product_id;
+        $productStock->product_variant_id = $variant->product_variant_id;
+        $productStock->unit_id = self::UNIT_ID;
+        $productStock->warehouse_id = self::WAREHOUSE_ID;
+        $productStock->ps_stock = 0;
+        $productStock->status = 1;
+        $productStock->save();
+
+        $supplies = new Supplies();
+        $supplies->supplies_name = 'Add-time Stock Check Test Supplies';
+        $supplies->supplies_unit = json_encode([self::UNIT_ID]);
+        $supplies->supplies_default_unit = self::UNIT_ID;
+        $supplies->status = 1;
+        $supplies->save();
+
+        $suppliesStock = new SuppliesStock();
+        $suppliesStock->supplies_id = $supplies->supplies_id;
+        $suppliesStock->unit_id = self::UNIT_ID;
+        $suppliesStock->warehouse_id = self::WAREHOUSE_ID;
+        $suppliesStock->ss_stock = self::STARTING_SUPPLIES_STOCK;
+        $suppliesStock->status = 1;
+        $suppliesStock->save();
+
+        // NOTE: boms.product_id actually stores a product_variant_id — see the flow doc.
+        $bom = new Bom();
+        $bom->product_id = $variant->product_variant_id;
+        $bom->bom_qty = self::BOM_QTY;
+        $bom->unit_id = self::UNIT_ID;
+        $bom->status = 1;
+        $bom->save();
+
+        $bomDetail = new BomDetail();
+        $bomDetail->bom_id = $bom->bom_id;
+        $bomDetail->supplies_id = $supplies->supplies_id;
+        $bomDetail->bom_detail_qty = self::BOM_DETAIL_QTY;
+        $bomDetail->unit_id = self::UNIT_ID;
+        $bomDetail->status = 1;
+        $bomDetail->save();
+
+        return compact('variant', 'productStock', 'supplies', 'suppliesStock', 'bom', 'bomDetail');
+    }
+
+    public function test_check_production_stock_allows_a_row_that_fits_available_stock(): void
+    {
+        $this->actingAsSuperAdminStaff();
+        $this->withActiveWarehouse(self::WAREHOUSE_ID);
+
+        $fx = $this->createFixture();
+        // Stock is 20, needs 2 per unit — 5 units needs 10, well within stock.
+        $pdQty = 5;
+
+        $response = $this->post('/checkProductionStock', [
+            'detail' => json_encode([[
+                'bom_id' => $fx['bom']->bom_id,
+                'product_variant_id' => $fx['variant']->product_variant_id,
+                'pd_qty' => $pdQty,
+                'unit_id' => self::UNIT_ID,
+            ]]),
+        ]);
+
+        $response->assertStatus(200);
+        $response->assertJson(['status' => 1]);
+
+        // Read-only: checking must never touch stock.
+        $fx['suppliesStock']->refresh();
+        $this->assertSame(
+            self::STARTING_SUPPLIES_STOCK,
+            $fx['suppliesStock']->ss_stock,
+            'checkProductionStock must not mutate ingredient stock'
+        );
+    }
+
+    public function test_check_production_stock_blocks_a_row_that_exceeds_available_stock(): void
+    {
+        $this->actingAsSuperAdminStaff();
+        $this->withActiveWarehouse(self::WAREHOUSE_ID);
+
+        $fx = $this->createFixture();
+        // Stock is 20, needs 2 per unit — 20 units needs 40, more than available.
+        $pdQty = 20;
+
+        $response = $this->post('/checkProductionStock', [
+            'detail' => json_encode([[
+                'bom_id' => $fx['bom']->bom_id,
+                'product_variant_id' => $fx['variant']->product_variant_id,
+                'pd_qty' => $pdQty,
+                'unit_id' => self::UNIT_ID,
+            ]]),
+        ]);
+
+        $response->assertStatus(200);
+        $response->assertJson(['status' => -1]);
+        $response->assertJsonFragment(['message' => 'Bahan baku tidak mencukupi untuk : '.$fx['supplies']->supplies_name]);
+
+        $fx['suppliesStock']->refresh();
+        $this->assertSame(
+            self::STARTING_SUPPLIES_STOCK,
+            $fx['suppliesStock']->ss_stock,
+            'a blocked add-time check must not mutate ingredient stock either'
+        );
+    }
+
+    public function test_check_production_stock_considers_rows_already_in_the_list(): void
+    {
+        $this->actingAsSuperAdminStaff();
+        $this->withActiveWarehouse(self::WAREHOUSE_ID);
+
+        $fx = $this->createFixture();
+        // Two rows of the same product at 6 units each (needs 12 each, 24 total) exceed the
+        // 20 in stock even though a single row of 6 (needs 12) would fit on its own — this is
+        // the whole point of #101: the check must run against the full candidate list (what
+        // the client sends as `detail`), not just the row being added in isolation.
+        $rowDetail = [
+            'bom_id' => $fx['bom']->bom_id,
+            'product_variant_id' => $fx['variant']->product_variant_id,
+            'pd_qty' => 6,
+            'unit_id' => self::UNIT_ID,
+        ];
+
+        $response = $this->post('/checkProductionStock', [
+            'detail' => json_encode([$rowDetail, $rowDetail]),
+        ]);
+
+        $response->assertStatus(200);
+        $response->assertJson(['status' => -1]);
+    }
+
+    public function test_insert_production_still_rejects_the_same_shortage_at_final_submit(): void
+    {
+        // insertProduction() now delegates to the same validateProductionItems() that
+        // checkProductionStock() calls — this proves the extraction in #101 didn't change
+        // final-submit behavior.
+        $this->actingAsSuperAdminStaff();
+        $this->withActiveWarehouse(self::WAREHOUSE_ID);
+
+        $fx = $this->createFixture();
+        $pdQty = 20;
+
+        $response = $this->post('/insertProduction', [
+            'production_date' => now()->toDateString(),
+            'production_desc' => 'Add-time stock check test (final submit shortage)',
+            'detail' => json_encode([[
+                'bom_id' => $fx['bom']->bom_id,
+                'product_variant_id' => $fx['variant']->product_variant_id,
+                'pd_qty' => $pdQty,
+                'unit_id' => self::UNIT_ID,
+            ]]),
+            'list_bahan' => json_encode([[
+                'supplies_id' => $fx['supplies']->supplies_id,
+                'bom_detail_qty' => self::BOM_DETAIL_QTY,
+                'unit_id' => self::UNIT_ID,
+            ]]),
+        ]);
+
+        $response->assertStatus(200);
+        $response->assertJson(['status' => -1]);
+    }
+}


### PR DESCRIPTION
## Ringkasan

Perubahan perilaku pada modal Tambah Produksi: cek ketersediaan stok bahan mentah sekarang jalan **setiap kali user menambah baris produk** ke Daftar Produk, bukan cuma saat klik tombol "Tambah Produksi" di akhir.

## Sebelumnya

Validasi (satuan resep aktif, satuan terkecil sesuai relasi, relasi produk, qty kelipatan resep, dan simulasi ketersediaan stok bahan mentah agregat termasuk perhitungan khusus dos/pack) cuma dijalankan sekali, di server, saat submit akhir. User bisa menyusun seluruh daftar produk dulu baru tahu belakangan bahwa stok bahan mentah tidak cukup - baru ketahuan setelah klik "Tambah Produksi".

## Sekarang

- **Backend**: seluruh blok validasi di `insertProduction()` (murni baca, tidak memutasi stok apa pun — simulasi stok di sini cuma untuk cek ketersediaan; deduksi stok sungguhan baru terjadi saat ACC produksi) diekstrak ke method baru `ProductionController::validateProductionItems()`. Dipakai bersama oleh:
  - Endpoint baru `POST /checkProductionStock` — dipanggil dari JS setiap klik "+" tambah produk.
  - `insertProduction()` submit akhir tetap memanggil validasi yang sama (belt-and-suspenders, karena stok bisa berubah antara nambah baris terakhir dan klik submit).
- **Frontend**: `continueAddProduct()` sekarang membangun salinan daftar produk (baris yang mau ditambah/digabung), kirim ke `/checkProductionStock`, dan baris baru benar-benar masuk ke daftar kalau cek itu lolos — pesan error & mekanismenya sama persis dengan submit akhir (pakai `handleProductionValidationError()` yang dipakai bersama kedua alur).

## Testing

- `tests/Workflow/ProductionCheckStockOnAddTest.php` (baru, 4 test): endpoint cek mengizinkan baris yang cukup stok, menolak baris yang melebihi stok, mempertimbangkan baris-baris yang sudah ada di daftar (bukan cuma baris yang baru ditambahkan sendirian), dan submit akhir tetap menolak shortage yang sama.
- Suite Production terkait lain (`ProductionFlowTest`, `ProductionUnitConversionFlowTest`, `ProductionCancelRequestFlowTest`, `ProductionAccSelfHealTest`) + `--testsuite=Smoke` full run tetap hijau — memastikan ekstraksi validasi ke method baru tidak mengubah perilaku submit akhir yang lama.

Refs #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)
