### PR TITLE
feat: pola Popup Table untuk modal input+tabel (pilot Produksi) — GitHub #111

### DIFF
--- a/.claude/skills/pegasus-modal-dropdown/SKILL.md
+++ b/.claude/skills/pegasus-modal-dropdown/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pegasus-modal-dropdown
-description: How to make a Bootstrap modal scroll internally (long tables, many rows) without breaking Select2 dropdowns inside it, in the okejob-pegasus Kanakku admin theme. Load before adding modal-dialog-scrollable to any modal, before debugging a modal whose footer is pushed off-screen or won't scroll, or before debugging a Select2/autocomplete dropdown that floats to the wrong place, gets cut off, or renders behind the modal.
+description: How to make a Bootstrap modal scroll internally (long tables, many rows) without breaking Select2 dropdowns inside it, in the okejob-pegasus Kanakku admin theme. Load before adding modal-dialog-scrollable to any modal, before debugging a modal whose footer is pushed off-screen or won't scroll, before debugging a Select2/autocomplete dropdown that floats to the wrong place, gets cut off, or renders behind the modal, or before touching any "input card + table of rows" popup (see the PG Popup Table pattern below, GitHub #111).
 ---
 
 # Bootstrap modal scrolling + Select2 dropdowns in Kanakku modals
@@ -10,6 +10,76 @@ component library, so every "make this modal scroll" or "the dropdown is in the 
 has to be solved by hand against Bootstrap 5's CSS + Select2 4.0's positioning JS. Both have sharp
 edges that look like unrelated bugs but are really the same handful of root causes. This was all
 learned the hard way fixing GitHub #101 (Produksi modal) — read this before repeating that work.
+
+## Popup modals with an input card + a table of rows (GitHub #111)
+
+If the modal's content is "an input card, then a table where each add appends a row" (Produksi,
+Sales Order, Stock Transfer, PO, Cash Armada/Gudang/Sales, Product Issues, etc.), don't reach for
+the generic `modal-dialog-scrollable` + `.modal-body` scroll recipe below — use the **PG Popup
+Table** pattern instead, which scrolls the *table* internally and keeps the input card fixed above
+it. This is the standard now; only fall back to scrolling the whole modal body for modals that
+aren't input-card-plus-table shaped.
+
+- Shared constants + behavior: `public/Custom_js/Shared/popup-table.js`, loaded globally from
+  `footer-scripts.blade.php` — `PG_POPUP_TABLE.MAX_VISIBLE_ROWS` (table caps at N rows tall, then
+  scrolls) and `PG_POPUP_TABLE.ROW_INSERT_POSITION` (`'top'` or `'bottom'`) are the **one place**
+  to change either behavior app-wide.
+- Shared CSS: `.pg-popup-table-input` / `.pg-popup-table-scroll` / `.pg-popup-table-empty` in
+  `resources/views/layout/partials/pg-modal-styles.blade.php`.
+- Blade shape:
+  ```html
+  <div class="pg-popup-table-input"> ...input fields, "+" button... </div>
+  <div class="table-responsive pg-popup-table-scroll">
+    <table>
+      <thead>...</thead>
+      <tbody><!-- empty-state <tr class="pg-popup-table-empty"> when no rows --></tbody>
+      <tfoot>...totals...</tfoot>
+    </table>
+  </div>
+  ```
+  Input card comes **first** in the DOM, table second — that's what gives the "input above table"
+  UX the issue asked for. `.pg-popup-table-input` already matches the table's cell padding
+  (`12px 16px`) and adds the gap below it; don't re-add ad-hoc padding/`mb-3` around either block.
+- JS: use `pgPopupTableInsert(list, item)` instead of `list.push(item)`/`list.unshift(item)`
+  directly when adding a new row, so the insert position stays driven by the shared constant.
+  Table height is recalculated automatically (MutationObserver on the `tbody` + `shown.bs.modal` +
+  `resize`) — no manual height math needed, don't hardcode a `max-height` px value per modal.
+- After a genuinely new row is added, call `pgPopupTableScrollToEdge($tableScrollEl)` so it's
+  immediately visible without the user having to scroll manually (scrolls to top or bottom to
+  match `ROW_INSERT_POSITION`). Call it **only** at the call site that means "user added a row" —
+  not from inside a generic re-render helper like `addRow()` itself, since that's also called on
+  delete/reset/view in this codebase's pattern (clear + full re-append), and those aren't "new
+  row" events even though they touch the DOM the same way. See the call right after
+  `addRow(items)` in `continueAddProduct()` for the guarded example.
+- **If a row array has a same-indexed companion array** (e.g. Produksi's `items[]` /
+  `list_bahan[]`), and `ROW_INSERT_POSITION` is `'top'`, you must `unshift` a matching placeholder
+  into the companion array too when a *new* row is added (not when an existing row's qty is
+  merged) — see `continueAddProduct()` in `Production.js` for the worked example. Skipping this
+  desyncs the two arrays by one index and produces a row that shows another row's detail data.
+- Column with only a button and no label (e.g. the "+" add button) needs an invisible spacer
+  label (`<label class="mb-2">&nbsp;</label>`) above it inside the input card, or it renders at
+  the wrong vertical position relative to the labeled fields next to it — this bit us in the
+  Produksi rollout, check any new "+"-only column for it.
+- **`MAX_VISIBLE_ROWS` above ~3-4 will silently under-cap the table if you miss this**: when the
+  row count is `<= MAX_VISIBLE_ROWS`, `pgPopupTableRefresh()` must clear the JS override with
+  `max-height: none`, not `max-height: ""` — an empty string just deletes the inline override and
+  falls back to the CSS placeholder (`--pg-popup-table-max-height`, a fixed `260px` meant only to
+  cover the instant before JS first runs), which is shorter than most real N-row heights. Confirmed
+  live 2026-09-02 raising `MAX_VISIBLE_ROWS` to 6 — the table capped at ~260px (~3 rows) instead of
+  6 until this was fixed. If you ever touch `popup-table.js`, keep that branch as `"none"`.
+- **`ResetLoadingButton(id, text)` does not restore a button's original inline `height`** — it does
+  `css({height: ''})`, which *removes* whatever height JS last set rather than reverting to the
+  raw-HTML `style="...height:42px..."` value (once jQuery has touched a live inline-style property,
+  the original attribute text is gone for good). Any fixed-height icon-only button (like the "+" add
+  button) that goes through `LoadingButton()`/`ResetLoadingButton()` will shrink after its first
+  loading cycle, and passing plain `"+"` as the reset text also drops the feather icon in favor of a
+  literal character. Fix: don't call `ResetLoadingButton` directly on that button — wrap it in a
+  small helper that resets to the icon markup and re-applies `height` explicitly (see
+  `resetAddProductButton()` in `Production.js`). This is a `LoadingButton`/`ResetLoadingButton`
+  quirk, not specific to PG Popup Table — watch for it on any other fixed-height icon button.
+- Worked reference: `resources/views/components/modals/production/add-production.blade.php` +
+  `public/Custom_js/Backoffice/Production/Production.js` (`addRow`, `continueAddProduct`,
+  the `.btnAdd`/`.btn_view` reset handlers).
 
 ## Symptom → root cause map
 

