### PR TITLE
fix(stock-opname): gudang eceran tidak digulung & draft bahan tidak kehilangan input

### DIFF
--- a/app/Support/StockOpname/BahanOpnameLifecycle.php
+++ b/app/Support/StockOpname/BahanOpnameLifecycle.php
@@ -7,6 +7,7 @@ use App\Models\StockOpnameBahanLine;
 use App\Models\Supplies;
 use App\Models\SuppliesStock;
 use App\Models\Unit;
+use App\Models\Warehouse;
 use App\Support\UnitRollUp;
 
 /**
@@ -100,6 +101,12 @@ class BahanOpnameLifecycle
         // Gudang DOKUMEN -- lihat OpnameLifecycle::rollUpUnits().
         $warehouseId = $stob->warehouse_id ?: null;
 
+        // Keputusan user 2026-09-02: kembaran persis OpnameLifecycle::rollUpUnits() -- gudang
+        // eceran tidak digulung sama sekali.
+        if (self::isRetailWarehouse($warehouseId)) {
+            return;
+        }
+
         foreach ($lines as $suppliesId => $group) {
             if (! $suppliesId) {
                 continue;
@@ -134,5 +141,19 @@ class BahanOpnameLifecycle
         $stob->stob_acc_name = $accBy ? optional(Staff::find($accBy))->staff_name : null;
         $stob->stob_decided_at = now();
         $stob->save();
+    }
+
+    /** Kembaran persis OpnameLifecycle::isRetailWarehouse(). */
+    private static function isRetailWarehouse(?int $warehouseId): bool
+    {
+        if (! $warehouseId) {
+            return false;
+        }
+
+        $warehouse = Warehouse::query()
+            ->with(['type' => fn ($q) => $q->select('id', 'is_main_warehouse')])
+            ->find($warehouseId);
+
+        return (bool) ($warehouse && $warehouse->type && (int) $warehouse->type->is_main_warehouse !== 1);
     }
 }

--- a/app/Support/StockOpname/BahanOpnameLineReader.php
+++ b/app/Support/StockOpname/BahanOpnameLineReader.php
@@ -53,9 +53,21 @@ class BahanOpnameLineReader
         // Dipin ke gudang dokumen ini, bukan gudang aktif sesi pembaca -- lihat liveStockMap().
         $live = $isDraft ? collect() : $this->liveStockMap($lines, $stob->warehouse_id ?: null);
 
+        // Bug dilaporkan user (2026-09-02): draft TIDAK PERNAH lewat publish() (lihat
+        // BahanOpnameLifecycle::publish()'s own guard), jadi sobl_unit_short_name masih NULL --
+        // dulu jatuh ke fallback "unit#12" di bawah. legacyItems() mencetak fallback itu ke dalam
+        // stobd_real/stobd_system, lalu CreateStockOpnameSupplies.js MEM-PARSE ULANG string itu
+        // (seedSavedValuesFromItems()/renderMode2()) dan mencocokkan nama satuan ke katalog asli
+        // ("pcs", bukan "unit#12") -- cocoknya gagal, jadi nilai yang barusan diinput staf tidak
+        // pernah muncul lagi saat draft dibuka ulang. Pakai nama satuan KATALOG (live, sama seperti
+        // yang dipakai legacyItems() membangun daftar 'units') sebagai fallback SEBELUM literal
+        // "unit#N" -- itu cadangan terakhir kalau unit-nya sendiri sudah terhapus dari database.
+        $unitNames = Unit::whereIn('unit_id', $lines->pluck('unit_id')->filter()->unique()->all())
+            ->pluck('unit_short_name', 'unit_id');
+
         return $lines
             ->groupBy('supplies_id')
