### PR TITLE
fix(stock-opname): draft tidak bocorkan stok sistem & bisa dibuka via URL orang lain

### DIFF
--- a/app/Http/Controllers/StockController.php
+++ b/app/Http/Controllers/StockController.php
@@ -245,6 +245,13 @@ class StockController extends Controller
         if (!$sto) {
             abort(404);
         }
+        // GitHub #115: getStockOpname() sengaja TIDAK memfilter by-id lookup (komentar di
+        // model-nya) supaya buka-lewat-menu tetap kefilter dengan benar tapi buka-lewat-URL-
+        // langsung tidak diam-diam 404 untuk dokumen sendiri -- makanya draft milik staff lain
+        // baru diblok di sini, bukan lewat query itu.
+        if ($sto->is_draft && !$this->canManageStockOpnameDraft($sto)) {
+            abort(404);
+        }
 
         // Dokumen versi baru: isi $items dari stock_opname_lines lewat adaptor, dalam struktur
         // yang sama persis -- sisa method ini (urutan, $data, view) dipakai bersama, dan
@@ -1060,6 +1067,12 @@ class StockController extends Controller
                 abort(404);
             }
             $param['data'] = $rows[0];
+
+            // GitHub #115: kembaran guard DetailStockOpname() -- draft milik staff lain tidak
+            // boleh terbuka lewat URL langsung.
+            if ($param['data']->is_draft && !$this->canManageStockOpnameBahanDraft($param['data'])) {
+                abort(404);
+            }
 
             // Dokumen versi baru: ->item di atas datang dari getStockOpnameBahan() yang membaca
             // stock_opname_detail_bahans -- tabel itu tidak lagi ditulis untuk dokumen ini. Timpa

--- a/app/Support/StockOpname/BahanOpnameLineReader.php
+++ b/app/Support/StockOpname/BahanOpnameLineReader.php
@@ -47,18 +47,26 @@ class BahanOpnameLineReader
         }
 
         $pending = (int) $stob->status === self::STATUS_MENUNGGU;
+        // GitHub #115: kembaran OpnameLineReader::readCurrent() -- draft tidak boleh membaca stok
+        // sistem sama sekali, cuma angka yang benar-benar sudah diinput staf sendiri.
+        $isDraft = (bool) $stob->is_draft;
         // Dipin ke gudang dokumen ini, bukan gudang aktif sesi pembaca -- lihat liveStockMap().
-        $live = $this->liveStockMap($lines, $stob->warehouse_id ?: null);
+        $live = $isDraft ? collect() : $this->liveStockMap($lines, $stob->warehouse_id ?: null);
 
         return $lines
             ->groupBy('supplies_id')