--- a/docs/popup-table-modal-rollout.md
+++ b/docs/popup-table-modal-rollout.md
@@ -1,0 +1,71 @@
+# PG Popup Table — rollout tracker (GitHub #111)
+
+**Issue:** [#111 — [Enhancement] [Fase 2] Modal Popup Table Enhancement](https://github.com/denny011299/pegasus/issues/111)
+**Pilot branch:** `feat/popup-table-produksi` (commit `c4e3fd7`)
+**Shared implementation:** `public/Custom_js/Shared/popup-table.js` (constants + behavior) +
+`.pg-popup-table-input` / `.pg-popup-table-scroll` / `.pg-popup-table-empty` in
+`resources/views/layout/partials/pg-modal-styles.blade.php`. How-to + gotchas documented in the
+`pegasus-modal-dropdown` skill (`.claude/skills/pegasus-modal-dropdown/SKILL.md`).
+
+## Criteria (from the issue)
+
+A modal qualifies if its content is a table with an "input row" — i.e. either:
+- **(A) input-card-above-table**: a card of fields + an add button sits above a table that the
+  add button pushes new rows into, or
+- **(B) inline-edit table**: every row already on the table is itself editable (qty inputs etc.),
+  even without a separate "add new row" card.
+
+Excluded on purpose:
+- Pure read-only view/detail/recap modals (nothing in them is an input).
+- "Riwayat"/history modals — a date-range **filter** sits above a **read-only** log table; that's
+  a different UX pattern (filter-a-list, not add-a-row) and out of #111's stated scope.
+- Deprecated modules ([[pegasus-pettycash-deprecated]]).
+
+Progress is tracked here so the rollout (one modal at a time, user-checked before continuing) doesn't
+lose track of what's left. Check off + note the PR/commit when a row ships.
+
+## Status
+
+| # | Modal | File(s) | Variant | Notes | Status |
+|---|---|---|---|---|---|
+| 1 | Produksi → Tambah Produksi | `components/modals/production/add-production.blade.php` + `Production.js` | A | Pilot — reference implementation | ✅ Done (`feat/popup-table-produksi`) |
+| 2 | Kas Operasional → Kas Admin | `components/modals/operational-cash/add-cash-admin.blade.php` | A | `btn-add-catatan` | ⬜ To do |
+| 3 | Kas Operasional → Kas Armada | `components/modals/operational-cash/add-cash-armada.blade.php` | A | already uses `input_table` class | ⬜ To do |
+| 4 | Kas Operasional → Kas Gudang | `components/modals/operational-cash/add-cash-gudang.blade.php` | A | already uses `input_table` class | ⬜ To do |
+| 5 | Kas Operasional → Kas Sales | `components/modals/operational-cash/add-cash-sales.blade.php` | A | already uses `input_table` class | ⬜ To do |
+| 6 | Purchase Order → Tambah Purchase Order | `components/modals/purchase-order/add-purchase-order.blade.php` | A | SKU/scan input above table, no scroll cap today | ⬜ To do |
+| 7 | Purchase Order Detail → Retur | `components/modals/purchase-order-detail/add-retur.blade.php` | A | already uses `input_table` class | ⬜ To do |
+| 8 | Sales Order → Tambah Sales Order | `components/modals/sales-order/add-sales-order.blade.php` | A | has its own **broken** ad-hoc `max-height:300px` cap — blade has a comment admitting it doesn't actually apply; migrating fixes this as a side effect | ⬜ To do |
+| 9 | Sales Order Detail → Tambah Catatan Pengiriman | `components/modals/sales-order-detail/add-sales-delivery.blade.php` | A | | ⬜ To do |
+| 10 | Stock Transfer → Tambah Stock Transfer | `components/modals/stock-transfer/add-stock-transfer.blade.php` | A | already uses `input_table` class | ⬜ To do |
+| 11 | Stock Transfer → Terima (Accept) | `components/modals/stock-transfer/accept-stock-transfer.blade.php` | B | no add-row card — search box above table instead; each row's Qty Terima is inline-editable; has ad-hoc `min-height:240px` | ⬜ To do |
+| 12 | Customer Return → Tambah Pengembalian | `components/modals/customer-return/add-customer-return.blade.php` | A | already hand-rolled `max-height:280px` + sticky thead — good migration candidate | ⬜ To do |
+| 13 | Product Issue → Tambah Produk Bermasalah | `components/modals/product-issue/add-product-issues.blade.php` | A | | ⬜ To do |
+| 14 | BOM → Tambah Resep Bahan | `components/modals/bom/add-bom.blade.php` | A | | ⬜ To do |
+| 15 | Produksi → Fix Recipe BOM | `components/modals/production/fix-recipe-bom.blade.php` | A/B | bahan list inside the recipe-fix modal | ⬜ To do |
+| 16 | Bahan Mentah → Tambah Bahan Mentah | `components/modals/supplies/add-supplies.blade.php` | A | **2 tables** in one modal: `productVariantTable` (variant, `btnAddRow`) and the relasi-unit table (`btnAddRowRelasi`) — both qualify | ⬜ To do |
+| 17 | Stock Product → Safety Stock | `components/modals/stock-product/modal-safety-stock.blade.php` | B | `table_safety_edit` (per-unit qty inputs, active). Its 2nd table (`table_safety_transfer`, "Transfer ke Stok Produk") is `d-none` / dead per its own comment — skip that section | ⬜ To do |
+
+### Not in scope (checked, excluded)
+
+| Modal | File | Why excluded |
+|---|---|---|
+| Riwayat Stok Produk | `components/modals/stock-product/add-stock-product.blade.php` | Date-range filter + read-only log table, not an input-row table |
+| Riwayat Stok Bahan | `components/modals/stock-supplies/add-stock-supplies.blade.php` | Same filter+log pattern as above |
+| Stock Transfer → Detail (view) | `components/modals/stock-transfer/view-stock-transfer.blade.php` | Read-only |
+| Supplier → Detail (view) | `components/modals/supplier/view-supplier.blade.php` | Read-only |
+| Cash → Detail Sales | `components/modals/cash/modal-detail-sales.blade.php` | Read-only |
+| Purchase Order Detail → Modal Terima | `components/modals/purchase-order-detail/modal-terima.blade.php` | Read-only recap (2 tables), confirmation only — no input row |
+| Purchase Order Detail → Tambah Delivery Notes | `components/modals/purchase-order-detail/add-purchase-delivery.blade.php` | Table is a read-only recap of PO items, no add-row |
+| Petty Cash → Tambah Petty Cash | `components/modals/petty-cash/add-petty-cash.blade.php` | Module deprecated ([[pegasus-pettycash-deprecated]]) — not touched |
+
+## How to work a row
+
+1. Load the `pegasus-modal-dropdown` skill first (has the PG Popup Table section + known gotchas:
+   the `max-height:"none"` vs `""` trap, `ResetLoadingButton` losing a fixed-height button, and the
+   companion-array desync when `ROW_INSERT_POSITION` is `'top'`).
+2. Move the input card above the table in the blade (or convert an existing ad-hoc-scrolled table),
+   add `.pg-popup-table-input` / `.pg-popup-table-scroll` / empty-state row.
+3. In the page's JS, switch direct `push`/`unshift` calls to `pgPopupTableInsert()`, and call
+   `pgPopupTableScrollToEdge()` right after a genuinely new row is added (not from delete/reset).
+4. Update this table's Status column + note the PR/commit, then move to the next row.

--- a/public/Custom_js/Backoffice/Production/Production.js
+++ b/public/Custom_js/Backoffice/Production/Production.js
@@ -988,6 +988,22 @@ function resolveProductionInputQtyUnit(tempBom) {
     };
 }
 
