### PR TITLE
fix: shimmer loading untuk tabel Kas Operasional saat filter (staff/sales/armada) berubah

### DIFF
--- a/public/Custom_js/Backoffice/Reports/Cash_Operational.js
+++ b/public/Custom_js/Backoffice/Reports/Cash_Operational.js
@@ -12,6 +12,14 @@
         $('#tableCash tfoot .sisa').html(`Rp ${formatRupiahMinus(sisa)}`);
     }
 
+    function showCashSkeleton() {
+        $('#tableCash-wrap').removeClass('dt-ready').addClass('dt-pending');
+    }
+
+    function hideCashSkeleton() {
+        $('#tableCash-wrap').removeClass('dt-pending').addClass('dt-ready');
+    }
+
     let today = new Date();
     let yyyy = today.getFullYear();
     let mm = String(today.getMonth() + 1).padStart(2, '0');
@@ -41,6 +49,7 @@
         if (!$cashType.find("option").length) {
             $cashType.append('<option value="" selected>Tidak ada akses</option>').prop("disabled", true);
             $("#tableCash tbody").html('<tr><td colspan="10" class="text-center text-muted">Anda tidak punya akses view Kas Operasional.</td></tr>');
+            hideCashSkeleton();
             return;
         }
 
@@ -614,6 +623,7 @@
     }
 
     function refreshCashAdmin() {
+        showCashSkeleton();
         $.ajax({
             url: "/getCashAdmin",
             data: {
@@ -705,8 +715,10 @@
 
                 feather.replace(); // Biar icon feather muncul lagi
                 openCashFromDashboardLink();
+                hideCashSkeleton();
             },
             error: function (err) {
+                hideCashSkeleton();
                 if (handlePermissionError(err)) return;
                 console.error("Gagal load kategori:", err);
             }
@@ -714,6 +726,7 @@
     }
 
     function refreshCashGudang() {
+        showCashSkeleton();
         $.ajax({
             url: "/getCashGudang",
             data: {
@@ -806,8 +819,10 @@
                     });
                 }, 100);
                 openCashFromDashboardLink();
+                hideCashSkeleton();
             },
             error: function (err) {
+                hideCashSkeleton();
                 if (handlePermissionError(err)) return;
                 console.error("Gagal load kategori:", err);
             }
@@ -815,6 +830,7 @@
     }
 
     function refreshCashArmada() {
+        showCashSkeleton();
         $.ajax({
             url: "/getCashArmada",
             data: {
@@ -917,8 +933,10 @@
 
                 feather.replace(); // Biar icon feather muncul lagi
                 openCashFromDashboardLink();
+                hideCashSkeleton();
             },
             error: function (err) {
+                hideCashSkeleton();
                 if (handlePermissionError(err)) return;
                 console.error("Gagal load kategori:", err);
             }
@@ -926,6 +944,7 @@
     }
 
     function refreshCashSales() {
+        showCashSkeleton();
         $.ajax({
             url: "/getCashSales",
             data: {
@@ -1020,8 +1039,10 @@
 
                 feather.replace(); // Biar icon feather muncul lagi
                 openCashFromDashboardLink();
+                hideCashSkeleton();
             },
             error: function (err) {
+                hideCashSkeleton();
                 if (handlePermissionError(err)) return;
                 console.error("Gagal load kategori:", err);
             }

--- a/resources/views/Backoffice/Reports/Cash_Operational.blade.php
+++ b/resources/views/Backoffice/Reports/Cash_Operational.blade.php
@@ -168,7 +168,37 @@
                 <div class="col-sm-12">
                     <div class="card-table">
                         <div class="card-body">
-                            <div class="table-responsive">
+                            <div class="table-responsive dt-pending" id="tableCash-wrap">
+                                <div class="dt-skeleton" aria-hidden="true">
+                                    <div class="dt-skeleton-head" style="grid-template-columns: 4% 11% 12% 11% 20% 10% 10% 8% 8% 6%;">
+                                        <span style="width:30%"></span>
+                                        <span style="width:60%"></span>
+                                        <span style="width:50%"></span>
+                                        <span style="width:60%"></span>
+                                        <span style="width:70%"></span>
+                                        <span style="width:50%"></span>
+                                        <span style="width:50%"></span>
+                                        <span style="width:60%"></span>
+                                        <span style="width:60%"></span>
+                                        <span style="width:60%"></span>
+                                    </div>
+                                    <div class="dt-skeleton-body">
+                                        @for ($i = 0; $i < 6; $i++)
+                                            <div class="dt-skeleton-row" style="grid-template-columns: 4% 11% 12% 11% 20% 10% 10% 8% 8% 6%;">
+                                                <span class="skel-text" style="width:30%"></span>
+                                                <span class="skel-text" style="width:70%"></span>
+                                                <span class="skel-badge" style="width:70%;justify-self:center"></span>
+                                                <span class="skel-text" style="width:70%"></span>
+                                                <span class="skel-text" style="width:85%"></span>
+                                                <span class="skel-text" style="width:70%;justify-self:end"></span>
+                                                <span class="skel-text" style="width:70%;justify-self:end"></span>
+                                                <span class="skel-text" style="width:70%"></span>
+                                                <span class="skel-text" style="width:70%"></span>
+                                                <span class="skel-text" style="width:60%"></span>
+                                            </div>
+                                        @endfor
+                                    </div>
+                                </div>
                                 <table class="table table-center table-hover" id="tableCash">
                                     <thead class="thead-light">
                                         <tr id="headers">


### PR DESCRIPTION
## Masalah
Di halaman Kas Operasional, ganti filter (dropdown Staff/Sales/Armada di kolom kanan, tanggal, atau tab Admin/Gudang/Armada/Sales) tidak menampilkan indikator loading sama sekali. Tabel lama tetap diam sampai response AJAX datang -- dari sisi user kelihatannya seperti nge-freeze / tidak merespon.

## Fix
Tambahkan skeleton shimmer di `#tableCash`, mengikuti pola `dt-pending`/`dt-ready` + `.dt-skeleton` yang sudah dipakai di halaman lain (Stock Produk, Stock Alert, dll -- lihat `custom-premium.css`):

- [Cash_Operational.blade.php](resources/views/Backoffice/Reports/Cash_Operational.blade.php): bungkus `#tableCash` dengan `#tableCash-wrap` + markup skeleton (10 kolom, mengikuti proporsi thead yang sudah ada).
- [Cash_Operational.js](public/Custom_js/Backoffice/Reports/Cash_Operational.js): tambah helper `showCashSkeleton()` / `hideCashSkeleton()`, dipanggil di ke-4 fungsi refresh (`refreshCashAdmin`, `refreshCashGudang`, `refreshCashArmada`, `refreshCashSales`) yang jadi tujuan semua handler filter di halaman ini (`#cashType`, `#filter_staff_id`, `#filter_customer_id`, `#filter_sales_id`, `#start_date`/`#end_date`, tombol Clear).
- Juga menutup skeleton di jalur "tidak ada akses" (`sanitizeCashTypeOptions`) supaya tidak nyangkut kalau role tidak punya akses sama sekali ke modul ini.

Target: `fase2/main`.