### PR TITLE
fix: cegah crash JS filter Kas Operasional saat role_access ada entry tanpa name

### DIFF
--- a/resources/views/layout/mainlayout.blade.php
+++ b/resources/views/layout/mainlayout.blade.php
@@ -182,7 +182,7 @@
     if (!window.permissionList || !Array.isArray(window.permissionList)) return false;
 
     return window.permissionList.some(
-      p => p.name.toLowerCase() === moduleName.toLowerCase()
+      p => p && typeof p.name === "string" && p.name.toLowerCase() === moduleName.toLowerCase()
     );
   }
 
@@ -191,7 +191,7 @@
     if (!window.permissionList || !Array.isArray(window.permissionList)) return false;
 
     const found = window.permissionList.find(p =>
-      p.name.toLowerCase() === moduleName.toLowerCase()
+      p && typeof p.name === "string" && p.name.toLowerCase() === moduleName.toLowerCase()
     );
 
     if (!found) return false;


### PR DESCRIPTION
## Masalah
Console error waktu login sebagai role Sales dan buka Kas Operasional:

```
Uncaught TypeError: Cannot read properties of undefined (reading 'toLowerCase')
    at hasAccessAction
    at hasAccessActionAny
```

`hasMenuAccess` dan `hasAccessAction` di [mainlayout.blade.php](resources/views/layout/mainlayout.blade.php) memanggil `p.name.toLowerCase()` pada tiap item `window.permissionList` tanpa memvalidasi bahwa `p` ada dan `p.name` berupa string. Kalau ada satu entry di `role_access` role tersebut yang tidak punya field `name`, exception ini dilempar di tengah render, sehingga proses filter/menu berhenti sebelum selesai -- inilah yang menyebabkan tombol filter Kas Operasional kadang harus diklik 2x (klik pertama exception & gagal, klik kedua baru berhasil karena sebagian state sudah kepasang dari percobaan pertama).

## Fix
Tambah guard `p && typeof p.name === "string"` sebelum memanggil `.toLowerCase()`, di kedua fungsi (`hasMenuAccess` & `hasAccessAction`). Entry yang malformed sekarang cukup diabaikan (dianggap tidak match) alih-alih melempar exception dan menghentikan seluruh proses.

Target: `fase2/main` (bukan `main`), sesuai arahan.

Closes #98