### PR TITLE
feat(ui): color ACC/Tolak/Edit/Delete table action buttons (#117)

### DIFF
--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -338,7 +338,7 @@ class ProductController extends Controller
         $html = '';
 
         if ($canEdit) {
-            $html .= '<a class="me-2 btn-action-icon p-2" href="/updateProduct/' . $productId . '">'
+            $html .= '<a class="me-2 btn-action-icon p-2 btn_edit" href="/updateProduct/' . $productId . '">'
                 . '<i class="fe fe-edit"></i></a>';
         }
 

--- a/docs/UNUSED_CODE_RECORD.md
+++ b/docs/UNUSED_CODE_RECORD.md
@@ -76,6 +76,20 @@ Not referenced by any `@section('custom_js')` include — literal leftover "copy
 - `public/Custom_js/Backoffice/Inventory/Stock_Product copy.js`
 - `public/Custom_js/Backoffice/Inventory/CreateStockOpname cop.js`
 
+**Different flavor — pre-unification per-type Pengembalian pages** (found 2026-09-02 while working GitHub #117):
+
+- `public/Custom_js/Backoffice/Customers/Customer_Product_Return.js` (calls `/customerProductReturns`)
+- `public/Custom_js/Backoffice/Customers/Customer_Supply_Return.js` (calls `/customerSupplyReturns`)
+
+Neither is `<script src>`'d from any Blade view — confirmed via repo-wide grep, zero hits. Unlike the
+"copy" files above, their **backend is still alive**: `CustomerProductReturnController` /
+`CustomerSupplyReturnController` and their routes ([routes/web.php:342-347](../routes/web.php#L342-L347),
+plus the matching store/update/destroy/accept/decline routes) are registered and would work if hit
+directly. Git blame (`4721ce88`, "feat: unified pengembalian, ...") shows why: Produk/Produk-varian/Bahan
+returns were merged into one shared table — `Customer_Return.js` / `#tableCustomerReturn` / the
+`/customerReturns` endpoint, which is what actually renders on Pengiriman → Pengembalian today. These
+two files (and arguably their controllers) are the pre-unification implementation left behind.
+
 ---
 
 ## 5. Dead functions

--- a/docs/table-action-button-color-rollout.md
+++ b/docs/table-action-button-color-rollout.md
@@ -1,0 +1,103 @@
+# Table ACC/Tolak action buttons — color rollout tracker (GitHub #117)
+
+**Issue:** [#117 — [Enhancement] [Fase 2] UI enhancement for action buttons](https://github.com/denny011299/pegasus/issues/117)
+**Ask (Bahasa Indonesia):** "Tombol acc dan tolak diberi warna dan bold agar bisa terlihat (Semua menu
+yang berhubungan dengan acc dan tolak di table)" — every ACC/Tolak (approve/reject) action button that
+lives **in a DataTable row** (not inside a modal footer) should be colored + bold so it's visually
+distinct from the plain edit/view/delete icons next to it.
+
+**Scope grew during rollout**: once approve/reject were fixed on a row, the neighboring view/edit/delete
+icons on that same row were still using the same defeated inline-`style=` pattern (only their color
+was forced, background stayed white per the base rule) — so per-row requests came in to fix those too.
+`.btn-action-view`/`.btn-action-edit`/`.btn-action-delete` were added alongside approve/reject for this
+(see Root cause). Applied so far only to `Customer_Return.js` (Pengiriman → Pengembalian tab); other
+tables' view/edit/delete icons haven't been swept yet — do it opportunistically per-row like the rest
+of this tracker, not as a blanket pass.
+
+## ⚠️ Root cause (found while fixing row #6, Tanda Terima PO)
+
+`resources/views/layout/partials/header.blade.php` (loaded on every Backoffice page) has a global rule:
+
+```css
+.btn-action-icon {
+    background: #ffffff !important;
+    color: #64748b !important;
+    ...
+}
+```
+
+`!important` on an external stylesheet beats **any** inline `style="..."` and any Bootstrap utility
+class (`bg-success`, `text-light`, etc.) with equal/lower specificity. This means **every row below
+marked "Already colored" before this was discovered is actually not visibly colored** — they were
+never actually verified in a browser, only by reading the JS source. Confirmed via DevTools Computed
+panel on row #6 (Tanda Terima PO): `background-color` computed to `rgb(255,255,255)` even though
+`element.style` had `background:#059669`.
+
+**The fix**: two new global classes added next to the existing `.text-success`/`.text-danger`/
+`.text-warning` convention in `header.blade.php`, each with its own `!important` (so it actually wins).
+Final style is a soft tint + border, matching the same visual language as the delete icon's `:hover`
+state (`#fef2f2`/`#fecaca`/`#dc2626`) but kept on permanently since approve/reject need to read as
+colored at a glance:
+
+```css
+.btn-action-icon.btn-action-approve { background:#ecfdf5 !important; border:1px solid #a7f3d0 !important; color:#059669 !important; font-weight:700 !important; }
+.btn-action-icon.btn-action-reject  { background:#fef2f2 !important; border:1px solid #fecaca !important; color:#dc2626 !important; font-weight:700 !important; }
+```
+
+(plus matching `:hover` variants, deeper tint). Rows below must add `btn-action-approve` /
+`btn-action-reject` to the anchor's class list — **inline `style=` or Bootstrap `bg-*` utility
+classes will silently do nothing**, don't use them.
+
+## Scope
+
+In scope: the small round icon buttons (`.btn-action-icon`) DataTables render per row for
+approve/reject-style actions on list pages.
+
+Out of scope (not "di table"):
+- Modal footer buttons (e.g. `#btn-terima` / `#btn-tolak` in Produksi's add-production modal,
+  `#btn-acc-po` / `#btn-tolak-po` in Purchase Order Detail, `#btn-acc-sto` in Stock Opname) — these
+  are full-width buttons inside a popup, already visually prominent, not a small row icon.
+- Status **badges** that happen to say "Tolak" (`ReportEfisiensiProduksi.js`, `ReportProduction.js`)
+  — these are read-only state labels, not clickable actions.
+- [[pegasus-pettycash-deprecated]] / [[pegasus-sales-order-delivery-deprecated]] /
+  [[pegasus-po-manual-delivery-deprecated]] / [[pegasus-warehouse-module-wip]] modules.
+
+## Status
+
+| # | Menu / Table | File | Current style | Status |
+|---|---|---|---|---|
+| 1 | Pengiriman (Sales Order list) → Konfirmasi | `Customers/Sales_Order.js` (`btn_confirm`) | was inline `style=` green tint, defeated by the global `!important` | ✅ Done — switched to `.btn-action-approve` |
+| 2 | Retur Pelanggan (Produk/Bahan, unified table) → Konfirmasi | `Customers/Customer_Return.js` (`cr-confirm`) | was inline style, same problem — this is the live implementation for the "Pengembalian" tab on the Sales Order page (`#tableCustomerReturn`, endpoint `/customerReturns`), covers all return types | ✅ Done — switched to `.btn-action-approve` |
+| 3 | ~~Retur Pelanggan (Produk, varian modal)~~ | `Customers/Customer_Product_Return.js` (`cpr-confirm`) | **Likely orphaned/dead code** — not `@include`d or `<script src>`'d from any `.blade.php` found in the whole repo (hits `/customerProductReturns`, superseded by row #2's unified table). Edited anyway (harmless) but needs an unused-code audit before anyone relies on this page being reachable. | ✅ Edited (see caveat) |
+| 4 | ~~Retur Pelanggan (Bahan)~~ | `Customers/Customer_Supply_Return.js` (`csr-confirm`) | Same orphaned-code caveat as row #3 (hits `/customerSupplyReturns`) | ✅ Edited (see caveat) |
+| 5 | ~~Product Issue (Produk Bermasalah) list~~ → Terima / Tolak | `Inventory/Product_Issues.js` (`.btn_acc`/`.btn_decline`) | **Miscategorized in the original pass** — the table row only ever renders a "Lihat" icon; Terima/Tolak are static buttons (`#btn-terima`/`#btn-tolak`) inside `add-product-issues.blade.php`'s modal footer, not a table row icon | ➡️ Moved to "Not in scope" below |
+| 6 | Tanda Terima PO (`tt`) list → Terima / Tolak | `Suppliers/tt.js` (`btn_acc_tt` / `btn_decline_tt`) | root-caused here; found the global `!important` override | ✅ Done — `.btn-action-approve`/`.btn-action-reject` classes (defined in `header.blade.php`), gradient matches `.pg-btn-accept`/`.pg-btn-decline`; also got shimmer loading + PG modal styling for its Konfirmasi Terima popup |
+| 7 | Stock Transfer list → ACC Terkirim | `Inventory/Stock_Transfer.js` (`btnAccept`, ~line 664) | was `text-info` only, then inline style (also defeated) | ✅ Done — switched to `.btn-action-approve` class |
+
+All 5 real table-row targets (rows #1, #2, #6, #7, plus the two orphaned files #3/#4) are now on the
+shared `.btn-action-approve`/`.btn-action-reject` classes with the gradient fill from `header.blade.php`.
+
+### Not in scope (checked, excluded)
+
+| Menu | File | Why excluded |
+|---|---|---|
+| Produksi → Terima/Tolak Produksi | `components/modals/production/add-production.blade.php` + `Production.js` | Modal footer button, not a table row icon |
+| Purchase Order Detail → Terima/Tolak PO | `Suppliers/Purchase_Order_Detail.js` (`#btn-acc-po`, `#btn-tolak-po`) | Modal footer button |
+| Stock Opname / Stock Opname Bahan → Konfirmasi ACC | `Inventory/CreateStockOpname(Supplies).js` (`#btn-acc-sto` / `#btn-acc-stob`) | Modal footer button |
+| Kas Operasional (Admin/Gudang/Armada/Sales) → ACC/Tolak | `Reports/Cash.js`, `Reports/Cash_Operational.js` (`.btn_acc`, `.btn_decline`) | Modal buttons, not row icons |
+| Sales Order Detail → Tolak (delivery/invoice) | `Customers/Sales_Order_detail.js` (`.btn-decline`) | Modal footer button |
+| ReportEfisiensiProduksi / ReportProduction "Tolak" | `Reports/ReportEfisiensiProduksi.js`, `Reports/ReportProduction.js` | Read-only status badge, not an action button |
+| Purchase Order list (Suppliers) | `Suppliers/Purchase_Order.js` | Only has Lihat/Hapus row icons; ACC/Tolak happens in the PO Detail modal instead |
+| Product Issue (Produk Bermasalah) list | `Inventory/Product_Issues.js` + `add-product-issues.blade.php` | Table row only shows Lihat; Terima/Tolak are modal footer buttons (`#btn-terima`/`#btn-tolak`), not row icons |
+
+## How to work a row
+
+1. Add class `btn-action-approve` to the accept button's anchor and `btn-action-reject` to the
+   reject button's anchor (alongside the existing `btn-action-icon` class). Do **not** rely on inline
+   `style=` or Bootstrap `bg-*`/`text-*` utility classes — they lose to `header.blade.php`'s global
+   `.btn-action-icon { ... !important }` rule (see Root cause above).
+2. Bump that page's `<script src="...?v=N">` cache-buster in its blade file so the browser picks up
+   the JS change (several of these still use a hardcoded `?v=1` that's never bumped).
+3. **Actually verify in a browser** (not just by reading the JS) — this bug was invisible from source
+   alone. Hard-refresh, or check DevTools Computed panel if in doubt.
+4. Update this table's Status column + note the PR/commit, then move to the next row.

--- a/public/Custom_js/Backoffice/Customers/Customer_Product_Return.js
+++ b/public/Custom_js/Backoffice/Customers/Customer_Product_Return.js
@@ -120,7 +120,7 @@
         var canDelete = pending && can("delete");
 
         if (canConfirm) {
-            html += '<a class="btn-action-icon cpr-confirm" data-id="' + row.return_id + '" href="javascript:void(0);" style="background:#ecfdf5;border:1px solid #a7f3d0;color:#059669;" data-bs-toggle="tooltip" title="Konfirmasi"><i class="fe fe-check-circle" style="font-size:14px;"></i></a>';
+            html += '<a class="btn-action-icon cpr-confirm btn-action-approve" data-id="' + row.return_id + '" href="javascript:void(0);" data-bs-toggle="tooltip" title="Konfirmasi"><i class="fe fe-check-circle" style="font-size:14px;"></i></a>';
         } else if (canView) {
             html += '<a class="btn-action-icon cpr-view" data-id="' + row.return_id + '" href="javascript:void(0);" style="background:#eff6ff;border:1px solid #bfdbfe;color:#2563eb;" data-bs-toggle="tooltip" title="Lihat"><i class="fe fe-eye" style="font-size:14px;"></i></a>';
         }

--- a/public/Custom_js/Backoffice/Customers/Customer_Return.js
+++ b/public/Custom_js/Backoffice/Customers/Customer_Return.js
@@ -139,18 +139,18 @@
         var key = esc(row.doc_key);
 
         if (canConfirm) {
-            html += '<a class="btn-action-icon cr-confirm" data-key="' + key + '" href="javascript:void(0);" style="background:#ecfdf5;border:1px solid #a7f3d0;color:#059669;" data-bs-toggle="tooltip" title="Konfirmasi"><i class="fe fe-check-circle" style="font-size:14px;"></i></a>';
+            html += '<a class="btn-action-icon cr-confirm btn-action-approve" data-key="' + key + '" href="javascript:void(0);" data-bs-toggle="tooltip" title="Konfirmasi"><i class="fe fe-check-circle" style="font-size:14px;"></i></a>';
         } else if (canView) {
-            html += '<a class="btn-action-icon cr-view" data-key="' + key + '" href="javascript:void(0);" style="background:#eff6ff;border:1px solid #bfdbfe;color:#2563eb;" data-bs-toggle="tooltip" title="Lihat"><i class="fe fe-eye" style="font-size:14px;"></i></a>';
+            html += '<a class="btn-action-icon cr-view btn-action-view" data-key="' + key + '" href="javascript:void(0);" data-bs-toggle="tooltip" title="Lihat"><i class="fe fe-eye" style="font-size:14px;"></i></a>';
         }
         if (status === 2) {
             html += '<a class="btn-action-icon cr-print" data-key="' + key + '" href="javascript:void(0);" style="background:#f8fafc;border:1px solid #cbd5e1;color:#334155;" data-bs-toggle="tooltip" title="Print"><i class="fe fe-printer" style="font-size:14px;"></i></a>';
         }
         if (canEdit) {
-            html += '<a class="btn-action-icon cr-edit" data-key="' + key + '" href="javascript:void(0);" style="background:#fffbeb;border:1px solid #fde68a;color:#d97706;" data-bs-toggle="tooltip" title="Edit"><i class="fe fe-edit-2" style="font-size:14px;"></i></a>';
+            html += '<a class="btn-action-icon cr-edit btn-action-edit" data-key="' + key + '" href="javascript:void(0);" data-bs-toggle="tooltip" title="Edit"><i class="fe fe-edit-2" style="font-size:14px;"></i></a>';
         }
         if (canDelete) {
-            html += '<a class="btn-action-icon cr-delete" data-key="' + key + '" href="javascript:void(0);" style="background:#fef2f2;border:1px solid #fecaca;color:#dc2626;" data-bs-toggle="tooltip" title="Hapus"><i class="fe fe-trash-2" style="font-size:14px;"></i></a>';
+            html += '<a class="btn-action-icon cr-delete btn-action-delete" data-key="' + key + '" href="javascript:void(0);" data-bs-toggle="tooltip" title="Hapus"><i class="fe fe-trash-2" style="font-size:14px;"></i></a>';
         }
         html += "</div>";
         if (!canConfirm && !canView && !canEdit && !canDelete) {

--- a/public/Custom_js/Backoffice/Customers/Customer_Supply_Return.js
+++ b/public/Custom_js/Backoffice/Customers/Customer_Supply_Return.js
@@ -120,7 +120,7 @@
         var canDelete = pending && can("delete");
 
         if (canConfirm) {
-            html += '<a class="btn-action-icon csr-confirm" data-id="' + row.return_id + '" href="javascript:void(0);" style="background:#ecfdf5;border:1px solid #a7f3d0;color:#059669;" data-bs-toggle="tooltip" title="Konfirmasi"><i class="fe fe-check-circle" style="font-size:14px;"></i></a>';
+            html += '<a class="btn-action-icon csr-confirm btn-action-approve" data-id="' + row.return_id + '" href="javascript:void(0);" data-bs-toggle="tooltip" title="Konfirmasi"><i class="fe fe-check-circle" style="font-size:14px;"></i></a>';
         } else if (canView) {
             html += '<a class="btn-action-icon csr-view" data-id="' + row.return_id + '" href="javascript:void(0);" style="background:#eff6ff;border:1px solid #bfdbfe;color:#2563eb;" data-bs-toggle="tooltip" title="Lihat"><i class="fe fe-eye" style="font-size:14px;"></i></a>';
         }

--- a/public/Custom_js/Backoffice/Customers/Sales_Order.js
+++ b/public/Custom_js/Backoffice/Customers/Sales_Order.js
@@ -1306,9 +1306,9 @@ function renderSoAction(row) {
     var canDelete = pending && soHasAccess("Pengiriman", "delete");
     if (canConfirm) {
         soa +=
-            '<a class="btn-action-icon btn_confirm" data-id="' +
+            '<a class="btn-action-icon btn_confirm btn-action-approve" data-id="' +
             row.so_id +
-            '" href="javascript:void(0);" style="background:#ecfdf5;border:1px solid #a7f3d0;color:#059669;" data-bs-toggle="tooltip" title="Konfirmasi"><i class="fe fe-check-circle" style="font-size:14px;"></i></a>';
+            '" href="javascript:void(0);" data-bs-toggle="tooltip" title="Konfirmasi"><i class="fe fe-check-circle" style="font-size:14px;"></i></a>';
     } else if (canView) {
         soa +=
             '<a class="btn-action-icon btn_view" data-id="' +

--- a/public/Custom_js/Backoffice/Inventory/Stock_Transfer.js
+++ b/public/Custom_js/Backoffice/Inventory/Stock_Transfer.js
@@ -661,7 +661,7 @@ function inisialisasi() {
                             : "";
 
                     var accBtn = canAcc
-                        ? `<a href="javascript:void(0);" class="me-2 p-2 btn-action-icon btnAccept text-info" title="ACC Terkirim" data-id="${row.id}">
+                        ? `<a href="javascript:void(0);" class="me-2 p-2 btn-action-icon btnAccept btn-action-approve" title="ACC Terkirim" data-id="${row.id}">
                                 <i class="fe fe-check-circle"></i>
                            </a>`
                         : "";

--- a/public/Custom_js/Backoffice/Suppliers/tt.js
+++ b/public/Custom_js/Backoffice/Suppliers/tt.js
@@ -4,6 +4,27 @@
     var grand = 0;
     var dates = null;
 var compressedImageFile = null;
+    var ttXhr = null;
+
+    function ttWrap() {
+        return $("#tableTTPurchaseOrder-wrap");
+    }
+
+    function setTtTableLoading(isLoading) {
+        var $wrap = ttWrap();
+        if (!$wrap.length) return;
+        $wrap.toggleClass("is-loading", !!isLoading);
+    }
+
+    function showTtSkeleton() {
+        ttWrap().removeClass("dt-ready").addClass("dt-pending");
+        setTtTableLoading(true);
+    }
+
+    function hideTtSkeleton() {
+        setTtTableLoading(false);
+        ttWrap().removeClass("dt-pending").addClass("dt-ready");
+    }
     autocompleteSupplier("#filter_supplier");
 function resetTtUploadProgress() {
     $("#tt_upload_progress")
@@ -67,7 +88,13 @@ function updateTtUploadProgress(percent) {
     }
 
     function refreshPurchaseOrder() {
-        $.ajax({
+        if (ttXhr && ttXhr.readyState !== 4) {
+            ttXhr.abort();
+        }
+
+        showTtSkeleton();
+
+        ttXhr = $.ajax({
             url: "/getTt",
             method: "get",
             data: {
@@ -102,9 +129,9 @@ function updateTtUploadProgress(percent) {
                     e[i].action = tta;
                     if (e[i].status == 1 && hasAccessAction("Tanda Terima PO", "others")) {
                         e[i].action +=
-                            '<a class="me-2 btn-action-icon p-2 btn_acc_tt bg-success text-light" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Terima"  tt_id = "' +
+                            '<a class="me-2 btn-action-icon p-2 btn_acc_tt btn-action-approve" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Terima"  tt_id = "' +
                             e[i].tt_id +
-                            '"><i class="fe fe-check"></i></a><a  class="me-2 btn-action-icon p-2 btn_decline_tt bg-danger text-light" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Tolak"  tt_id = "' +
+                            '"><i class="fe fe-check"></i></a><a  class="me-2 btn-action-icon p-2 btn_decline_tt btn-action-reject" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Tolak"  tt_id = "' +
                             e[i].tt_id +
                             '"><i class="fe fe-x"></i></a>';
                     }
@@ -123,8 +150,14 @@ function updateTtUploadProgress(percent) {
                 feather.replace(); // Biar icon feather muncul lagi
             },
             error: function (err) {
+                if (err && err.statusText === "abort") return;
                 if (handlePermissionError(err)) return;
                 console.error("Gagal load so:", err);
+            },
+            complete: function (xhr, status) {
+                if (status === "abort") return;
+                hideTtSkeleton();
+                if (table) table.columns.adjust();
             }
         });
     }

--- a/resources/views/Backoffice/Suppliers/Tt.blade.php
+++ b/resources/views/Backoffice/Suppliers/Tt.blade.php
@@ -37,6 +37,58 @@
         .select2-container {
             max-width: 100% !important;
         }
+
+        #tableTTPurchaseOrder-wrap .dt-skeleton {
+            border-radius: 0;
+            background: transparent;
+            box-shadow: none;
+        }
+
+        #tableTTPurchaseOrder_wrapper .dataTables_processing {
+            position: absolute !important;
+            top: 0 !important;
+            left: 0 !important;
+            right: 0 !important;
+            bottom: 0 !important;
+            width: 100% !important;
+            height: 100% !important;
+            margin: 0 !important;
+            padding: 0 !important;
+            border: 0 !important;
+            border-radius: 8px;
+            background: rgba(255, 255, 255, 0.72) !important;
+            box-shadow: none !important;
+            z-index: 20;
+            align-items: center;
+            justify-content: center;
+            color: #1e293b;
+            font-weight: 600;
+            font-size: 14px;
+        }
+
+        #tableTTPurchaseOrder-wrap:not(.is-loading) .dataTables_processing {
+            display: none !important;
+        }
+
+        #tableTTPurchaseOrder-wrap.is-loading .dataTables_processing {
+            display: flex !important;
+        }
+
+        #tableTTPurchaseOrder_wrapper .dataTables_processing > div {
+            display: inline-flex;
+            align-items: center;
+            gap: 10px;
+            padding: 10px 16px;
+            border-radius: 10px;
+            background: #fff;
+            border: 1px solid #e2e8f0;
+            box-shadow: 0 8px 24px rgba(15, 23, 42, 0.08);
+        }
+
+        #tableTTPurchaseOrder-wrap.is-loading tbody {
+            opacity: 0.45;
+            pointer-events: none;
+        }
     </style>
 @endsection
 @section('content')
@@ -63,7 +115,38 @@
                     <div class=" card-table">
                         <div class="card-body">
                             
-                            <div class="table-responsive">
+                            <div class="table-responsive dt-pending" id="tableTTPurchaseOrder-wrap">
+                                <div class="dt-skeleton" aria-hidden="true">
+                                    <div style="padding: 16px 25px;">
+                                        <span class="skel-text" style="width: 250px; height: 38px; border-radius: 20px;"></span>
+                                    </div>
+                                    <div class="dt-skeleton-head" style="grid-template-columns: 10% 12% 18% 12% 12% 10% 10% 10% 6%;">
+                                        <span style="width:60%"></span>
+                                        <span style="width:60%"></span>
+                                        <span style="width:55%"></span>
+                                        <span style="width:50%"></span>
+                                        <span style="width:50%"></span>
+                                        <span style="width:50%"></span>
+                                        <span style="width:55%"></span>
+                                        <span style="width:55%"></span>
+                                        <span style="width:40%"></span>
+                                    </div>
+                                    <div class="dt-skeleton-body">
+                                        @for ($i = 0; $i < 5; $i++)
+                                            <div class="dt-skeleton-row" style="grid-template-columns: 10% 12% 18% 12% 12% 10% 10% 10% 6%;">
+                                                <span class="skel-text" style="width:70%"></span>
+                                                <span class="skel-text" style="width:60%"></span>
+                                                <span class="skel-text" style="width:80%"></span>
+                                                <span class="skel-text" style="width:60%"></span>
+                                                <span class="skel-text" style="width:70%"></span>
+                                                <span class="skel-badge" style="width:60%;justify-self:center"></span>
+                                                <span class="skel-text" style="width:60%"></span>
+                                                <span class="skel-text" style="width:60%"></span>
+                                                <span class="skel-badge" style="width:50%;justify-self:center"></span>
+                                            </div>
+                                        @endfor
+                                    </div>
+                                </div>
                                 <table class="table table-center table-hover" id="tableTTPurchaseOrder">
                                     <thead class="thead-light">
                                         <tr>
@@ -79,7 +162,7 @@
                                         </tr>
                                     </thead>
                                     <tbody>
-                                        
+
                                     </tbody>
                                 </table>
                             </div>
@@ -99,5 +182,5 @@
         var public = "{{ asset('') }}";    
     </script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/compressorjs/1.2.1/compressor.min.js"></script>
-    <script src="{{asset('Custom_js/Backoffice/Suppliers/tt.js')}}?v=1"></script>
+    <script src="{{asset('Custom_js/Backoffice/Suppliers/tt.js')}}?v={{ time() }}"></script>
 @endsection

--- a/resources/views/components/modals/tt/add-acc-tt.blade.php
+++ b/resources/views/components/modals/tt/add-acc-tt.blade.php
@@ -1,12 +1,18 @@
-  <div class="modal modal-lg custom-modal fade" id="add_acc_tt" role="dialog" data-bs-backdrop="static"
+  <div class="modal modal-lg custom-modal fade pg-modal--confirm" id="add_acc_tt" role="dialog" data-bs-backdrop="static"
     data-bs-keyboard="false">
     <div class="modal-dialog modal-dialog-centered modal-md">
-      <div class="modal-content">
-        <div class="modal-header border-0 pb-0">
-          <div class="form-header modal-header-title  text-start mb-0">
-            <h4 class="mb-0 modal-title">Konfirmasi Terima</h4>
+      <div class="modal-content" style="border-radius: 16px; overflow: hidden; border: none;">
+        <div class="modal-header">
+          <div class="d-flex align-items-center gap-3">
+            <div class="pg-modal-icon">
+              <i class="fe fe-check-circle"></i>
+            </div>
+            <div>
+              <h5 class="mb-0 fw-bold modal-title">Konfirmasi Terima</h5>
+              <small class="text-muted modal-subtitle">Konfirmasi pembayaran dan pelunasan invoice terkait</small>
+            </div>
           </div>
-          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close">
+          <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close">
           </button>
         </div>
         <form action="#">
@@ -29,7 +35,7 @@
                   <h5 class="mb-1">Unggah Foto Bukti Transaksi</h5>
                   <p class="text-muted small mb-3" id="file_name">xx.jpg</p>
                   <div class="img-upload">
-                    <label class="btn btn-primary px-5 shadow-sm">
+                    <label class="btn pg-btn-save px-5 shadow-sm">
                       Unggah <input type="file" class="d-none input-gambar" accept="image/png, image/jpeg"
                         id="image">
                     </label>
@@ -51,9 +57,9 @@
               <textarea class="form-control" rows="3" id="keterangan" placeholder="Masukkan keterangan tambahan..."></textarea>
             </div>
           </div>
-          <div class="modal-footer">
-            <button type="button" data-bs-dismiss="modal" class="btn btn-back cancel-btn me-2">Batal</button>
-            <button type="button" class="btn btn-primary paid-continue-btn btn-save">Konfirmasi</button>
+          <div class="modal-footer pg-modal-footer">
+            <button type="button" data-bs-dismiss="modal" class="btn pg-btn-cancel cancel-btn">Batal</button>
+            <button type="button" class="btn pg-btn-confirm paid-continue-btn btn-save"><i class="fe fe-check-circle me-1"></i>Konfirmasi</button>
           </div>
         </form>
       </div>

--- a/resources/views/layout/partials/header.blade.php
+++ b/resources/views/layout/partials/header.blade.php
@@ -592,6 +592,79 @@
             box-shadow: 0 2px 8px rgba(22, 163, 74, 0.15) !important;
             transform: translateY(-1px) !important;
         }
+        /* ACC / TERIMA (approve) — GitHub #117: needs to stand out from view/edit icons.
+           Soft tint + border, same language as the delete icon's hover state, kept permanently
+           on for approve/reject since these need to read as colored at a glance, not just on hover. */
+        .btn-action-icon.btn-action-approve {
+            background: #ecfdf5 !important;
+            border: 1px solid #a7f3d0 !important;
+            color: #059669 !important;
+            font-weight: 700 !important;
+        }
+        .btn-action-icon.btn-action-approve:hover {
+            background: #d1fae5 !important;
+            border-color: #6ee7b7 !important;
+            color: #047857 !important;
+            box-shadow: 0 2px 8px rgba(5, 150, 105, 0.15) !important;
+            transform: translateY(-1px) !important;
+        }
+        /* TOLAK (reject) — GitHub #117. Same tint values as the delete icon's hover state. */
+        .btn-action-icon.btn-action-reject {
+            background: #fef2f2 !important;
+            border: 1px solid #fecaca !important;
+            color: #dc2626 !important;
+            font-weight: 700 !important;
+        }
+        .btn-action-icon.btn-action-reject:hover {
+            background: #fee2e2 !important;
+            border-color: #fca5a5 !important;
+            color: #b91c1c !important;
+            box-shadow: 0 2px 8px rgba(220, 38, 38, 0.15) !important;
+            transform: translateY(-1px) !important;
+        }
+        /* VIEW — same soft-tint language */
+        .btn-action-icon.btn-action-view {
+            background: #eff6ff !important;
+            border: 1px solid #bfdbfe !important;
+            color: #2563eb !important;
+            font-weight: 700 !important;
+        }
+        .btn-action-icon.btn-action-view:hover {
+            background: #dbeafe !important;
+            border-color: #93c5fd !important;
+            color: #1d4ed8 !important;
+            box-shadow: 0 2px 8px rgba(37, 99, 235, 0.15) !important;
+            transform: translateY(-1px) !important;
+        }
+        /* EDIT — same soft-tint language, reusable wherever an edit icon's inline style
+           needs to survive the base .btn-action-icon !important reset. */
+        .btn-action-icon.btn-action-edit {
+            background: #fffbeb !important;
+            border: 1px solid #fde68a !important;
+            color: #d97706 !important;
+            font-weight: 700 !important;
+        }
+        .btn-action-icon.btn-action-edit:hover {
+            background: #fef3c7 !important;
+            border-color: #fcd34d !important;
+            color: #b45309 !important;
+            box-shadow: 0 2px 8px rgba(217, 119, 6, 0.15) !important;
+            transform: translateY(-1px) !important;
+        }
+        /* DELETE (permanent tint, distinct from .btn_delete/.text-danger which only tint on hover) */
+        .btn-action-icon.btn-action-delete {
+            background: #fef2f2 !important;
+            border: 1px solid #fecaca !important;
+            color: #dc2626 !important;
+            font-weight: 700 !important;
+        }
+        .btn-action-icon.btn-action-delete:hover {
+            background: #fee2e2 !important;
+            border-color: #fca5a5 !important;
+            color: #b91c1c !important;
+            box-shadow: 0 2px 8px rgba(220, 38, 38, 0.15) !important;
+            transform: translateY(-1px) !important;
+        }
     </style>
     <div class="dropdown warehouse-custom-dropdown" style="float: left; margin-left: 45px; margin-top: 13px;">
         @php

--- a/resources/views/layout/partials/pg-modal-styles.blade.php
+++ b/resources/views/layout/partials/pg-modal-styles.blade.php
@@ -319,6 +319,30 @@
         border-color: #fca5a5 !important;
     }
 
+    /* ═══ Edit action icon — selalu kuning/amber, sama seperti pola delete di atas.
+       GitHub #117: btn_edit dipakai lewat helper global roleIconEdit() jadi ini otomatis
+       menyala di semua tabel master data (Bank, BOM/Resep Bahan Mentah, Warehouse, dst),
+       bukan cuma satu halaman. ═══ */
+    .table tbody td a.btn-action-icon.btn_edit,
+    .table tbody td a.btn-action-icon.text-warning {
+        background: #fffbeb !important;
+        border: 1px solid #fde68a !important;
+        color: #d97706 !important;
+        border-radius: 8px !important;
+        width: 32px !important;
+        height: 32px !important;
+        padding: 0 !important;
+        display: inline-flex !important;
+        align-items: center !important;
+        justify-content: center !important;
+    }
+    .table tbody td a.btn-action-icon.btn_edit:hover,
+    .table tbody td a.btn-action-icon.text-warning:hover {
+        color: #b45309 !important;
+        background: #fef3c7 !important;
+        border-color: #fcd34d !important;
+    }
+
     /* ═══ PG Popup Table — tabel input di dalam modal (GitHub #111) ═══
        Pola standar: kartu input di ATAS, lalu tabel daftar item yang scroll
        sendiri setinggi PG_POPUP_TABLE.MAX_VISIBLE_ROWS baris.


### PR DESCRIPTION
## Summary
- GitHub #117 asked for ACC/Tolak table action buttons to be colored + bold so they're visible. Root cause: a global `.btn-action-icon { background:#fff !important; ... }` rule (`header.blade.php`) was silently defeating any inline `style=` or Bootstrap `bg-*` class used to color these buttons — several looked colored in source but rendered plain white on every page.
- Added shared, permanently-tinted classes (soft bg + border + colored icon/bold, same visual language as the existing delete icon) that survive the global override:
  - `.btn-action-approve` / `.btn-action-reject` (`header.blade.php`)
  - `.table tbody td a.btn-action-icon.btn_edit` next to the existing `.btn_delete` rule (`pg-modal-styles.blade.php`) — `btn_edit` is emitted by the shared `roleIconEdit()` helper, so this colors edit icons on every master-data page (Bank, BOM/Resep Bahan Mentah, etc.) at once
  - `.btn-action-view` for the Pengembalian table's Lihat icon
- Wired real per-row targets onto the new classes: Tanda Terima PO, Stock Transfer (ACC Terkirim), Sales Order/Pengiriman (Konfirmasi), Customer Return/Pengembalian (Konfirmasi/Lihat/Edit/Hapus)
- Fixed `ProductController::buildProductActionHtml()` — Daftar Produk's edit icon was missing the `btn_edit` class server-side, so it never matched any color rule at all
- Tanda Terima: added DataTables shimmer/skeleton loading state (load, filter, pagination) and migrated its Konfirmasi Terima modal to the PG modal design system (`pg-modal--confirm`)
- `docs/table-action-button-color-rollout.md`: tracker for the rest of this rollout (which tables are done, which are intentionally out of scope, and the root-cause writeup so nobody re-discovers it the hard way)
- `docs/UNUSED_CODE_RECORD.md`: recorded `Customer_Product_Return.js` / `Customer_Supply_Return.js` as orphaned pre-unification pages — backend controllers/routes still work, but nothing loads the JS anymore (superseded by the unified Pengembalian table)

## Test plan
- [x] Verified in-browser (not just source) via DevTools on Tanda Terima PO — this bug was invisible from reading JS alone
- [x] Hard-refresh each touched page and confirm ACC/Tolak/Edit/Delete icons render colored: Tanda Terima PO, Stock Transfer, Pengiriman, Pengiriman → Pengembalian, Bank, Resep Bahan Mentah (BOM), Daftar Produk
- [x] Tanda Terima: confirm shimmer shows on load and on filter change, and Konfirmasi Terima modal matches the new PG modal style

Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)