-            ->map(function ($group) use ($pending, $live, $isDraft) {
+            ->map(function ($group) use ($pending, $live, $isDraft, $unitNames) {
                 $first = $group->first();
                 $units = [];
 
@@ -69,7 +81,7 @@ class BahanOpnameLineReader
                     }
 
                     $units[] = [
-                        'unit' => $line->sobl_unit_short_name ?? ('unit#'.$line->unit_id),
+                        'unit' => $line->sobl_unit_short_name ?? $unitNames->get($line->unit_id) ?? ('unit#'.$line->unit_id),
                         'unit_id' => $line->unit_id,
                         'system' => $system,
                         'live' => $liveQty,

--- a/app/Support/StockOpname/OpnameLifecycle.php
+++ b/app/Support/StockOpname/OpnameLifecycle.php
@@ -8,6 +8,7 @@ use App\Models\ProductVariant;
 use App\Models\Staff;
 use App\Models\StockOpnameLine;
 use App\Models\Unit;
+use App\Models\Warehouse;
 use App\Support\UnitRollUp;
 
 /**
@@ -148,6 +149,16 @@ class OpnameLifecycle
         // UnitRollUp::collapseProduct() untuk alasannya.
         $warehouseId = $sto->warehouse_id ?: null;
 
+        // Keputusan user 2026-09-02: skema multi-gudang membatasi gudang ECERAN untuk cuma
+        // menghitung/menyimpan retail_unit varian itu sendiri (lihat ProductVariant::
+        // getProductVariant() dan StockOpnameRetailWarehouseUnitVisibilityTest) -- menggulung ke
+        // satuan atas di sana bertabrakan langsung dengan aturan itu, karena satuan atas memang
+        // SENGAJA tidak pernah ada/tersimpan di gudang eceran. Gudang utama tetap digulung seperti
+        // biasa (catatan lama tetap berlaku di sana).
+        if (self::isRetailWarehouse($warehouseId)) {
+            return;
+        }
+
         foreach ($lines as $productVariantId => $group) {
             if (! $productVariantId) {
                 continue;
@@ -184,5 +195,24 @@ class OpnameLifecycle
         $sto->sto_acc_name = $accBy ? optional(Staff::find($accBy))->staff_name : null;
         $sto->sto_decided_at = now();
         $sto->save();
+    }
+
+    /**
+     * true = $warehouseId ada dan tipenya BUKAN gudang utama (is_main_warehouse != 1), jadi
+     * eceran. Tidak ada gudang (null/0) atau tipe yang tidak ketemu dianggap BUKAN eceran --
+     * gulung tetap jalan seperti sebelum multi-gudang ada, sama seperti pola inline yang sama di
+     * ProductVariant::getProductVariant().
+     */
+    private static function isRetailWarehouse(?int $warehouseId): bool
+    {
+        if (! $warehouseId) {
+            return false;
+        }
+
+        $warehouse = Warehouse::query()
+            ->with(['type' => fn ($q) => $q->select('id', 'is_main_warehouse')])
+            ->find($warehouseId);
+
+        return (bool) ($warehouse && $warehouse->type && (int) $warehouse->type->is_main_warehouse !== 1);
     }
 }

--- a/app/Support/StockOpname/OpnameLineReader.php
+++ b/app/Support/StockOpname/OpnameLineReader.php
@@ -5,6 +5,7 @@ namespace App\Support\StockOpname;
 use App\Models\ProductStock;
 use App\Models\StockOpnameDetail;
 use App\Models\StockOpnameLine;
+use App\Models\Unit;
 
 /**
  * Satu-satunya pintu baca dokumen Stock Opname untuk TAMPILAN (PDF, halaman detail, daftar).
@@ -111,9 +112,18 @@ class OpnameLineReader
         // liveStockMap().
         $live = $isDraft ? collect() : $this->liveStockMap($lines, $sto->warehouse_id ?: null);
 
+        // Bug dilaporkan user (2026-09-02, ditemukan lewat kembarannya di Bahan): draft TIDAK
+        // PERNAH lewat publish() (lihat OpnameLifecycle::publish()'s own guard), jadi
+        // sol_unit_short_name masih NULL -- dulu jatuh ke fallback "unit#12" di bawah, yang lantas
+        // ikut tercetak sebagai label satuan di halaman edit (CreateStockOpname.js renderMode2())
+        // dan di PDF. Pakai nama satuan KATALOG (live) sebagai fallback SEBELUM literal "unit#N" --
+        // itu cadangan terakhir kalau unit-nya sendiri sudah terhapus dari database.
+        $unitNames = Unit::whereIn('unit_id', $lines->pluck('unit_id')->filter()->unique()->all())
+            ->pluck('unit_short_name', 'unit_id');
+
         return $lines
             ->groupBy('product_variant_id')
-            ->map(function ($group) use ($pending, $live, $isDraft) {
+            ->map(function ($group) use ($pending, $live, $isDraft, $unitNames) {
                 $first = $group->first();
                 $units = [];
 
@@ -127,7 +137,7 @@ class OpnameLineReader
                     }
 
                     $units[] = [
-                        'unit' => $line->sol_unit_short_name ?? ('unit#'.$line->unit_id),
+                        'unit' => $line->sol_unit_short_name ?? $unitNames->get($line->unit_id) ?? ('unit#'.$line->unit_id),
                         'unit_id' => $line->unit_id,
                         'system' => $system,
                         'live' => $liveQty,

--- a/tests/Workflow/StockOpnameBahanV2LifecycleTest.php
+++ b/tests/Workflow/StockOpnameBahanV2LifecycleTest.php
@@ -304,6 +304,51 @@ class StockOpnameBahanV2LifecycleTest extends TestCase
         $this->assertSame(10, (int) $lines->first()->sobl_counted_qty);
     }
 
+    /**
+     * Bug dilaporkan user (2026-09-02): draft tidak pernah lewat publish() (lihat
+     * BahanOpnameLifecycle::publish()'s guard), jadi sobl_unit_short_name masih NULL selama masih
+     * draft. legacyItems() DULU jatuh ke fallback literal "unit#12" untuk label satuan yang
+     * dicetak ke stobd_real/stobd_system -- padahal 'units' (katalog) di payload yang SAMA tetap
+     * memuat nama asli ("pcs"). CreateStockOpnameSupplies.js (seedSavedValuesFromItems()) mem-
+     * PARSE ULANG stobd_real lalu mencocokkan namanya ke katalog itu untuk mengisi ulang form saat
+     * draft dibuka lagi -- "unit#12" vs "pcs" tidak pernah cocok, jadi angka yang barusan diinput
+     * staf hilang dari tampilan (walau tetap tersimpan benar di DB). Simulasikan persis logika
+     * JS itu di sini supaya regresi ini tertangkap tanpa perlu test browser.
+     */
+    public function test_draft_legacy_items_unit_label_matches_the_catalog_name_it_will_be_matched_against(): void
+    {
+        [$supplies, $dos, $pcs, $dosUnit, $pcsUnit] = $this->makeFixture();
+        $stob = $this->makeDocument(isDraft: true);
+        $this->addLines($stob, $supplies, [$dos->unit_id => 8, $pcs->unit_id => null]);
+
+        $items = (new BahanOpnameLineReader())->legacyItems($stob);
+        $this->assertCount(1, $items);
+        $item = $items[0];
+
+        // Baris di stobd_real cuma boleh mencetak nama satuan katalog asli -- tidak pernah lagi
+        // fallback "unit#N" selama unit-nya sendiri masih ada di database.
+        $this->assertStringContainsString('8 '.$dosUnit->unit_short_name, $item['stobd_real']);
+        $this->assertStringNotContainsString('unit#', $item['stobd_real']);
+
+        // Simulasi persis seedSavedValuesFromItems() (CreateStockOpnameSupplies.js): urai
+        // stobd_real jadi peta nama->qty, lalu cocokkan tiap unit katalog ke peta itu.
+        $realMap = [];
+        foreach (explode(', ', $item['stobd_real']) as $part) {
+            [$qty, $name] = array_pad(explode(' ', trim($part), 2), 2, '');
+            $realMap[$name] = $qty;
+        }
+
+        $restored = [];
+        foreach ($item['units'] as $u) {
+            if (array_key_exists($u['unit_short_name'], $realMap) && $realMap[$u['unit_short_name']] !== '-') {
+                $restored[$u['unit_id']] = (int) $realMap[$u['unit_short_name']];
+            }
+        }
+
+        $this->assertSame(8, $restored[$dosUnit->unit_id] ?? null, 'nilai yang sudah diinput harus berhasil dipulihkan ke form saat draft dibuka lagi');
+        $this->assertArrayNotHasKey($pcsUnit->unit_id, $restored, 'satuan yang belum diisi tidak boleh ikut "dipulihkan"');
+    }
+
     // ---------------------------------------------------------------- laporan
 
     public function test_selisih_report_includes_new_version_bahan_documents(): void

--- a/tests/Workflow/StockOpnameBahanV2LifecycleTest.php
+++ b/tests/Workflow/StockOpnameBahanV2LifecycleTest.php
@@ -12,6 +12,7 @@ use App\Support\StockOpname\BahanOpnameLifecycle;
 use App\Support\StockOpname\BahanOpnameLineReader;
 use Illuminate\Support\Facades\DB;
 use Tests\Support\ActingAsStaff;
+use Tests\Support\ResolvesTestWarehouses;
 use Tests\TestCase;
 
 /**
@@ -28,6 +29,7 @@ use Tests\TestCase;
 class StockOpnameBahanV2LifecycleTest extends TestCase
 {
     use ActingAsStaff;
+    use ResolvesTestWarehouses;
 
     private function staffId(): int
     {
@@ -35,7 +37,7 @@ class StockOpnameBahanV2LifecycleTest extends TestCase
     }
 
     /** @return array{0: Supplies, 1: SuppliesStock, 2: SuppliesStock, 3: Unit, 4: Unit} */
-    private function makeFixture(int $dosStock = 12, int $pcsStock = 42): array
+    private function makeFixture(int $dosStock = 12, int $pcsStock = 42, int $warehouseId = 1): array
     {
         $units = Unit::where('status', 1)->limit(2)->get();
         $this->assertGreaterThanOrEqual(2, $units->count(), 'fixture butuh minimal 2 satuan aktif');
@@ -53,7 +55,7 @@ class StockOpnameBahanV2LifecycleTest extends TestCase
             $s = new SuppliesStock();
             $s->supplies_id = $supplies->supplies_id;
             $s->unit_id = $unit->unit_id;
-            $s->warehouse_id = 1;
+            $s->warehouse_id = $warehouseId;
             $s->ss_stock = $qty;
             $s->status = 1;
             $s->save();
@@ -326,9 +328,9 @@ class StockOpnameBahanV2LifecycleTest extends TestCase
     // ---------------------------------------------------------------- gulung satuan (rollUpUnits)
 
     /** Kembaran persis makeFixtureWithLadder() (Produk) -- lihat StockOpnameV2LifecycleTest. */
-    private function makeFixtureWithLadder(int $dosStock = 12, int $pcsStock = 42, int $ratio = 12): array
+    private function makeFixtureWithLadder(int $dosStock = 12, int $pcsStock = 42, int $ratio = 12, int $warehouseId = 1): array
     {
-        [$supplies, $dos, $pcs, $dosUnit, $pcsUnit] = $this->makeFixture($dosStock, $pcsStock);
+        [$supplies, $dos, $pcs, $dosUnit, $pcsUnit] = $this->makeFixture($dosStock, $pcsStock, $warehouseId);
 
         $relation = new SuppliesRelation();
         $relation->supplies_id = $supplies->supplies_id;
@@ -445,5 +447,38 @@ class StockOpnameBahanV2LifecycleTest extends TestCase
 
         (new BahanOpnameLifecycle())->rollUpUnits($stob);
         $this->assertSame(0, StockOpnameBahanLine::where('stob_id', $stob->stob_id)->count());
+    }
+
+    /** Kembaran persis Produk -- lihat StockOpnameV2LifecycleTest untuk alasan lengkap. */
+    public function test_roll_up_skips_a_retail_warehouse_document_entirely(): void
+    {
+        $retailWarehouseId = $this->resolveActiveRetailWarehouseId();
+
+        [$supplies, $dos, $pcs] = $this->makeFixtureWithLadder(dosStock: 0, pcsStock: 42, ratio: 12, warehouseId: $retailWarehouseId);
+        $stob = $this->makeDocument(isDraft: false);
+        $stob->warehouse_id = $retailWarehouseId;
+        $stob->save();
+        $this->addLines($stob, $supplies, [$pcs->unit_id => 30, $dos->unit_id => null]);
+
+        (new BahanOpnameLifecycle())->rollUpUnits($stob);
+
+        $lines = StockOpnameBahanLine::getLines($stob->stob_id)->keyBy('unit_id');
+        $this->assertSame(30, (int) $lines[$pcs->unit_id]->sobl_counted_qty, 'pcs harus tetap apa adanya, tidak digulung');
+        $this->assertNull($lines[$dos->unit_id]->sobl_counted_qty, 'DOS tidak boleh ikut terisi otomatis di gudang eceran');
+    }
+
+    /** Dokumen tanpa gudang sama sekali (warehouse_id null) tetap digulung seperti sebelum multi-gudang ada. */
+    public function test_roll_up_still_applies_when_document_has_no_warehouse_pinned(): void
+    {
+        [$supplies, $dos, $pcs] = $this->makeFixtureWithLadder(dosStock: 0);
+        $stob = $this->makeDocument(isDraft: false);
+        $this->assertNull($stob->warehouse_id);
+        $this->addLines($stob, $supplies, [$pcs->unit_id => 30, $dos->unit_id => null]);
+
+        (new BahanOpnameLifecycle())->rollUpUnits($stob);
+
+        $lines = StockOpnameBahanLine::getLines($stob->stob_id)->keyBy('unit_id');
+        $this->assertSame(2, (int) $lines[$dos->unit_id]->sobl_counted_qty);
+        $this->assertSame(6, (int) $lines[$pcs->unit_id]->sobl_counted_qty);
     }
 }

--- a/tests/Workflow/StockOpnameV2LifecycleTest.php
+++ b/tests/Workflow/StockOpnameV2LifecycleTest.php
@@ -14,6 +14,7 @@ use App\Support\StockOpname\OpnameLifecycle;
 use App\Support\StockOpname\OpnameLineReader;
 use Illuminate\Support\Facades\DB;
 use Tests\Support\ActingAsStaff;
+use Tests\Support\ResolvesTestWarehouses;
 use Tests\TestCase;
 
 /**
@@ -31,6 +32,7 @@ use Tests\TestCase;
 class StockOpnameV2LifecycleTest extends TestCase
 {
     use ActingAsStaff;
+    use ResolvesTestWarehouses;
 
     private function staffId(): int
     {
@@ -38,7 +40,7 @@ class StockOpnameV2LifecycleTest extends TestCase
     }
 
     /** @return array{0: ProductVariant, 1: ProductStock, 2: ProductStock, 3: Unit, 4: Unit} */
-    private function makeFixture(int $dosStock = 12, int $pcsStock = 42): array
+    private function makeFixture(int $dosStock = 12, int $pcsStock = 42, int $warehouseId = 1): array
     {
         $units = Unit::where('status', 1)->limit(2)->get();
         $this->assertGreaterThanOrEqual(2, $units->count(), 'fixture butuh minimal 2 satuan aktif');
@@ -71,7 +73,7 @@ class StockOpnameV2LifecycleTest extends TestCase
             $s->product_id = $product->product_id;
             $s->product_variant_id = $variant->product_variant_id;
             $s->unit_id = $unit->unit_id;
-            $s->warehouse_id = 1;
+            $s->warehouse_id = $warehouseId;
             $s->ps_stock = $qty;
             $s->status = 1;
             $s->save();
@@ -370,9 +372,9 @@ class StockOpnameV2LifecycleTest extends TestCase
     // ---------------------------------------------------------------- gulung satuan (rollUpUnits)
 
     /** @return array{0: ProductVariant, 1: ProductStock, 2: ProductStock, 3: Unit, 4: Unit} */
-    private function makeFixtureWithLadder(int $dosStock = 12, int $pcsStock = 42, int $ratio = 12): array
+    private function makeFixtureWithLadder(int $dosStock = 12, int $pcsStock = 42, int $ratio = 12, int $warehouseId = 1): array
     {
-        [$variant, $dos, $pcs, $dosUnit, $pcsUnit] = $this->makeFixture($dosStock, $pcsStock);
+        [$variant, $dos, $pcs, $dosUnit, $pcsUnit] = $this->makeFixture($dosStock, $pcsStock, $warehouseId);
 
         $relation = new ProductRelation();
         $relation->product_variant_id = $variant->product_variant_id;
@@ -502,6 +504,44 @@ class StockOpnameV2LifecycleTest extends TestCase
 
         (new OpnameLifecycle())->rollUpUnits($sto);
         $this->assertSame(0, StockOpnameLine::where('sto_id', $sto->sto_id)->count());
+    }
+
+    /**
+     * Keputusan user 2026-09-02: skema multi-gudang membatasi gudang eceran untuk cuma
+     * menghitung satuan eceran-nya sendiri (retail_unit) -- menggulung ke satuan atas di sana
+     * bertabrakan langsung dengan aturan itu, jadi gudang eceran TIDAK digulung sama sekali,
+     * beda dari gudang utama yang tetap tergulung seperti biasa (lihat test-test di atas).
+     */
+    public function test_roll_up_skips_a_retail_warehouse_document_entirely(): void
+    {
+        $retailWarehouseId = $this->resolveActiveRetailWarehouseId();
+
+        [$variant, $dos, $pcs] = $this->makeFixtureWithLadder(dosStock: 0, pcsStock: 42, ratio: 12, warehouseId: $retailWarehouseId);
+        $sto = $this->makeDocument(isDraft: false);
+        $sto->warehouse_id = $retailWarehouseId;
+        $sto->save();
+        $this->addLines($sto, $variant, [$pcs->unit_id => 30, $dos->unit_id => null]);
+
+        (new OpnameLifecycle())->rollUpUnits($sto);
+
+        $lines = StockOpnameLine::getLines($sto->sto_id)->keyBy('unit_id');
+        $this->assertSame(30, (int) $lines[$pcs->unit_id]->sol_counted_qty, 'pcs harus tetap apa adanya, tidak digulung');
+        $this->assertNull($lines[$dos->unit_id]->sol_counted_qty, 'DOS tidak boleh ikut terisi otomatis di gudang eceran');
+    }
+
+    /** Dokumen tanpa gudang sama sekali (warehouse_id null) tetap digulung seperti sebelum multi-gudang ada. */
+    public function test_roll_up_still_applies_when_document_has_no_warehouse_pinned(): void
+    {
+        [$variant, $dos, $pcs] = $this->makeFixtureWithLadder(dosStock: 0);
+        $sto = $this->makeDocument(isDraft: false);
+        $this->assertNull($sto->warehouse_id);
+        $this->addLines($sto, $variant, [$pcs->unit_id => 30, $dos->unit_id => null]);
+
+        (new OpnameLifecycle())->rollUpUnits($sto);
+
+        $lines = StockOpnameLine::getLines($sto->sto_id)->keyBy('unit_id');
+        $this->assertSame(2, (int) $lines[$dos->unit_id]->sol_counted_qty);
+        $this->assertSame(6, (int) $lines[$pcs->unit_id]->sol_counted_qty);
     }
 
     // ---------------------------------------------------------------- identitas baris


### PR DESCRIPTION
Susulan PR #118 (sudah merged) — dua perbaikan baru, terpisah dari perubahan yang sudah masuk lewat #118.

## 1. Gudang eceran tidak lagi digulung ke satuan atas

Skema multi-gudang membatasi gudang eceran untuk cuma menghitung/menyimpan `retail_unit` varian itu sendiri, sementara roll-up hasil hitung (`OpnameLifecycle`/`BahanOpnameLifecycle::rollUpUnits()`, keputusan PM 2026-08-27 — isi satuan kecil, satuan besar yang belum disentuh ikut naik otomatis) berasumsi tangga satuan penuh tersedia. Dua aturan itu bertabrakan di gudang eceran.

- `rollUpUnits()` (Produk & Bahan) sekarang keluar lebih dulu kalau dokumen dipin ke gudang eceran (`is_main_warehouse != 1`). Dokumen tanpa gudang (`warehouse_id` null) atau di gudang utama tetap digulung seperti sebelumnya.
- Tes baru di `StockOpnameV2LifecycleTest`/`StockOpnameBahanV2LifecycleTest`.

## 2. Draft Bahan kehilangan nilai yang barusan diinput saat dibuka ulang

**Root cause:** draft tidak pernah lewat `publish()` (guard-nya sendiri sengaja skip draft), jadi `sobl_unit_short_name` masih `NULL` selama masih draft — `BahanOpnameLineReader::readCurrent()` jatuh ke fallback literal `"unit#12"` untuk label satuan yang dicetak ke `stobd_real`. `CreateStockOpnameSupplies.js` (`seedSavedValuesFromItems()`) mem-PARSE ULANG string itu dan mencocokkan namanya ke katalog satuan asli (`"kg"`, bukan `"unit#12"`) untuk mengisi ulang form draft — cocoknya gagal, jadi angka yang barusan diinput staf hilang dari layar (walau tetap tersimpan benar di DB).

Produk tidak kena bug yang sama persis di jalur restore-nya (`CreateStockOpname.js` membaca `real_qty` langsung by `unit_id`), tapi label satuannya sendiri tetap salah cetak `"unit#12"` di layar/PDF untuk draft — diperbaiki juga untuk konsistensi.

**Perbaikan:** kedua reader sekarang pakai nama satuan katalog (live, dari tabel `units`) sebagai fallback SEBELUM literal `"unit#N"` — itu jadi cadangan terakhir untuk unit yang sudah benar-benar terhapus dari database.

**Tes baru:** `StockOpnameBahanV2LifecycleTest::test_draft_legacy_items_unit_label_matches_the_catalog_name_it_will_be_matched_against` mensimulasikan persis logika parse JS-nya — dikonfirmasi gagal tanpa perbaikan ini (mencetak `"unit#1, unit#2"`) dan lolos dengan perbaikan.

### Testing
`php artisan test --filter=StockOpname`: 132 passed, 3 kegagalan pra-ada di `StockOpnameV2EndToEndTest` (tidak terkait perubahan ini, sudah dikonfirmasi lewat `git stash` sebelumnya).

🤖 Generated with [Claude Code](https://claude.com/claude-code)