### PR TITLE
fix: Kas Operasional dropdown kosong untuk role akses generik / super admin

### DIFF
--- a/resources/views/Backoffice/Reports/Cash_Operational.blade.php
+++ b/resources/views/Backoffice/Reports/Cash_Operational.blade.php
@@ -97,10 +97,10 @@
 
         $isSuper = (int)($user->role_id ?? 0) === -1;
         $all     = $check('Kas Operasional');
-        $admin   = $check('Kas Operasional Admin') || $check('Kas Admin');
-        $gudang  = $check('Kas Operasional Gudang') || $check('Kas Gudang');
-        $armada  = $check('Kas Operasional Armada') || $check('Kas Armada');
-        $sales   = $check('Kas Operasional Sales') || $check('Kas Sales');
+        $admin   = $isSuper || $all || $check('Kas Operasional Admin') || $check('Kas Admin');
+        $gudang  = $isSuper || $all || $check('Kas Operasional Gudang') || $check('Kas Gudang');
+        $armada  = $isSuper || $all || $check('Kas Operasional Armada') || $check('Kas Armada');
+        $sales   = $isSuper || $all || $check('Kas Operasional Sales') || $check('Kas Sales');
     @endphp
     <!-- Page Wrapper -->
     <div class="page-wrapper">

--- a/tests/Smoke/AkuntansiLaporanSmokeTest.php
+++ b/tests/Smoke/AkuntansiLaporanSmokeTest.php
@@ -116,4 +116,51 @@ class AkuntansiLaporanSmokeTest extends TestCase
     {
         $this->get('/operationalCash')->assertRedirect('/login');
     }
+
+    /**
+     * GitHub #97: staff granted only the generic "Kas Operasional" module
+     * (no per-jenis submodule) saw an empty jenis dropdown on this page and
+     * couldn't view/insert anything, while roles with the specific
+     * submodules worked fine. Cash_Operational.blade.php computed $all
+     * (the generic-module check) and $isSuper but never OR'd them into the
+     * per-jenis $admin/$gudang/$armada/$sales flags that gate each <option>.
+     */
+    public function test_operational_cash_shows_all_jenis_options_for_generic_kas_operasional_permission(): void
+    {
+        $this->actingAsStaffWithOnlyPermission('Kas Operasional');
+
+        $response = $this->get('/operationalCash');
+
+        $response->assertStatus(200);
+        $response->assertSee('value="admin"', false);
+        $response->assertSee('value="gudang"', false);
+        $response->assertSee('value="armada"', false);
+        $response->assertSee('value="sales"', false);
+    }
+
+    public function test_operational_cash_shows_all_jenis_options_for_super_admin(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $response = $this->get('/operationalCash');
+
+        $response->assertStatus(200);
+        $response->assertSee('value="admin"', false);
+        $response->assertSee('value="gudang"', false);
+        $response->assertSee('value="armada"', false);
+        $response->assertSee('value="sales"', false);
+    }
+
+    public function test_operational_cash_shows_only_granted_jenis_option(): void
+    {
+        $this->actingAsStaffWithOnlyPermission('Kas Operasional Gudang');
+
+        $response = $this->get('/operationalCash');
+
+        $response->assertStatus(200);
+        $response->assertSee('value="gudang"', false);
+        $response->assertDontSee('value="admin"', false);
+        $response->assertDontSee('value="armada"', false);
+        $response->assertDontSee('value="sales"', false);
+    }
 }


### PR DESCRIPTION
## Masalah
Issue #97: role Admin tidak bisa view/insert Akuntansi > Kas Operasional, sementara role Direksi (user cik jun) bisa.

## Root cause
Di [Cash_Operational.blade.php](resources/views/Backoffice/Reports/Cash_Operational.blade.php), `$isSuper` (role super admin) dan `$all` (cek modul generik `Kas Operasional`) dihitung tapi tidak pernah di-OR-kan ke flag `$admin`/`$gudang`/`$armada`/`$sales` yang menentukan opsi `<option>` jenis kas mana yang muncul di dropdown halaman. Riwayat git menunjukkan versi lama file ini selalu meng-OR `$isSuperAdminKas` dan `$canKasOperasionalAll` ke tiap flag jenis -- itu hilang di refactor berikutnya sementara variabelnya masih dihitung (dead code), jadi luput dari review.

Akibatnya: role yang cuma dikasih izin generik `Kas Operasional` (bukan submodule spesifik Admin/Gudang/Armada/Sales), atau bahkan super admin sekalipun, melihat dropdown jenis kas kosong -- tidak ada riwayat yang bisa dipilih maupun cara untuk input.

## Fix
OR-kan kembali `$isSuper` dan `$all` ke keempat flag jenis kas.

## Test
Tambah 3 test regresi di AkuntansiLaporanSmokeTest: generic-permission role \& super admin melihat keempat opsi, role dengan submodule spesifik (mis. hanya `Kas Operasional Gudang`) tetap cuma melihat opsi miliknya (guard supaya fix ini tidak over-grant).

```
php artisan test tests/Smoke/AkuntansiLaporanSmokeTest.php
Tests: 39 passed (52 assertions)
```

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)