-            ->map(function ($group) use ($pending, $live) {
+            ->map(function ($group) use ($pending, $live, $isDraft) {
                 $first = $group->first();
                 $units = [];
 
                 foreach ($group as $line) {
-                    $liveQty = (int) ($live->get($line->supplies_id.'-'.$line->unit_id) ?? 0);
-                    $system = $pending ? $liveQty : (int) ($line->sobl_system_qty_final ?? 0);
+                    if ($isDraft) {
+                        $liveQty = null;
+                        $system = null;
+                    } else {
+                        $liveQty = (int) ($live->get($line->supplies_id.'-'.$line->unit_id) ?? 0);
+                        $system = $pending ? $liveQty : (int) ($line->sobl_system_qty_final ?? 0);
+                    }
 
                     $units[] = [
                         'unit' => $line->sobl_unit_short_name ?? ('unit#'.$line->unit_id),
@@ -66,7 +74,7 @@ class BahanOpnameLineReader
                         'system' => $system,
                         'live' => $liveQty,
                         'counted' => $line->sobl_counted_qty === null ? null : (int) $line->sobl_counted_qty,
-                        'selisih' => $line->selisih($system),
+                        'selisih' => $isDraft ? null : $line->selisih($system),
                     ];
                 }
 
@@ -145,15 +153,21 @@ class BahanOpnameLineReader
             ? Unit::whereIn('unit_id', array_keys($allUnitIds))->get()->keyBy('unit_id')
             : collect();
 
+        // GitHub #115: draft -- 'stock' di sini murni buat placeholder hint di halaman input,
+        // yang justru harus KOSONG untuk draft (lihat readCurrent()). Jangan ambil sama sekali.
         // Dipin ke gudang dokumen ini -- lihat liveStockMap()'s doc.
         $warehouseId = $stob->warehouse_id ?: null;
-        $liveStocks = ($warehouseId !== null
-                ? SuppliesStock::withoutGlobalScope('active_warehouse')->where('warehouse_id', $warehouseId)
-                : SuppliesStock::query())
-            ->where('status', 1)
-            ->whereIn('supplies_id', $suppliesIds)
-            ->get()
-            ->groupBy('supplies_id');
+        if ($stob->is_draft) {
+            $liveStocks = collect();
+        } else {
+            $liveStocks = ($warehouseId !== null
+                    ? SuppliesStock::withoutGlobalScope('active_warehouse')->where('warehouse_id', $warehouseId)
+                    : SuppliesStock::query())
+                ->where('status', 1)
+                ->whereIn('supplies_id', $suppliesIds)
+                ->get()
+                ->groupBy('supplies_id');
+        }
 
         return $rows->map(function (array $row) use ($supplies, $unitsMap, $liveStocks) {
             $supply = $supplies->get($row['supplies_id']);
@@ -214,15 +228,19 @@ class BahanOpnameLineReader
      * GitHub #78 follow-up (lihat OpnameLineReader::text()): satuan tak dihitung tercetak "cocok
      * dengan sistem", bukan tanda hubung telanjang. Murni kosmetik tampilan.
      */
+    /**
+     * GitHub #115: kembaran OpnameLineReader::text() -- draft tidak membawa stok sistem
+     * ($u['system'] === null), jadi tidak ada fallback untuk dipegang: "-" apa adanya.
+     */
     private function text(array $units, string $key): string
     {
         $parts = [];
         foreach ($units as $u) {
             $value = $u[$key];
             if ($value === null) {
-                $value = $key === 'selisih' ? 0 : $u['system'];
+                $value = ($key === 'selisih' && $u['system'] !== null) ? 0 : $u['system'];
             }
-            $parts[] = $value.' '.$u['unit'];
+            $parts[] = ($value === null ? '-' : $value).' '.$u['unit'];
         }
 
         return implode(', ', $parts);

--- a/app/Support/StockOpname/OpnameLineReader.php
+++ b/app/Support/StockOpname/OpnameLineReader.php
@@ -101,20 +101,30 @@ class OpnameLineReader
         }
 
         $pending = (int) $sto->status === self::STATUS_MENUNGGU;
-        // Stok live selalu diambil: dipakai sebagai stok sistem saat dokumen masih menunggu, dan
-        // sebagai petunjuk placeholder di halaman input untuk satuan yang belum dihitung. Dipin ke
-        // gudang dokumen ini (bukan gudang aktif sesi pembaca) -- lihat liveStockMap().
-        $live = $this->liveStockMap($lines, $sto->warehouse_id ?: null);
+        // GitHub #115: draft belum apa-apa -- jangan ambil/lihatkan stok sistem sama sekali,
+        // cuma angka yang benar-benar sudah diinput staf sendiri yang boleh tampil. Beda dari
+        // "menunggu" (sudah diajukan): itu tetap baca live seperti sebelumnya di bawah.
+        $isDraft = (bool) $sto->is_draft;
+        // Stok live selalu diambil (kecuali draft): dipakai sebagai stok sistem saat dokumen masih
+        // menunggu, dan sebagai petunjuk placeholder di halaman input untuk satuan yang belum
+        // dihitung. Dipin ke gudang dokumen ini (bukan gudang aktif sesi pembaca) -- lihat
+        // liveStockMap().
+        $live = $isDraft ? collect() : $this->liveStockMap($lines, $sto->warehouse_id ?: null);
 
         return $lines
             ->groupBy('product_variant_id')
-            ->map(function ($group) use ($pending, $live) {
+            ->map(function ($group) use ($pending, $live, $isDraft) {
                 $first = $group->first();
                 $units = [];
 
                 foreach ($group as $line) {
-                    $liveQty = (int) ($live->get($line->product_variant_id.'-'.$line->unit_id) ?? 0);
-                    $system = $pending ? $liveQty : (int) ($line->sol_system_qty_final ?? 0);
+                    if ($isDraft) {
+                        $liveQty = null;
+                        $system = null;
+                    } else {
+                        $liveQty = (int) ($live->get($line->product_variant_id.'-'.$line->unit_id) ?? 0);
+                        $system = $pending ? $liveQty : (int) ($line->sol_system_qty_final ?? 0);
+                    }
 
                     $units[] = [
                         'unit' => $line->sol_unit_short_name ?? ('unit#'.$line->unit_id),
@@ -122,7 +132,7 @@ class OpnameLineReader
                         'system' => $system,
                         'live' => $liveQty,
                         'counted' => $line->sol_counted_qty === null ? null : (int) $line->sol_counted_qty,
-                        'selisih' => $line->selisih($system),
+                        'selisih' => $isDraft ? null : $line->selisih($system),
                     ];
                 }
 
@@ -240,6 +250,11 @@ class OpnameLineReader
      * halaman edit (legacyItems()) tetap null apa adanya -- cuma string yang dicetak di sini
      * yang dihumanisasi. Untuk dokumen lama humanisasinya sudah terjadi lebih awal di
      * readLegacy() (di dalam $units itu sendiri), jadi di sini jadi no-op untuknya.
+     *
+     * GitHub #115: draft tidak pernah membawa stok sistem ($u['system'] === null, lihat
+     * readCurrent()) -- fallback di bawah TIDAK ADA apa pun untuk dijadikan pegangan, jadi
+     * "tidak dihitung" tercetak "-" apa adanya (bukan angka sistem yang memang tidak pernah
+     * diambil sama sekali).
      */
     private function text(array $units, string $key): string
     {
@@ -247,9 +262,9 @@ class OpnameLineReader
         foreach ($units as $u) {
             $value = $u[$key];
             if ($value === null) {
-                $value = $key === 'selisih' ? 0 : $u['system'];
+                $value = ($key === 'selisih' && $u['system'] !== null) ? 0 : $u['system'];
             }
-            $parts[] = $value.' '.$u['unit'];
+            $parts[] = ($value === null ? '-' : $value).' '.$u['unit'];
         }
 
         return implode(', ', $parts);

--- a/public/Custom_js/Backoffice/Inventory/CreateStockOpname.js
+++ b/public/Custom_js/Backoffice/Inventory/CreateStockOpname.js
@@ -160,15 +160,19 @@ function refreshStockOpname(callback) {
                     // on an EXISTING document being re-edited (mode 2, e.g. a draft reload) -- a
                     // brand-new create form (mode 1) stays fully blank, per the user's explicit
                     // request.
+                    // GitHub #115: draft murni cuma boleh menampilkan apa yang sudah diinput
+                    // sendiri -- stok sistem TIDAK ditampilkan sama sekali selama masih draft.
                     let createPlaceholder =
-                        mode == 2 ? ` placeholder="${element.ps_stock}"` : "";
+                        mode == 2 && !data.is_draft
+                            ? ` placeholder="${element.ps_stock}"`
+                            : "";
                     rl_stock += `
                         <input type="text"
                             class="form-control real-stock nominal_only text-end"
                             value=""${createPlaceholder}
                             data-unit-id="${element.unit_id}"
                             data-unit-name="${element.unit_short_name}"
-                            data-system-qty="${element.ps_stock}">
+                            data-system-qty="${data.is_draft ? "" : element.ps_stock}">
                         <span class="input-group-text">${escapeHtml(element.unit_short_name)}</span>
                     `;
                 });
@@ -252,9 +256,13 @@ function renderMode2(items) {
             // dihitung) di histori dokumen, tidak menghidupkan lagi bug fallback lama.
             let untouched = element.real_qty === null || element.real_qty === undefined;
             let prefill = untouched ? "" : formatRupiah(String(element.real_qty));
-            let placeholderAttr = untouched
-                ? ` placeholder="${formatRupiah(String(element.live_qty ?? element.system_qty ?? 0))}"`
-                : "";
+            // GitHub #115: draft tidak membawa live_qty/system_qty sama sekali (backend sengaja
+            // tidak mengambilnya) -- tidak ada placeholder untuk ditampilkan.
+            let systemHint = element.live_qty ?? element.system_qty;
+            let placeholderAttr =
+                untouched && systemHint !== null && systemHint !== undefined
+                    ? ` placeholder="${formatRupiah(String(systemHint))}"`
+                    : "";
             rl_stock += `
                 <input type="text"
                     class="form-control real-stock nominal_only text-end"

--- a/public/Custom_js/Backoffice/Inventory/CreateStockOpnameSupplies.js
+++ b/public/Custom_js/Backoffice/Inventory/CreateStockOpnameSupplies.js
@@ -170,15 +170,19 @@ function refreshStockOpname(callback) {
                     // on an EXISTING document being re-edited (mode 2, e.g. a draft reload) -- a
                     // brand-new create form (mode 1) stays fully blank, per the user's explicit
                     // request.
+                    // GitHub #115: draft murni cuma boleh menampilkan apa yang sudah diinput
+                    // sendiri -- stok sistem TIDAK ditampilkan sama sekali selama masih draft.
                     let createPlaceholder =
-                        mode == 2 ? ` placeholder="${element.ss_stock}"` : "";
+                        mode == 2 && !data.is_draft
+                            ? ` placeholder="${element.ss_stock}"`
+                            : "";
                     rl_stock += `
                         <input type="text"
                             class="form-control real-stock nominal_only text-end"
                             value=""${createPlaceholder}
                             data-unit-id="${element.unit_id}"
                             data-unit-name="${element.unit_short_name}"
-                            data-system-qty="${element.ss_stock}">
+                            data-system-qty="${data.is_draft ? "" : element.ss_stock}">
                         <span class="input-group-text">${escapeHtml(element.unit_short_name)}</span>
                     `;
                 });
@@ -304,9 +308,13 @@ function renderMode2(items) {
             // CreateStockOpname.js untuk penjelasan lengkap.
             let untouched = element.real_qty === null || element.real_qty === undefined;
             let prefill = untouched ? "" : formatRupiah(String(element.real_qty));
-            let placeholderAttr = untouched
-                ? ` placeholder="${formatRupiah(String(element.live_qty))}"`
-                : "";
+            // GitHub #115: draft tidak membawa stok sistem/live sama sekali (backend sengaja
+            // tidak mengambilnya, jadi stobd_system/item.stock keduanya kosong di sini) --
+            // tidak ada placeholder untuk ditampilkan.
+            let placeholderAttr =
+                untouched && !data.is_draft
+                    ? ` placeholder="${formatRupiah(String(element.live_qty))}"`
+                    : "";
             rl_stock += `
                 <input type="text"
                     class="form-control real-stock nominal_only text-end"

--- a/tests/Workflow/StockOpnameDraftPrivacyTest.php
+++ b/tests/Workflow/StockOpnameDraftPrivacyTest.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace Tests\Workflow;
+
+use App\Models\ProductStock;
+use App\Models\StockOpname;
+use Illuminate\Support\Facades\DB;
+use Tests\Support\ActingAsStaff;
+use Tests\TestCase;
+
+/**
+ * GitHub #115: a draft must (1) never leak system stock — only what the staff has typed
+ * themselves — and (2) stay invisible/uneditable to every staff except its own creator (or a
+ * super admin), including a direct-by-URL open of its detail page (the listing's own filter,
+ * StockOpname::getStockOpname(), is intentionally skipped for a by-id lookup — see its own
+ * comment — so the guard has to live in the controller instead).
+ */
+class StockOpnameDraftPrivacyTest extends TestCase
+{
+    use ActingAsStaff;
+
+    private function pickFixtureStock(): ProductStock
+    {
+        return ProductStock::withoutGlobalScope('active_warehouse')
+            ->where('status', 1)
+            ->where('warehouse_id', 1) // Gudang Pusat (main), seeded 2026-08-01
+            ->where('ps_stock', '>', 10)
+            ->firstOrFail();
+    }
+
+    private function categoryId(): int
+    {
+        return (int) DB::table('categories')->where('status', 1)->value('category_id');
+    }
+
+    private function insertDraft(ProductStock $stock, int $realQty): int
+    {
+        $response = $this->post('/insertStockOpname', [
+            'sto_date' => now()->toDateString(),
+            'staff_id' => session('user')->staff_id,
+            'category_id' => $this->categoryId(),
+            'sto_notes' => 'Draft privacy test',
+            'is_draft' => 1,
+            'item' => json_encode([[
+                'product_id' => $stock->product_id,
+                'product_variant_id' => $stock->product_variant_id,
+                'units' => [[
+                    'unit_id' => $stock->unit_id,
+                    'system_qty' => $stock->ps_stock,
+                    'real_qty' => $realQty,
+                ]],
+                'stod_system' => $stock->ps_stock.' pcs',
+                'stod_real' => $realQty.' pcs',
+                'stod_selisih' => ($realQty - $stock->ps_stock).' pcs',
+                'stod_notes' => null,
+            ]]),
+        ]);
+        $response->assertStatus(200);
+        $response->assertJson(['status' => 1]);
+
+        return (int) $response->json('sto_id');
+    }
+
+    public function test_draft_detail_page_never_exposes_system_stock(): void
+    {
+        $owner = $this->actingAsStaffWithOnlyPermission('Stok Opname Produk', ['view', 'create', 'edit']);
+
+        $stock = $this->pickFixtureStock();
+        $realQty = $stock->ps_stock - 3; // deliberately different from system, so a leak is obvious
+        $stoId = $this->insertDraft($stock, $realQty);
+
+        $sto = StockOpname::find($stoId);
+        $this->assertTrue((bool) $sto->is_draft);
+
+        $page = $this->get('/detailStockOpname/'.$stoId);
+        $page->assertStatus(200);
+
+        // Pull the `var data = {...};` payload the blade hands the page's JS (CreateStockOpname.js
+        // reads item[].units[].system_qty/live_qty straight from this) instead of eyeballing raw
+        // HTML text, which can coincidentally contain the same digits for unrelated reasons (ids,
+        // dates, csrf tokens, ...).
+        preg_match('/var data = (\{.*?\});\s*\n\s*var mode/s', $page->getContent(), $m);
+        $this->assertNotEmpty($m, 'could not find the data payload in the rendered page');
+        $payload = json_decode($m[1], true);
+
+        $this->assertTrue($payload['is_draft']);
+        $unit = $payload['item'][0]['units'][0];
+        $this->assertSame($realQty, $unit['real_qty'], 'the value the staff actually typed must still show');
+        $this->assertNull($unit['system_qty'], 'a draft must never carry a system stock value at all');
+        $this->assertNull($unit['live_qty'], 'a draft must never carry a live stock value either');
+
+        $owner_id = $owner->staff_id;
+        $this->assertSame($owner_id, $sto->created_by);
+    }
+
+    public function test_other_staff_cannot_open_another_staffs_draft_by_url(): void
+    {
+        $this->actingAsStaffWithOnlyPermission('Stok Opname Produk', ['view', 'create', 'edit'], ['staff_id' => 555001]);
+        $stock = $this->pickFixtureStock();
+        $stoId = $this->insertDraft($stock, $stock->ps_stock - 1);
+
+        // A different staff, same module access, but not the creator.
+        $this->actingAsStaffWithOnlyPermission('Stok Opname Produk', ['view', 'create', 'edit'], ['staff_id' => 555002]);
+
+        $this->get('/detailStockOpname/'.$stoId)->assertStatus(404);
+        $this->get('/generateStockOpname/'.$stoId)->assertStatus(404);
+
+        $this->post('/updateStockOpname', [
+            'sto_id' => $stoId,
+            'item' => json_encode([]),
+        ])->assertJson(['status' => -1]);
+
+        $this->post('/submitStockOpname', ['sto_id' => $stoId])
+            ->assertJson(['status' => -1]);
+    }
+
+    public function test_owner_can_still_open_their_own_draft_by_url(): void
+    {
+        $this->actingAsStaffWithOnlyPermission('Stok Opname Produk', ['view', 'create', 'edit'], ['staff_id' => 555003]);
+        $stock = $this->pickFixtureStock();
+        $stoId = $this->insertDraft($stock, $stock->ps_stock - 1);
+
+        $this->get('/detailStockOpname/'.$stoId)->assertStatus(200);
+    }
+
+    public function test_super_admin_can_open_any_staffs_draft(): void
+    {
+        $this->actingAsStaffWithOnlyPermission('Stok Opname Produk', ['view', 'create', 'edit'], ['staff_id' => 555004]);
+        $stock = $this->pickFixtureStock();
+        $stoId = $this->insertDraft($stock, $stock->ps_stock - 1);
+
+        $this->actingAsSuperAdminStaff();
+        $this->get('/detailStockOpname/'.$stoId)->assertStatus(200);
+    }
+}


### PR DESCRIPTION
## Closes #115

### Masalah
1. **Draft menampilkan stok sistem.** Halaman edit/detail draft (Produk & Bahan) selalu ikut mengambil stok sistem/live sebagai placeholder (dan, untuk dokumen "menunggu", sebagai kolom sistem) — padahal draft seharusnya murni menampilkan apa yang sudah diinput staf sendiri.
2. **Draft bisa dibuka staff lain lewat URL langsung.** `getStockOpname()` (listing) sengaja tidak memfilter lookup by-id (supaya buka-lewat-menu tetap terfilter tapi buka-URL-sendiri tidak 404), tapi `DetailStockOpname()`/`DetailStockOpnameBahan()` tidak pernah menambahkan guard kepemilikan draft yang harusnya menggantikannya — beda dari insert/update/delete/submit/PDF yang semua sudah dijaga `canManageStockOpnameDraft()`.

### Perbaikan
- `OpnameLineReader`/`BahanOpnameLineReader::readCurrent()`: saat `is_draft`, stok live tidak diambil sama sekali dan `system`/`selisih` selalu `null` — bukan lagi dibaca live seperti dokumen "menunggu". `text()` dirapikan supaya mencetak `-` (bukan angka `null`) untuk kasus ini.
- `BahanOpnameLineReader::legacyItems()`: `stock` (placeholder live stock yang dikirim ke JS) juga tidak diambil untuk draft.
- `StockController::DetailStockOpname()` / `DetailStockOpnameBahan()`: tambah guard draft-hanya-pembuat (404 untuk staff lain), sama seperti jalur lain.
- `CreateStockOpname.js` / `CreateStockOpnameSupplies.js`: sembunyikan placeholder & `data-system-qty` stok sistem selama draft, di kedua alur render (reload katalog penuh & `renderMode2` view-only).

### Testing
- Tes baru `tests/Workflow/StockOpnameDraftPrivacyTest.php`: payload draft tidak pernah bawa `system_qty`/`live_qty`, staff lain dapat 404 saat buka detail/PDF/update/submit draft orang lain, pemilik & super admin tetap bisa.
- `php artisan test --filter=StockOpname`: 127 passed, 3 pre-existing failures di `StockOpnameV2EndToEndTest` (dikonfirmasi sudah gagal sebelum perubahan ini lewat `git stash`, tidak terkait).

🤖 Generated with [Claude Code](https://claude.com/claude-code)