+/**
+ * Reset tombol "+" (btn-add-product) ke state semula setelah loading.
+ * Tidak bisa pakai ResetLoadingButton(".btn-add-product", "+") polos:
+ * - ResetLoadingButton mengosongkan inline height (`css({height:''})`), yang
+ *   MENGHAPUS `height:42px` bawaan tombol (bukan mengembalikannya) begitu
+ *   LoadingButton sempat menimpanya - tombol jadi lebih pendek dari input di
+ *   sebelahnya (GitHub #111 follow-up).
+ * - Teks "+" polos juga menghapus ikon feather (fe-plus), diganti karakter
+ *   biasa.
+ * Jadi kembalikan ikon + paksa lagi height 42px eksplisit di sini.
+ */
+function resetAddProductButton() {
+    ResetLoadingButton(".btn-add-product", '<i class="fe fe-plus"></i>');
+    $(".btn-add-product").css("height", "42px");
+}
+
 function continueAddProduct(tempBom) {
     var satuanResep = validateBomActiveUnits(tempBom);
     if (!satuanResep.valid) {
@@ -1114,8 +1130,11 @@ function continueAddProduct(tempBom) {
                     : productionNonRetailDestinationName()),
             bom_id: temp.bom_id,
         };
-        candidateItems.push(data);
+        // Posisi baris baru (atas/bawah) ikut konstanta bersama PG_POPUP_TABLE
+        // di public/Custom_js/Shared/popup-table.js (GitHub #111).
+        pgPopupTableInsert(candidateItems, data);
     }
+    var addedNewRow = idx == -1;
 
     // Cek stok bahan mentah agregat (termasuk baris ini) SEBELUM baris masuk ke
     // daftar - dulu cek ini cuma jalan pas klik "Tambah Produksi" di akhir, jadi
