### PR TITLE
fix: modal Tambah Pengiriman tidak bisa scroll ke bawah di tablet/laptop

### DIFF
--- a/resources/views/components/modals/sales-order/add-sales-order.blade.php
+++ b/resources/views/components/modals/sales-order/add-sales-order.blade.php
@@ -1,7 +1,21 @@
+<style>
+  /* Flex items default to min-height:auto, which stops them from shrinking
+     below their content height even with flex-grow set - without this the
+     form/modal-body below never actually get capped to max-height, so
+     .modal-body's overflow-y:auto never kicks in and the footer/bottom rows
+     end up unreachable on shorter (tablet/laptop) viewports. See the
+     pegasus-modal-dropdown skill / GitHub #101 for the full writeup. */
+  #add_sales_order form {
+    min-height: 0 !important;
+  }
+  #add_sales_order .modal-body {
+    min-height: 0 !important;
+  }
+</style>
 <div class="modal fade custom-modal pg-modal--form" id="add_sales_order" data-bs-backdrop="static"
     data-bs-keyboard="false" tabindex="-1" aria-hidden="true">
     <div class="modal-dialog modal-dialog-centered modal-xl" style="max-width: 90vw;">
-      <div class="modal-content d-flex flex-column" style="border-radius: 16px; overflow: hidden; border: none; max-height: 92vh;">
+      <div class="modal-content d-flex flex-column" style="border-radius: 16px; overflow: hidden; border: none; max-height: calc(100dvh - 2rem);">
 
         {{-- ── HEADER ── --}}
         <div class="modal-header">


### PR DESCRIPTION
## Ringkasan
Memperbaiki modal **Tambah Pengiriman** (Sales Order) yang tidak bisa di-scroll ke bawah pada layar tablet dan laptop, sehingga baris produk dan tombol di bagian bawah modal tidak terjangkau.

## Akar masalah
`.modal-content` pada modal ini sudah dibatasi tingginya (`max-height`), tapi elemen `<form>` dan `.modal-body` di dalamnya (yang berperan sebagai flex item) tidak diberi `min-height: 0`. Secara default, flex item punya `min-height: auto`, yang membuatnya menolak menyusut walau sudah diberi `flex: 1 1 auto`. Akibatnya `overflow-y: auto` pada `.modal-body` tidak pernah benar-benar aktif — pada layar tinggi (desktop besar) ini tidak terasa, tapi pada viewport yang lebih pendek (tablet/laptop) baris bawah dan tombol footer jadi tidak terjangkau/tidak bisa di-scroll.

Pola bug dan perbaikan ini sama persis dengan yang sudah pernah dibereskan di modal Produksi (GitHub #101), didokumentasikan di skill `pegasus-modal-dropdown`.

## Perubahan
- Tambah `min-height: 0 !important` pada `#add_sales_order form` dan `#add_sales_order .modal-body` agar flexbox benar-benar menyusut ke batas tinggi modal, sehingga scroll internal aktif.
- Ganti cap tinggi `.modal-content` dari `92vh` ke `calc(100dvh - 2rem)`, konsisten dengan pola modal lain yang sudah diperbaiki (mis. `add-production.blade.php`).

## Cara test
1. Buka menu Pengiriman → Tambah Pengiriman.
2. Tambahkan cukup banyak produk ke daftar sampai konten modal melebihi tinggi layar.
3. Di viewport tablet/laptop (tinggi layar terbatas), pastikan modal-body bisa di-scroll ke bawah dan tombol "Tambah Pengiriman"/"Batal" di footer tetap terjangkau.

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)