@@ -1132,14 +1151,29 @@ function continueAddProduct(tempBom) {
             "X-CSRF-TOKEN": token,
         },
         success: function (e) {
-            ResetLoadingButton(".btn-add-product", "+");
+            resetAddProductButton();
             if (!e || e.status != 1) {
                 handleProductionValidationError(e, temp.bom_id);
                 return;
             }
 
+            // list_bahan sejajar index dengan items — kalau baris baru masuk di
+            // paling atas, geser juga isinya supaya getBom() tidak memakai daftar
+            // bahan milik baris lain.
+            if (addedNewRow && pgPopupTableInsertsAtTop()) {
+                list_bahan.unshift(undefined);
+            }
             items = candidateItems;
             addRow(items);
+            // Baris baru langsung terlihat tanpa harus scroll manual, ikut
+            // arah ROW_INSERT_POSITION (GitHub #111 follow-up). Cuma di sini,
+            // bukan di titik addRow() lain (reset/delete/view) - lihat catatan
+            // di pgPopupTableScrollToEdge().
+            if (addedNewRow) {
+                pgPopupTableScrollToEdge(
+                    $("#tableProduct").closest(".pg-popup-table-scroll"),
+                );
+            }
 
             $("#product_id").empty();
             $("#unit_id").empty();
@@ -1153,7 +1187,7 @@ function continueAddProduct(tempBom) {
             clearPendingProductionAdd();
         },
         error: function (a) {
-            ResetLoadingButton(".btn-add-product", "+");
+            resetAddProductButton();
             if (handlePermissionError(a)) return;
             console.log(a);
             notifikasi(
@@ -1183,7 +1217,7 @@ $(document).on("click", ".btnAdd", function () {
     $("#addProduction input").val("");
     $("#product_id").empty();
     $("#production_qty").val(1);
-    $("#tableProduct tr.row-product").remove();
+    addRow([]);
     $(".is-invalid").removeClass("is-invalid");
     $(".prod-detail-field").hide();
     $("#row-production-acc-by").hide();
@@ -1632,7 +1666,7 @@ function openProductionRevisionFromDashboardLink() {
         $("#addProduction input").val("");
         $("#product_id").empty();
         $("#production_qty").val(1);
-        $("#tableProduct tr.row-product").remove();
+        addRow([]);
         $(".is-invalid").removeClass("is-invalid");
         $(".prod-detail-field").hide();
         $("#row-production-acc-by").hide();
@@ -1884,7 +1918,13 @@ function afterInsert() {
 }
 
 function addRow(e) {
+    if (!Array.isArray(e)) e = [];
     $("#tableProduct tbody").html("");
+    if (e.length === 0) {
+        $("#tableProduct tbody").html(
+            '<tr class="pg-popup-table-empty"><td colspan="5">Belum ada produk. Tambahkan lewat form di atas.</td></tr>',
+        );
+    }
     e.forEach((element, index) => {
         console.log(element);
 
@@ -1910,6 +1950,7 @@ function addRow(e) {
     if (mode == 3) {
         $("#tableProduct [data-bs-toggle='tooltip']").tooltip();
     }
+    pgPopupTableRefresh($("#tableProduct").closest(".pg-popup-table-scroll"));
 }
 
 /**
@@ -2024,7 +2065,7 @@ function attemptAddProductionProduct(options) {
 
     LoadingButton(".btn-add-product");
     loadBomForValidation(bomId, function (fullBom) {
-        ResetLoadingButton(".btn-add-product", "+");
+        resetAddProductButton();
         if (!fullBom) {
             notifikasi(
                 "error",
@@ -2074,7 +2115,7 @@ $(document).on("click", ".btn_view", function () {
     $("#addProduction input").val("");
     $("#product_id").empty();
     $("#production_qty").val(1);
-    $("#tableProduct tr.row-product").remove();
+    addRow([]);
     $(".is-invalid").removeClass("is-invalid");
     $("#unit_id").html("");
     $("#production_date").val(data.production_date);

--- a/public/Custom_js/Shared/popup-table.js
+++ b/public/Custom_js/Shared/popup-table.js
@@ -1,0 +1,173 @@
+/**
+ * PG Popup Table — perilaku standar untuk tabel input di dalam modal popup.
+ *
+ * Dipakai oleh semua modal yang isinya "kartu input + tabel baris item"
+ * (Produksi, Sales Order, Stock Transfer, PO, dst). Tujuannya supaya UX-nya
+ * seragam: kartu input selalu di ATAS tabel, dan yang scroll adalah tabelnya
+ * sendiri (setinggi N baris), bukan modal-body-nya.
+ *
+ * SATU-SATUNYA tempat mengubah konstanta ada di file ini.
+ *
+ * Cara pakai di blade:
+ *   <div class="pg-popup-table-input"> ...kartu input... </div>
+ *   <div class="table-responsive pg-popup-table-scroll ...">
+ *     <table>...</table>
+ *   </div>
+ * Tinggi maksimal tabel dihitung otomatis (tidak perlu panggil apa pun).
+ *
+ * Cara pakai di JS halaman:
+ *   pgPopupTableInsert(items, data);   // hormati ROW_INSERT_POSITION
+ */
+var PG_POPUP_TABLE = {
+    /** Tinggi maksimal tabel = setinggi berapa baris item. */
+    MAX_VISIBLE_ROWS: 4,
+
+    /**
+     * Posisi baris baru saat ditambahkan.
+     * 'top'    → baris baru masuk paling atas (langsung terlihat tanpa scroll)
+     * 'bottom' → baris baru masuk paling bawah
+     */
+    ROW_INSERT_POSITION: "top",
+};
+window.PG_POPUP_TABLE = PG_POPUP_TABLE;
+
+/**
+ * Sisipkan item ke array daftar baris sesuai ROW_INSERT_POSITION.
+ * Dipakai juga untuk array pendamping (mis. list_bahan) supaya index-nya
+ * tetap sejajar dengan array utama.
+ *
+ * @param {Array} list array daftar baris (dimodifikasi in-place)
+ * @param {*} item item baru
+ * @returns {Array} list yang sama
+ */
+function pgPopupTableInsert(list, item) {
+    if (!Array.isArray(list)) return list;
+    if (PG_POPUP_TABLE.ROW_INSERT_POSITION === "top") {
+        list.unshift(item);
+    } else {
+        list.push(item);
+    }
+    return list;
+}
+window.pgPopupTableInsert = pgPopupTableInsert;
+
+/** true kalau baris baru masuk di paling atas. */
+function pgPopupTableInsertsAtTop() {
+    return PG_POPUP_TABLE.ROW_INSERT_POSITION === "top";
+}
+window.pgPopupTableInsertsAtTop = pgPopupTableInsertsAtTop;
+
+/**
+ * Hitung ulang tinggi maksimal satu container scroll tabel popup.
+ * Aman dipanggil berkali-kali; kalau elemennya belum terlihat (modal masih
+ * tertutup) perhitungan dilewati supaya tidak menghasilkan tinggi 0.
+ *
+ * @param {Element|jQuery|string} el container ber-class .pg-popup-table-scroll
+ */
+function pgPopupTableRefresh(el) {
+    var $scroll = $(el);
+    if (!$scroll.length) return;
+
+    $scroll.each(function () {
+        var $s = $(this);
+        if (!$s.is(":visible")) return;
+
+        var $rows = $s.find("tbody > tr").not(".pg-popup-table-ignore");
+        var max = parseInt(PG_POPUP_TABLE.MAX_VISIBLE_ROWS, 10) || 4;
+
+        if ($rows.length <= max) {
+            // Muat semua → tidak perlu scroll vertikal sama sekali. Pakai "none",
+            // BUKAN "" — mengosongkan inline style hanya menjatuhkan balik ke
+            // fallback CSS (--pg-popup-table-max-height, cuma placeholder
+            // sebelum JS ini sempat jalan), yang jadi lebih pendek dari
+            // MAX_VISIBLE_ROWS baris asli begitu row makin tinggi/banyak.
+            $s.css("max-height", "none");
+            return;
+        }
+
+        var height = 0;
+        $s.find("thead").each(function () {
+            height += this.offsetHeight || 0;
+        });
+        $s.find("tfoot").each(function () {
+            height += this.offsetHeight || 0;
+        });
+        $rows.slice(0, max).each(function () {
+            height += this.offsetHeight || 0;
+        });
+
+        if (height <= 0) return; // belum ter-layout, biarkan apa adanya
+        $s.css("max-height", Math.ceil(height) + "px");
+    });
+}
+window.pgPopupTableRefresh = pgPopupTableRefresh;
+
+/** Hitung ulang semua container scroll tabel popup yang sedang terlihat. */
+function pgPopupTableRefreshAll(root) {
+    pgPopupTableRefresh($(root || document).find(".pg-popup-table-scroll"));
+}
+window.pgPopupTableRefreshAll = pgPopupTableRefreshAll;
+
+/**
+ * Scroll container tabel supaya baris yang baru saja ditambahkan langsung
+ * terlihat, mengikuti arah ROW_INSERT_POSITION ('top' → scroll ke atas,
+ * 'bottom' → scroll ke bawah).
+ *
+ * Sengaja TIDAK dipanggil otomatis dari MutationObserver di file ini — daftar
+ * baris di modal ini di-render ulang lewat clear+append penuh (`addRow()`)
+ * untuk insert MAUPUN delete/reset, jadi dari sisi DOM keduanya sama-sama
+ * "node baru ditambahkan". Kalau di-auto-scroll dari situ, hapus baris pun
+ * ikut melompat ke bawah/atas. Panggil ini secara eksplisit HANYA di titik
+ * kode yang benar-benar berarti "user menambah baris baru" (bukan di titik
+ * render ulang untuk alasan lain) — lihat pemanggilannya di
+ * `continueAddProduct()` (Production.js) untuk contoh.
+ *
+ * @param {Element|jQuery|string} el container ber-class .pg-popup-table-scroll
+ */
+function pgPopupTableScrollToEdge(el) {
+    var $s = $(el);
+    if (!$s.length) return;
+    $s.each(function () {
+        var top =
+            PG_POPUP_TABLE.ROW_INSERT_POSITION === "top"
+                ? 0
+                : this.scrollHeight;
+        if (typeof this.scrollTo === "function") {
+            this.scrollTo({ top: top, behavior: "smooth" });
+        } else {
+            // Browser lama tanpa smooth scroll (mis. Safari sebelum ~15.4) — langsung lompat.
+            this.scrollTop = top;
+        }
+    });
+}
+window.pgPopupTableScrollToEdge = pgPopupTableScrollToEdge;
+
+$(function () {
+    // Baris tabel di modal ini di-render ulang lewat .html()/.append() dari JS
+    // halaman (bukan DataTables), jadi pakai MutationObserver supaya halaman
+    // pemakai tidak perlu memanggil refresh manual setiap render.
+    if (window.MutationObserver) {
+        var observer = new MutationObserver(function (mutations) {
+            var touched = [];
+            mutations.forEach(function (m) {
+                var scroll = $(m.target).closest(".pg-popup-table-scroll")[0];
+                if (scroll && touched.indexOf(scroll) === -1)
+                    touched.push(scroll);
+            });
+            if (touched.length) pgPopupTableRefresh($(touched));
+        });
+        $(".pg-popup-table-scroll").each(function () {
+            var tbody = this.querySelector("tbody");
+            if (tbody) observer.observe(tbody, { childList: true });
+        });
+    }
+
+    // Saat modal baru dibuka, elemennya baru punya tinggi nyata.
+    $(document).on("shown.bs.modal", ".modal", function () {
+        pgPopupTableRefreshAll(this);
+    });
+
+    $(window).on("resize", function () {
+        pgPopupTableRefreshAll(document);
+    });
+});

--- a/public/Custom_js/Shared/popup-table.js
+++ b/public/Custom_js/Shared/popup-table.js
@@ -27,7 +27,7 @@ var PG_POPUP_TABLE = {
      * 'top'    → baris baru masuk paling atas (langsung terlihat tanpa scroll)
      * 'bottom' → baris baru masuk paling bawah
      */
-    ROW_INSERT_POSITION: "top",
+    ROW_INSERT_POSITION: "bottom",
 };
 window.PG_POPUP_TABLE = PG_POPUP_TABLE;
 

--- a/resources/views/components/modals/production/add-production.blade.php
+++ b/resources/views/components/modals/production/add-production.blade.php
@@ -40,6 +40,11 @@
     overflow-y: auto !important;
     overflow-x: hidden !important;
   }
+  /* Hint "1 pallet = N dos" di bawah field Qty diposisikan absolute; beri ruang
+     ekstra di bawah kartu input supaya teksnya tidak keluar dari kartu. */
+  #addProduction .pg-popup-table-input {
+    padding-bottom: 24px;
+  }
   /* Nama Produk / Gudang Tujuan autocompletes are appended to <body> (not
      .modal-content) so their dropdown can't get clipped by the modal's own
      overflow:hidden. Bootstrap's .modal is z-index 1055, above select2's
@@ -136,7 +141,80 @@
               <span class="fw-bold text-dark" style="font-size:14px;">Daftar Produk</span>
             </div>
 
-            <div class="table-responsive rounded border mb-3 bg-white">
+            <div class="pg-popup-table-input input_table">
+              <div class="row g-3 align-items-end">
+                <div class="col-12 col-lg-3 add">
+                  <div class="input-block mb-0" id="row-product">
+                    <label class="text-muted mb-2"
+                      style="font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:.4px;">Nama Produk
+                      <span class="text-danger">*</span></label>
+                    <select class="form-select fill_product" id="product_id"
+                      style="font-size:14px;border-radius:8px;height:42px;"></select>
+                  </div>
+                </div>
+                <div class="col-6 col-lg-2 add">
+                  <div class="input-block mb-0" style="position: relative;">
+                    <label class="text-muted mb-2"
+                      style="font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:.4px;">Qty <span
+                        class="text-danger">*</span></label>
+                    <input type="text" class="form-control fill_product number-only" id="production_qty"
+                      placeholder="Qty" value="1" style="font-size:14px;border-radius:8px;height:42px;">
+                    <small class="text-muted position-absolute" id="production_pallet_hint"
+                      style="bottom: -18px; left: 2px; font-size: 10px; white-space: nowrap;"></small>
+                  </div>
+                </div>
+                <div class="col-6 col-lg-2 add">
+                  <div class="input-block mb-0">
+                    <label class="text-muted mb-2"
+                      style="font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:.4px;">Satuan
+                      <span class="text-danger">*</span></label>
+                    <select class="form-select fill_product" id="unit_id"
+                      style="font-size:14px;border-radius:8px;height:42px;"></select>
+                  </div>
+                </div>
+                <div class="col-12 col-lg-4 add">
+                  <div class="input-block mb-0">
+                    <label class="text-muted mb-2"
+                      style="font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:.4px;">Gudang
+                      Tujuan <span class="text-danger">*</span></label>
+                    @php
+                      $prodDestWh = $activeWarehouse ?? null;
+                      $prodDestWhName = $prodDestWh
+                        ? ($prodDestWh->warehouse_name ?? $prodDestWh->name ?? '')
+                        : '';
+                      $isActiveMainWh = $prodDestWh
+                        && isset($prodDestWh->type)
+                        && (int) ($prodDestWh->type->is_main_warehouse ?? 0) === 1;
+                      $prodMainWhName = $prodDestWhName;
+                      if (! $isActiveMainWh && isset($warehouses)) {
+                          $prodMainWh = collect($warehouses)->first(function ($wh) {
+                              return isset($wh->type) && (int) $wh->type->is_main_warehouse === 1;
+                          });
+                          if ($prodMainWh) {
+                              $prodMainWhName = $prodMainWh->warehouse_name ?? $prodMainWh->name ?? $prodMainWhName;
+                          }
+                      }
+                    @endphp
+                    <div id="production-main-warehouse-badge" class="d-flex align-items-center px-3"
+                      style="height:42px;border-radius:8px;background:#eff6ff;border:1px solid #bfdbfe;color:#1d4ed8;font-size:13px;font-weight:600;">
+                      <i class="fe fe-home me-2"></i><span>{{ $prodMainWhName !== '' ? $prodMainWhName : 'Gudang utama' }}</span>
+                    </div>
+                    <select class="form-select" id="production_destination_warehouse_id"
+                      style="display:none;font-size:14px;border-radius:8px;height:42px;"></select>
+                  </div>
+                </div>
+                <div class="col-12 col-md-12 col-lg-1 add">
+                  <label class="text-muted mb-2 d-none d-lg-block"
+                    style="font-size:11px;font-weight:600;">&nbsp;</label>
+                  <button type="button"
+                    class="btn btn-primary w-100 btn-add-product d-flex align-items-center justify-content-center"
+                    style="background:linear-gradient(135deg,#3b82f6,#2563eb);color:#fff;border:none;border-radius:8px;height:42px;box-shadow:0 4px 12px rgba(59,130,246,.3);">
+                    <i class="fe fe-plus"></i>
+                  </button>
+                </div>
+              </div>
+            </div>
+            <div class="table-responsive rounded border bg-white pg-popup-table-scroll">
               <table class="table table-center custom-table-scroll mb-0" id="tableProduct"
                 style="min-width: 800px;">
                 <thead style="background: #f1f5f9;">
@@ -159,6 +237,9 @@
                   </tr>
                 </thead>
                 <tbody>
+                  <tr class="pg-popup-table-empty">
+                    <td colspan="5">Belum ada produk. Tambahkan lewat form di atas.</td>
+                  </tr>
                 </tbody>
                 <tfoot class="dos" style="background: #f8fafc; border-top: 2px solid #e2e8f0;">
                   <tr>
@@ -173,76 +254,6 @@
                   </tr>
                 </tfoot>
               </table>
-            </div>
-            <div class="row input_table g-3 align-items-end p-3 rounded bg-white"
-              style="border: 1px solid #e2e8f0; box-shadow: 0 2px 4px rgba(0,0,0,0.02);">
-              <div class="col-12 col-lg-3 add">
-                <div class="input-block mb-0" id="row-product">
-                  <label class="text-muted mb-2"
-                    style="font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:.4px;">Nama Produk
-                    <span class="text-danger">*</span></label>
-                  <select class="form-select fill_product" id="product_id"
-                    style="font-size:14px;border-radius:8px;height:42px;"></select>
-                </div>
-              </div>
-              <div class="col-6 col-lg-2 add">
-                <div class="input-block mb-0" style="position: relative;">
-                  <label class="text-muted mb-2"
-                    style="font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:.4px;">Qty <span
-                      class="text-danger">*</span></label>
-                  <input type="text" class="form-control fill_product number-only" id="production_qty"
-                    placeholder="Qty" value="1" style="font-size:14px;border-radius:8px;height:42px;">
-                  <small class="text-muted position-absolute" id="production_pallet_hint"
-                    style="bottom: -18px; left: 2px; font-size: 10px; white-space: nowrap;"></small>
-                </div>
-              </div>
-              <div class="col-6 col-lg-2 add">
-                <div class="input-block mb-0">
-                  <label class="text-muted mb-2"
-                    style="font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:.4px;">Satuan
-                    <span class="text-danger">*</span></label>
-                  <select class="form-select fill_product" id="unit_id"
-                    style="font-size:14px;border-radius:8px;height:42px;"></select>
-                </div>
-              </div>
-              <div class="col-12 col-lg-4 add">
-                <div class="input-block mb-0">
-                  <label class="text-muted mb-2"
-                    style="font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:.4px;">Gudang
-                    Tujuan <span class="text-danger">*</span></label>
-                  @php
-                    $prodDestWh = $activeWarehouse ?? null;
-                    $prodDestWhName = $prodDestWh
-                      ? ($prodDestWh->warehouse_name ?? $prodDestWh->name ?? '')
-                      : '';
-                    $isActiveMainWh = $prodDestWh
-                      && isset($prodDestWh->type)
-                      && (int) ($prodDestWh->type->is_main_warehouse ?? 0) === 1;
-                    $prodMainWhName = $prodDestWhName;
-                    if (! $isActiveMainWh && isset($warehouses)) {
-                        $prodMainWh = collect($warehouses)->first(function ($wh) {
-                            return isset($wh->type) && (int) $wh->type->is_main_warehouse === 1;
-                        });
-                        if ($prodMainWh) {
-                            $prodMainWhName = $prodMainWh->warehouse_name ?? $prodMainWh->name ?? $prodMainWhName;
-                        }
-                    }
-                  @endphp
-                  <div id="production-main-warehouse-badge" class="d-flex align-items-center px-3"
-                    style="height:42px;border-radius:8px;background:#eff6ff;border:1px solid #bfdbfe;color:#1d4ed8;font-size:13px;font-weight:600;">
-                    <i class="fe fe-home me-2"></i><span>{{ $prodMainWhName !== '' ? $prodMainWhName : 'Gudang utama' }}</span>
-                  </div>
-                  <select class="form-select" id="production_destination_warehouse_id"
-                    style="display:none;font-size:14px;border-radius:8px;height:42px;"></select>
-                </div>
-              </div>
-              <div class="col-12 col-md-12 col-lg-1 add text-end">
-                <button type="button"
-                  class="btn btn-primary w-100 btn-add-product d-flex align-items-center justify-content-center"
-                  style="background:linear-gradient(135deg,#3b82f6,#2563eb);color:#fff;border:none;border-radius:8px;height:42px;box-shadow:0 4px 12px rgba(59,130,246,.3);">
-                  <i class="fe fe-plus"></i>
-                </button>
-              </div>
             </div>
           </div>
         </div>

--- a/resources/views/layout/partials/footer-scripts.blade.php
+++ b/resources/views/layout/partials/footer-scripts.blade.php
@@ -170,6 +170,9 @@
 <!-- multiselect JS -->
 <script src="{{ URL::asset('/assets/js/jquery-ui.min.js') }}"></script>
 
+<!-- PG Popup Table: konstanta + perilaku standar tabel input di dalam modal -->
+<script src="{{ URL::asset('/Custom_js/Shared/popup-table.js') }}"></script>
+
 @if (Route::is(['lightbox', 'template-invoice']))
   <!-- lightbox JS -->
   <script src="{{ URL::asset('/assets/plugins/lightbox/glightbox.min.js') }}"></script>

--- a/resources/views/layout/partials/pg-modal-styles.blade.php
+++ b/resources/views/layout/partials/pg-modal-styles.blade.php
@@ -318,4 +318,58 @@
         background: #fee2e2 !important;
         border-color: #fca5a5 !important;
     }
+
+    /* ═══ PG Popup Table — tabel input di dalam modal (GitHub #111) ═══
+       Pola standar: kartu input di ATAS, lalu tabel daftar item yang scroll
+       sendiri setinggi PG_POPUP_TABLE.MAX_VISIBLE_ROWS baris.
+       Konstanta + perhitungan tinggi ada di public/Custom_js/Shared/popup-table.js —
+       nilai --pg-popup-table-max-height di bawah hanya fallback sebelum JS jalan. */
+    .pg-popup-table-scroll {
+        --pg-popup-table-max-height: 260px;
+        max-height: var(--pg-popup-table-max-height);
+        overflow-y: auto;
+        overflow-x: auto;
+    }
+    /* Header & footer total tetap terlihat saat baris di-scroll. */
+    .pg-popup-table-scroll > table > thead > tr > th {
+        position: sticky;
+        top: 0;
+        z-index: 3;
+        background: #f1f5f9;
+    }
+    .pg-popup-table-scroll > table > tfoot > tr > td {
+        position: sticky;
+        bottom: 0;
+        z-index: 3;
+        background: #f8fafc;
+    }
+    .pg-popup-table-scroll::-webkit-scrollbar {
+        width: 8px;
+        height: 8px;
+    }
+    .pg-popup-table-scroll::-webkit-scrollbar-thumb {
+        background: #cbd5e1;
+        border-radius: 8px;
+    }
+    .pg-popup-table-scroll::-webkit-scrollbar-thumb:hover {
+        background: #94a3b8;
+    }
+
+    /* Kartu input: padding disamakan dengan sel tabel (12px 16px) + jarak ke tabel. */
+    .pg-popup-table-input {
+        padding: 12px 16px;
+        margin-bottom: 16px;
+        background: #ffffff;
+        border: 1px solid #e2e8f0;
+        border-radius: 8px;
+        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.02);
+    }
+
+    /* Baris placeholder saat daftar masih kosong. */
+    .pg-popup-table-empty td {
+        padding: 24px 16px !important;
+        text-align: center;
+        color: #94a3b8;
+        font-size: 13px;
+    }
 </style>


### PR DESCRIPTION
## Ringkasan

Implementasi awal (pilot) untuk **GitHub #111 — Modal Popup Table Enhancement**: menyeragamkan UX semua modal popup yang isinya "kartu input + tabel daftar baris" (Produksi, Sales Order, Stock Transfer, PO, dst).

Sesuai deskripsi issue, tujuannya:
- input diletakkan di **atas** tabel
- yang **scroll adalah tabelnya**, bukan seluruh modal content — tinggi maksimal setinggi N baris, N-nya konstanta yang bisa diubah di 1 tempat
- posisi baris baru saat ditambah (**atas**/**bawah**) juga konstanta yang bisa diubah di 1 tempat
- padding kartu input disamakan dengan padding sel tabel + ada jarak ke tabel

Untuk PR ini scope-nya baru **1 modal** dulu (Produksi → Tambah Produksi) sebagai pilot yang sudah dicek langsung oleh @arielchristianworks. Modal lain yang sesuai kriteria di-daftar sebagai rollout selanjutnya (lihat bagian di bawah) — dikerjakan satu-satu dengan pengecekan progres, bukan sekaligus.

## Yang dibangun (dipakai bersama, bukan cuma untuk Produksi)

- **`public/Custom_js/Shared/popup-table.js`** (baru) — 1 tempat konstanta:
  - `PG_POPUP_TABLE.MAX_VISIBLE_ROWS` — tinggi maksimal tabel = setinggi berapa baris
  - `PG_POPUP_TABLE.ROW_INSERT_POSITION` — `'top'` atau `'bottom'`
  - `pgPopupTableInsert(list, item)` — insert ke array sesuai konstanta di atas
  - `pgPopupTableRefresh()` — hitung ulang tinggi tabel otomatis (dipasang lewat `MutationObserver` di `tbody` + saat modal dibuka + saat resize, jadi halaman pemakai gak perlu manggil apa-apa)
  - `pgPopupTableScrollToEdge()` — smooth-scroll ke baris yang baru ditambahkan
  - Di-load global lewat `footer-scripts.blade.php`, jadi otomatis tersedia di semua halaman.
- **CSS bersama** di `pg-modal-styles.blade.php`: `.pg-popup-table-input` / `.pg-popup-table-scroll` / `.pg-popup-table-empty`.
- **Panduan + gotcha** didokumentasikan di skill `pegasus-modal-dropdown` (`.claude/skills/pegasus-modal-dropdown/SKILL.md`) supaya rollout ke modal berikutnya gak perlu re-derive dari nol.

## Diterapkan ke Produksi → Tambah Produksi

- Kartu input dipindah ke atas tabel (`add-production.blade.php`).
- Tabel daftar produk sekarang scroll sendiri, modal content tidak lagi ikut scroll.
- Baris kosong (empty-state) ditampilkan saat daftar produk masih kosong.
- Insert baris baru & `list_bahan` (array pendamping) ikut konstanta `ROW_INSERT_POSITION`.
- 2 bug ditemukan & diperbaiki selama pengujian manual:
  - Tinggi tabel salah dihitung saat baris ≤ `MAX_VISIBLE_ROWS` — mengosongkan `max-height` inline jatuh balik ke fallback CSS (`260px`), bukan "tanpa batas". Diperbaiki pakai `max-height: none`.
  - Tombol "+" kehilangan tinggi tetapnya (42px) & ikonnya setelah 1x siklus loading — `ResetLoadingButton()` ternyata menghapus inline `height`, bukan mengembalikan nilai aslinya. Ditambah helper `resetAddProductButton()` khusus tombol ini.

## Rollout selanjutnya (belum di PR ini)

Sudah dibuat daftar tracking lengkap di **`docs/popup-table-modal-rollout.md`** — hasil survey semua modal yang punya `<table>` di `resources/views/components/modals/`, diklasifikasi masuk kriteria atau tidak.

**16 modal lagi yang akan menyusul** (dikerjakan satu per satu):

| Modal | Catatan |
|---|---|
| Kas Operasional → Kas Admin/Armada/Gudang/Sales (4 modal) | 3 di antaranya sudah pakai class `input_table` lama, migrasi cukup langsung |
| Purchase Order → Tambah Purchase Order | belum ada scroll cap sama sekali hari ini |
| Purchase Order Detail → Retur | sudah pakai `input_table` |
| Sales Order → Tambah Sales Order | sudah ada `max-height:300px` versi manual yang **ternyata tidak jalan** (ada komentar di kode yang mengakui ini) — migrasi sekaligus jadi perbaikan bug lama |
| Sales Order Detail → Tambah Catatan Pengiriman | |
| Stock Transfer → Tambah Stock Transfer | sudah pakai `input_table` |
| Stock Transfer → Terima (Accept) | varian tabel inline-edit (tanpa kartu input terpisah, ada search box) |
| Customer Return → Tambah Pengembalian | sudah ada scroll manual `max-height:280px`, kandidat migrasi bagus |
| Product Issue → Tambah Produk Bermasalah | |
| BOM → Tambah Resep Bahan | |
| Produksi → Fix Recipe BOM | |
| Bahan Mentah → Tambah Bahan Mentah | ada **2 tabel** dalam 1 modal, keduanya masuk kriteria |
| Stock Product → Safety Stock | varian inline-edit; ada 1 section lain yang `d-none`/mati, dilewati |

**8 modal lain sudah dicek & sengaja TIDAK dimasukkan** (didaftar di `docs/popup-table-modal-rollout.md` bagian "Not in scope") karena bentuknya filter+tabel-riwayat read-only atau modal konfirmasi read-only — bukan "tabel dengan input row" seperti dimaksud issue #111. Termasuk Petty Cash yang memang sudah deprecated.

## Testing

- `php artisan view:cache` (kompilasi semua blade) — lolos.
- `node --check` untuk kedua file JS yang diubah — lolos.
- Manual test langsung oleh @arielchristianworks di modal Produksi, termasuk uji ganti nilai `MAX_VISIBLE_ROWS`/`ROW_INSERT_POSITION` dan siklus tombol "+" berulang — sudah oke setelah 2 bug di atas diperbaiki.

---
Terkait #111 (pilot 1 modal; issue TETAP DIBUKA sampai seluruh modal di `docs/popup-table-modal-rollout.md` selesai — jangan pakai kata "Closes" di PR rollout berikutnya sampai baris terakhir kelar).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
