### PR TITLE
fix(bank+kategori-kas): reject duplicate names on insert/update

### DIFF
--- a/app/Models/Bank.php
+++ b/app/Models/Bank.php
@@ -32,8 +32,27 @@ class Bank extends Model
         return $rows;
     }
 
+    /**
+     * True kalau ada bank aktif lain dengan nama yang sama (case-insensitive, trimmed).
+     * $excludeId dipakai saat update supaya baris itu sendiri tidak dianggap bentrok
+     * dengan dirinya sendiri.
+     */
+    function isDuplicateName($name, $excludeId = null)
+    {
+        $query = Bank::where('status', 1)
+            ->whereRaw('LOWER(TRIM(bank_kode)) = ?', [strtolower(trim($name))]);
+        if ($excludeId) {
+            $query->where('bank_id', '!=', $excludeId);
+        }
+        return $query->exists();
+    }
+
     function insertBank($data)
     {
+        if ($this->isDuplicateName($data["bank_kode"])) {
+            return response()->json(['message' => 'Nama bank sudah digunakan'], 422);
+        }
+
         $t = new Bank();
         $t->bank_kode = $data["bank_kode"];
         $t->created_by = Session::get('user') ? Session::get('user')->staff_id : null;
@@ -44,6 +63,12 @@ class Bank extends Model
     function updateBank($data)
     {
         $t = Bank::find($data["bank_id"]);
+        if (!$t) return null;
+
+        if ($this->isDuplicateName($data["bank_kode"], $t->bank_id)) {
+            return response()->json(['message' => 'Nama bank sudah digunakan'], 422);
+        }
+
         $t->bank_kode = $data["bank_kode"];
         $t->save();
         return $t->bank_id;

--- a/app/Models/CashCategory.php
+++ b/app/Models/CashCategory.php
@@ -54,8 +54,27 @@ class CashCategory extends Model
             ->select(['cc_id', 'cc_name', 'cc_type']);
     }
 
+    /**
+     * True kalau ada kategori kas aktif lain dengan nama yang sama (case-insensitive,
+     * trimmed). $excludeId dipakai saat update supaya baris itu sendiri tidak dianggap
+     * bentrok dengan dirinya sendiri.
+     */
+    function isDuplicateName($name, $excludeId = null)
+    {
+        $query = CashCategory::where('status', 1)
+            ->whereRaw('LOWER(TRIM(cc_name)) = ?', [strtolower(trim($name))]);
+        if ($excludeId) {
+            $query->where('cc_id', '!=', $excludeId);
+        }
+        return $query->exists();
+    }
+
     function insertCashCategory($data)
     {
+        if ($this->isDuplicateName($data["cc_name"])) {
+            return response()->json(['message' => 'Nama kategori kas sudah digunakan'], 422);
+        }
+
         $t = new CashCategory();
         $t->cc_name = $data["cc_name"];
         $t->cc_type = $data["cc_type"];
@@ -71,6 +90,10 @@ class CashCategory extends Model
         // gagal bersih. Mirror pattern yang sudah dipakai di StockOpname::updateStockOpname() dkk.
         $t = CashCategory::find($data["cc_id"]);
         if (!$t) return null;
+
+        if ($this->isDuplicateName($data["cc_name"], $t->cc_id)) {
+            return response()->json(['message' => 'Nama kategori kas sudah digunakan'], 422);
+        }
 
         $t->cc_name = $data["cc_name"];
         $t->cc_type = $data["cc_type"];

--- a/public/Custom_js/Backoffice/Reports/Category_Cash.js
+++ b/public/Custom_js/Backoffice/Reports/Category_Cash.js
@@ -133,6 +133,8 @@
             error:function(e){
                 ResetLoadingButton('.btn-save', mode == 1?"Tambah Kategori Kas" : "Update Kategori Kas");
                 if (handlePermissionError(e)) return;
+                var msg = (e.responseJSON && e.responseJSON.message) || "Silahkan cek kembali inputan anda";
+                notifikasi('error', mode == 1?"Gagal Insert":"Gagal Update", msg);
                 console.log(e);
             }
         });

--- a/public/Custom_js/Backoffice/User/Bank.js
+++ b/public/Custom_js/Backoffice/User/Bank.js
@@ -132,6 +132,8 @@
             error:function(e){
                 ResetLoadingButton('.btn-save', mode == 1?"Tambah Bank" : "Update Bank");
                 if (handlePermissionError(e)) return;
+                var msg = (e.responseJSON && e.responseJSON.message) || "Silahkan cek kembali inputan anda";
+                notifikasi('error', mode == 1?"Gagal Insert":"Gagal Update", msg);
                 console.log(e);
             }
         });

--- a/resources/views/components/modals/bank/add-bank.blade.php
+++ b/resources/views/components/modals/bank/add-bank.blade.php
@@ -1,32 +1,40 @@
-  <div class="modal modal-lg custom-modal fade" id="add_bank" role="dialog" data-bs-backdrop="static"
+  <div class="modal modal-lg custom-modal fade pg-modal--form" id="add_bank" role="dialog" data-bs-backdrop="static"
     data-bs-keyboard="false">
-    <div class="modal-dialog modal-dialog-centered modal-md">
-      <div class="modal-content">
-        <div class="modal-header border-0 pb-0">
-          <div class="form-header modal-header-title  text-start mb-0">
-            <h4 class="mb-0 modal-title">Tambah Bank</h4>
-          </div>
-          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close">
-          </button>
-        </div>
-        <form action="#">
-          <div class="modal-body">
-            <div class="form-groups-item border-0 pb-0">
-              <div class="row">
-                <div class="col-12">
-                  <div class="input-block mb-3">
-                    <label>Kode Bank<span class="text-danger">*</span></label>
-                    <input type="text" class="form-control fill" id="bank_kode" placeholder="Input Kode Bank">
-                  </div>
-                </div>
-              </div>
+    <div class="modal-dialog modal-dialog-centered">
+      <div class="modal-content d-flex flex-column" style="border-radius:16px;overflow:hidden;border:none;">
+        {{-- ── HEADER ── --}}
+        <div class="modal-header">
+          <div class="d-flex align-items-center gap-3">
+            <div class="pg-modal-icon">
+              <i class="fe fe-credit-card"></i>
+            </div>
+            <div>
+              <h5 class="mb-0 fw-bold modal-title">Tambah Bank</h5>
+              <small class="text-muted modal-subtitle">Input data akun bank baru</small>
             </div>
           </div>
-          <div class="modal-footer">
-            <button type="button" data-bs-dismiss="modal" class="btn btn-back cancel-btn me-2">Batal</button>
-            <button type="button" class="btn btn-primary paid-continue-btn btn-save">Tambah Bank</button>
+          <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"
+            aria-label="Close"></button>
+        </div>
+
+        <form action="#">
+          <div class="modal-body p-4" style="background:#f8fafc;">
+            {{-- Kode Bank --}}
+            <div class="mb-3">
+              <label class="text-muted mb-2"
+                style="font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:.4px;">Kode Bank
+                <span class="text-danger">*</span></label>
+              <input type="text" class="form-control fill" id="bank_kode" placeholder="Input Kode Bank"
+                style="font-size:14px;border-radius:8px;height:42px;">
+            </div>
           </div>
-        </form>
-      </div>
+
+          {{-- ── FOOTER ── --}}
+        <div class="modal-footer pg-modal-footer">
+          <button type="button" data-bs-dismiss="modal" class="btn pg-btn-cancel">Batal</button>
+          <button type="button" class="btn pg-btn-save btn-save"><i class="fe fe-save me-1"></i>Tambah Bank</button>
+        </div>
+      </form>
     </div>
   </div>
+</div>

--- a/resources/views/components/modals/cash-category/add-cash-category.blade.php
+++ b/resources/views/components/modals/cash-category/add-cash-category.blade.php
@@ -1,43 +1,58 @@
-  <div class="modal modal-lg custom-modal fade" id="add_cash_category" role="dialog" data-bs-backdrop="static"
+  <div class="modal modal-lg custom-modal fade pg-modal--form" id="add_cash_category" role="dialog" data-bs-backdrop="static"
     data-bs-keyboard="false">
-    <div class="modal-dialog modal-dialog-centered modal-md">
-      <div class="modal-content">
-        <div class="modal-header border-0 pb-0">
-          <div class="form-header modal-header-title  text-start mb-0">
-            <h4 class="mb-0 modal-title">Tambah Kategori Kas</h4>
+    <div class="modal-dialog modal-dialog-centered">
+      <div class="modal-content d-flex flex-column" style="border-radius:16px;overflow:hidden;border:none;">
+        {{-- ── HEADER ── --}}
+        <div class="modal-header">
+          <div class="d-flex align-items-center gap-3">
+            <div class="pg-modal-icon">
+              <i class="fe fe-dollar-sign"></i>
+            </div>
+            <div>
+              <h5 class="mb-0 fw-bold modal-title">Tambah Kategori Kas</h5>
+              <small class="text-muted modal-subtitle">Input data kategori kas baru</small>
+            </div>
           </div>
-          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close">
-          </button>
+          <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"
+            aria-label="Close"></button>
         </div>
+
         <form action="#">
-          <div class="modal-body">
-            <div class="form-groups-item border-0 pb-0">
-              <div class="row">
-                <div class="col-lg-6 col-12">
-                  <div class="input-block mb-3">
-                    <label>Nama Kategori<span class="text-danger">*</span></label>
-                    <input type="text" class="form-control fill" id="cc_name" placeholder="ex Makan Siang">
-                  </div>
+          <div class="modal-body p-4" style="background:#f8fafc;">
+            <div class="row">
+              <div class="col-lg-6 col-12">
+                {{-- Nama Kategori --}}
+                <div class="mb-3">
+                  <label class="text-muted mb-2"
+                    style="font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:.4px;">Nama
+                    Kategori <span class="text-danger">*</span></label>
+                  <input type="text" class="form-control fill" id="cc_name" placeholder="ex Makan Siang"
+                    style="font-size:14px;border-radius:8px;height:42px;">
                 </div>
-                <div class="col-lg-6 col-12">
-                  <div class="input-block mb-3">
-                    <label>Tipe Kategori<span class="text-danger">*</span></label>
-                    <select class="form-select fill" id="cc_type">
-                      <option value="" selected disabled>Pilih Tipe Kategori</option>
-                      <option value="Keluar">Keluar</option>
-                      <option value="Keluar 1">Keluar 1</option>
-                      <option value="Masuk">Masuk / Setoran Tunai</option>
-                    </select>
-                  </div>
+              </div>
+              <div class="col-lg-6 col-12">
+                {{-- Tipe Kategori --}}
+                <div class="mb-3">
+                  <label class="text-muted mb-2"
+                    style="font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:.4px;">Tipe
+                    Kategori <span class="text-danger">*</span></label>
+                  <select class="form-select fill" id="cc_type" style="font-size:14px;border-radius:8px;height:42px;">
+                    <option value="" selected disabled>Pilih Tipe Kategori</option>
+                    <option value="Keluar">Keluar</option>
+                    <option value="Keluar 1">Keluar 1</option>
+                    <option value="Masuk">Masuk / Setoran Tunai</option>
+                  </select>
                 </div>
               </div>
             </div>
           </div>
-          <div class="modal-footer">
-            <button type="button" data-bs-dismiss="modal" class="btn btn-back cancel-btn me-2">Batal</button>
-            <button type="button" class="btn btn-primary paid-continue-btn btn-save">Tambah Kategori Kas</button>
-          </div>
-        </form>
-      </div>
+
+          {{-- ── FOOTER ── --}}
+        <div class="modal-footer pg-modal-footer">
+          <button type="button" data-bs-dismiss="modal" class="btn pg-btn-cancel">Batal</button>
+          <button type="button" class="btn pg-btn-save btn-save"><i class="fe fe-save me-1"></i>Tambah Kategori Kas</button>
+        </div>
+      </form>
     </div>
   </div>
+</div>

--- a/resources/views/components/modals/category/add-category.blade.php
+++ b/resources/views/components/modals/category/add-category.blade.php
@@ -1,33 +1,40 @@
-  <div class="modal modal-lg custom-modal fade" id="add_category" role="dialog" data-bs-backdrop="static"
+  <div class="modal modal-lg custom-modal fade pg-modal--form" id="add_category" role="dialog" data-bs-backdrop="static"
     data-bs-keyboard="false">
-    <div class="modal-dialog modal-dialog-centered modal-md">
-      <div class="modal-content">
-        <div class="modal-header border-0 pb-0">
-          <div class="form-header modal-header-title  text-start mb-0">
-            <h4 class="mb-0 modal-title">Tambah Kategori</h4>
-          </div>
-          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close">
-          </button>
-        </div>
-        <form action="#">
-          <div class="modal-body">
-            <div class="form-groups-item border-0 pb-0">
-              <div class="row">
-                <div class="col-12">
-                  <div class="input-block mb-3">
-                    <label>Nama Kategori<span class="text-danger">*</span></label>
-                    <input type="text" class="form-control fill" id="category_name"
-                      placeholder="Input Nama Kategori">
-                  </div>
-                </div>
-              </div>
+    <div class="modal-dialog modal-dialog-centered">
+      <div class="modal-content d-flex flex-column" style="border-radius:16px;overflow:hidden;border:none;">
+        {{-- ── HEADER ── --}}
+        <div class="modal-header">
+          <div class="d-flex align-items-center gap-3">
+            <div class="pg-modal-icon">
+              <i class="fe fe-folder"></i>
+            </div>
+            <div>
+              <h5 class="mb-0 fw-bold modal-title">Tambah Kategori</h5>
+              <small class="text-muted modal-subtitle">Input data kategori produk baru</small>
             </div>
           </div>
-          <div class="modal-footer">
-            <button type="button" data-bs-dismiss="modal" class="btn btn-back cancel-btn me-2">Batal</button>
-            <button type="button" class="btn btn-primary paid-continue-btn btn-save">Tambah Kategori</button>
+          <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"
+            aria-label="Close"></button>
+        </div>
+
+        <form action="#">
+          <div class="modal-body p-4" style="background:#f8fafc;">
+            {{-- Nama Kategori --}}
+            <div class="mb-3">
+              <label class="text-muted mb-2"
+                style="font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:.4px;">Nama Kategori
+                <span class="text-danger">*</span></label>
+              <input type="text" class="form-control fill" id="category_name" placeholder="Input Nama Kategori"
+                style="font-size:14px;border-radius:8px;height:42px;">
+            </div>
           </div>
-        </form>
-      </div>
+
+          {{-- ── FOOTER ── --}}
+        <div class="modal-footer pg-modal-footer">
+          <button type="button" data-bs-dismiss="modal" class="btn pg-btn-cancel">Batal</button>
+          <button type="button" class="btn pg-btn-save btn-save"><i class="fe fe-save me-1"></i>Tambah Kategori</button>
+        </div>
+      </form>
     </div>
   </div>
+</div>

--- a/resources/views/components/modals/unit/add-unit.blade.php
+++ b/resources/views/components/modals/unit/add-unit.blade.php
@@ -1,39 +1,54 @@
-  <div class="modal modal-lg custom-modal fade" id="add_unit" role="dialog" data-bs-backdrop="static"
+  <div class="modal modal-lg custom-modal fade pg-modal--form" id="add_unit" role="dialog" data-bs-backdrop="static"
     data-bs-keyboard="false">
-    <div class="modal-dialog modal-dialog-centered modal-md">
-      <div class="modal-content">
-        <div class="modal-header border-0 pb-0">
-          <div class="form-header modal-header-title  text-start mb-0">
-            <h4 class="mb-0 modal-title">Tambah Satuan</h4>
+    <div class="modal-dialog modal-dialog-centered">
+      <div class="modal-content d-flex flex-column" style="border-radius:16px;overflow:hidden;border:none;">
+        {{-- ── HEADER ── --}}
+        <div class="modal-header">
+          <div class="d-flex align-items-center gap-3">
+            <div class="pg-modal-icon">
+              <i class="fe fe-package"></i>
+            </div>
+            <div>
+              <h5 class="mb-0 fw-bold modal-title">Tambah Satuan</h5>
+              <small class="text-muted modal-subtitle">Input data satuan produk baru</small>
+            </div>
           </div>
-          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close">
-          </button>
+          <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"
+            aria-label="Close"></button>
         </div>
+
         <form action="#">
-          <div class="modal-body">
-            <div class="form-groups-item border-0 pb-0">
-              <div class="row">
-                <div class="col-lg-6 col-md-12">
-                  <div class="input-block mb-3">
-                    <label>Nama Satuan<span class="text-danger">*</span></label>
-                    <input type="text" class="form-control fill" id="unit_name" placeholder="Input Nama Satuan">
-                  </div>
+          <div class="modal-body p-4" style="background:#f8fafc;">
+            <div class="row">
+              <div class="col-lg-6 col-md-12">
+                {{-- Nama Satuan --}}
+                <div class="mb-3">
+                  <label class="text-muted mb-2"
+                    style="font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:.4px;">Nama Satuan
+                    <span class="text-danger">*</span></label>
+                  <input type="text" class="form-control fill" id="unit_name" placeholder="Input Nama Satuan"
+                    style="font-size:14px;border-radius:8px;height:42px;">
                 </div>
-                <div class="col-lg-6 col-md-12">
-                  <div class="input-block mb-3">
-                    <label>Singkatan<span class="text-danger">*</span></label>
-                    <input type="text" class="form-control fill" id="unit_short_name"
-                      placeholder="Input Singkatan">
-                  </div>
+              </div>
+              <div class="col-lg-6 col-md-12">
+                {{-- Singkatan --}}
+                <div class="mb-3">
+                  <label class="text-muted mb-2"
+                    style="font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:.4px;">Singkatan
+                    <span class="text-danger">*</span></label>
+                  <input type="text" class="form-control fill" id="unit_short_name" placeholder="Input Singkatan"
+                    style="font-size:14px;border-radius:8px;height:42px;">
                 </div>
               </div>
             </div>
           </div>
-          <div class="modal-footer">
-            <button type="button" data-bs-dismiss="modal" class="btn btn-back cancel-btn me-2">Batal</button>
-            <button type="button" class="btn btn-primary paid-continue-btn btn-save">Tambah Satuan</button>
-          </div>
-        </form>
-      </div>
+
+          {{-- ── FOOTER ── --}}
+        <div class="modal-footer pg-modal-footer">
+          <button type="button" data-bs-dismiss="modal" class="btn pg-btn-cancel">Batal</button>
+          <button type="button" class="btn pg-btn-save btn-save"><i class="fe fe-save me-1"></i>Tambah Satuan</button>
+        </div>
+      </form>
     </div>
   </div>
+</div>

--- a/resources/views/components/modals/variant/add-variant.blade.php
+++ b/resources/views/components/modals/variant/add-variant.blade.php
@@ -1,41 +1,50 @@
-  <div class="modal modal-lg custom-modal fade" id="add_variant" role="dialog" data-bs-backdrop="static"
+  <div class="modal modal-lg custom-modal fade pg-modal--form" id="add_variant" role="dialog" data-bs-backdrop="static"
     data-bs-keyboard="false">
-    <div class="modal-dialog modal-dialog-centered modal-md">
-      <div class="modal-content">
-        <div class="modal-header border-0 pb-0">
-          <div class="form-header modal-header-title  text-start mb-0">
-            <h4 class="mb-0 modal-title">Tambah Variasi</h4>
-          </div>
-          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close">
-          </button>
-        </div>
-        <form action="#">
-          <div class="modal-body">
-            <div class="form-groups-item border-0 pb-0">
-              <div class="row">
-                <div class="col-12">
-                  <div class="input-block mb-3">
-                    <label>Nama<span class="text-danger">*</span></label>
-                    <input type="text" class="form-control fill" id="variant_name"
-                      placeholder="Input Nama Variasi">
-                  </div>
-                </div>
-                <div class="col-12">
-                  <div class="input-block mb-3">
-                    <label>Variasi<span class="text-danger">*</span></label>
-                    <select class="form-control tagging fill" id="variant_attribute" multiple="multiple">
-
-                    </select>
-                  </div>
-                </div>
-              </div>
+    <div class="modal-dialog modal-dialog-centered">
+      <div class="modal-content d-flex flex-column" style="border-radius:16px;overflow:hidden;border:none;">
+        {{-- ── HEADER ── --}}
+        <div class="modal-header">
+          <div class="d-flex align-items-center gap-3">
+            <div class="pg-modal-icon">
+              <i class="fe fe-layers"></i>
+            </div>
+            <div>
+              <h5 class="mb-0 fw-bold modal-title">Tambah Variasi</h5>
+              <small class="text-muted modal-subtitle">Input data variasi produk baru</small>
             </div>
           </div>
-          <div class="modal-footer">
-            <button type="button" data-bs-dismiss="modal" class="btn btn-back cancel-btn me-2">Batal</button>
-            <button type="button" class="btn btn-primary paid-continue-btn btn-save">Tambah Variasi</button>
+          <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"
+            aria-label="Close"></button>
+        </div>
+
+        <form action="#">
+          <div class="modal-body p-4" style="background:#f8fafc;">
+            {{-- Nama --}}
+            <div class="mb-3">
+              <label class="text-muted mb-2"
+                style="font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:.4px;">Nama
+                <span class="text-danger">*</span></label>
+              <input type="text" class="form-control fill" id="variant_name" placeholder="Input Nama Variasi"
+                style="font-size:14px;border-radius:8px;height:42px;">
+            </div>
+            {{-- Variasi --}}
+            <div class="mb-3">
+              <label class="text-muted mb-2"
+                style="font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:.4px;">Variasi
+                <span class="text-danger">*</span></label>
+              <select class="form-control tagging fill" id="variant_attribute" multiple="multiple"
+                style="border-radius:8px;">
+
+              </select>
+            </div>
           </div>
-        </form>
-      </div>
+
+          {{-- ── FOOTER ── --}}
+        <div class="modal-footer pg-modal-footer">
+          <button type="button" data-bs-dismiss="modal" class="btn pg-btn-cancel">Batal</button>
+          <button type="button" class="btn pg-btn-save btn-save"><i class="fe fe-save me-1"></i>Tambah Variasi</button>
+        </div>
+      </form>
     </div>
   </div>
+</div>

--- a/resources/views/components/modals/variant/add-variant.blade.php
+++ b/resources/views/components/modals/variant/add-variant.blade.php
@@ -1,3 +1,54 @@
+  <style>
+    /* Rapikan tampilan chip bootstrap-tagsinput khusus di modal Variasi — style global
+       .bootstrap-tagsinput (style.css) pakai display:flex tanpa flex-wrap + overflow-x:auto,
+       jadi chip yang kepanjangan ikut menyempit/wrap dua baris di dalam pill-nya sendiri
+       alih-alih pindah baris sebagai chip utuh. Di-scope ke #add_variant supaya penggunaan
+       bootstrap-tagsinput lain di luar modal ini tidak ikut berubah. */
+    #add_variant .bootstrap-tagsinput {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      align-content: flex-start;
+      gap: 8px;
+      overflow: visible;
+      min-height: 46px;
+      padding: 10px;
+      border: 1px solid #e2e8f0;
+      border-radius: 8px;
+      background: #fff;
+    }
+    #add_variant .bootstrap-tagsinput input {
+      flex: 1 1 140px;
+      min-width: 140px;
+      padding: 4px 2px;
+    }
+    #add_variant .bootstrap-tagsinput .tag {
+      display: inline-flex;
+      align-items: center;
+      flex: 0 0 auto;
+      white-space: nowrap;
+      margin: 0;
+      padding: 6px 10px;
+      border-radius: 999px;
+      font-size: 13px;
+      font-weight: 600;
+      line-height: 1.2;
+    }
+    #add_variant .bootstrap-tagsinput .tag [data-role="remove"] {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 18px;
+      height: 18px;
+      margin-left: 8px;
+      padding: 0;
+      border-radius: 50%;
+      background: rgba(255, 255, 255, .25);
+    }
+    #add_variant .bootstrap-tagsinput .tag [data-role="remove"]:after {
+      font-size: 10px;
+    }
+  </style>
   <div class="modal modal-lg custom-modal fade pg-modal--form" id="add_variant" role="dialog" data-bs-backdrop="static"
     data-bs-keyboard="false">
     <div class="modal-dialog modal-dialog-centered">

--- a/tests/Regression/DuplicateNameGuardTest.php
+++ b/tests/Regression/DuplicateNameGuardTest.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace Tests\Regression;
+
+use App\Models\Bank;
+use App\Models\CashCategory;
+use Tests\Support\ActingAsStaff;
+use Tests\TestCase;
+
+/**
+ * ✅ FIXED (GitHub #122, 2026-09-02): `Bank::insertBank()`/`updateBank()` and
+ * `CashCategory::insertCashCategory()`/`updateCashCategory()` had no uniqueness check at all —
+ * inserting (or renaming into) a name that already existed on another active row was silently
+ * accepted, so the same Bank Account / Kategori Kas name could exist multiple times. Both models
+ * now reject a duplicate name (case-insensitive, trimmed, scoped to active/`status=1` rows) with a
+ * 422 + message, matching the `response()->json(['message' => ...], 422)` convention used
+ * elsewhere in this codebase.
+ */
+class DuplicateNameGuardTest extends TestCase
+{
+    use ActingAsStaff;
+
+    public function test_inserting_a_bank_with_a_duplicate_name_is_rejected(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $bank = new Bank();
+        $bank->bank_kode = 'Regression Bank Dup';
+        $bank->status = 1;
+        $bank->save();
+
+        $response = $this->post('/insertBank', [
+            'bank_kode' => ' regression bank dup ',
+        ]);
+
+        $response->assertStatus(422);
+        $this->assertSame(1, Bank::where('bank_kode', 'Regression Bank Dup')->where('status', 1)->count());
+    }
+
+    public function test_updating_a_bank_into_another_banks_name_is_rejected(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $bankA = new Bank();
+        $bankA->bank_kode = 'Regression Bank A';
+        $bankA->status = 1;
+        $bankA->save();
+
+        $bankB = new Bank();
+        $bankB->bank_kode = 'Regression Bank B';
+        $bankB->status = 1;
+        $bankB->save();
+
+        $response = $this->post('/updateBank', [
+            'bank_id' => $bankB->bank_id,
+            'bank_kode' => 'Regression Bank A',
+        ]);
+
+        $response->assertStatus(422);
+        $bankB->refresh();
+        $this->assertSame('Regression Bank B', $bankB->bank_kode);
+    }
+
+    public function test_updating_a_bank_with_its_own_unchanged_name_still_works(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $bank = new Bank();
+        $bank->bank_kode = 'Regression Bank Self';
+        $bank->status = 1;
+        $bank->save();
+
+        $response = $this->post('/updateBank', [
+            'bank_id' => $bank->bank_id,
+            'bank_kode' => 'Regression Bank Self',
+        ]);
+
+        $response->assertStatus(200);
+    }
+
+    public function test_inserting_a_cash_category_with_a_duplicate_name_is_rejected(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $category = new CashCategory();
+        $category->cc_name = 'Regression Category Dup';
+        $category->cc_type = 'Keluar';
+        $category->status = 1;
+        $category->save();
+
+        $response = $this->post('/insertCashCategory', [
+            'cc_name' => ' regression category dup ',
+            'cc_type' => 'Masuk',
+        ]);
+
+        $response->assertStatus(422);
+        $this->assertSame(1, CashCategory::where('cc_name', 'Regression Category Dup')->where('status', 1)->count());
+    }
+
+    public function test_updating_a_cash_category_into_another_categorys_name_is_rejected(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $categoryA = new CashCategory();
+        $categoryA->cc_name = 'Regression Category A';
+        $categoryA->cc_type = 'Keluar';
+        $categoryA->status = 1;
+        $categoryA->save();
+
+        $categoryB = new CashCategory();
+        $categoryB->cc_name = 'Regression Category B';
+        $categoryB->cc_type = 'Masuk';
+        $categoryB->status = 1;
+        $categoryB->save();
+
+        $response = $this->post('/updateCashCategory', [
+            'cc_id' => $categoryB->cc_id,
+            'cc_name' => 'Regression Category A',
+            'cc_type' => 'Masuk',
+        ]);
+
+        $response->assertStatus(422);
+        $categoryB->refresh();
+        $this->assertSame('Regression Category B', $categoryB->cc_name);
+    }
+
+    public function test_a_soft_deleted_bank_name_can_be_reused(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $bank = new Bank();
+        $bank->bank_kode = 'Regression Bank Deleted';
+        $bank->status = 0; // sudah dihapus (soft delete)
+        $bank->save();
+
+        $response = $this->post('/insertBank', [
+            'bank_kode' => 'Regression Bank Deleted',
+        ]);
+
+        $response->assertStatus(200);
+    }
+}


### PR DESCRIPTION
## Summary
Fixes #122 — Bank Account and Kategori Kas allowed inserting/renaming into a name another active row already had, because there was no uniqueness check anywhere (app-level or DB-level).

## Changes
- `Bank::isDuplicateName()` / `CashCategory::isDuplicateName()` — case-insensitive, trimmed, scoped to active (`status=1`) rows, excludes the row's own id on update so a no-op rename still works.
- `insertBank`/`updateBank`/`insertCashCategory`/`updateCashCategory` return `422 + {message}` on a duplicate, matching the existing convention used elsewhere in the app.
- `Bank.js` / `Category_Cash.js` now surface that message via `notifikasi('error', ...)` on save failure instead of only `console.log`-ing it.
- `tests/Regression/DuplicateNameGuardTest.php` — 6 cases (duplicate insert rejected both modules, rename-into-another-row rejected both modules, unchanged self-rename still works, soft-deleted row's old name can be reused).
- Documented in `cdocs/testing/KNOWN_ISSUES.md`.

## Additional: popup UI refresh
Restyled the Tambah/Update popup modals for 5 simple master-data modules to match the existing "Tambah Tipe Gudang" modal look (gradient header + icon + subtitle, styled body, shared `pg-modal-footer`/`pg-btn-cancel`/`pg-btn-save` footer buttons) instead of the old plain `custom-modal` style:

- Bank Account (`add-bank.blade.php`)
- Master Kategori (`add-category.blade.php`)
- Master Satuan (`add-unit.blade.php`)
- Master Variasi (`add-variant.blade.php`)
- Akuntansi → Kategori Kas (`add-cash-category.blade.php`)

Field ids/classes (`.fill`, `.btn-save`, `.is-invalid`, `#bank_kode`, `#category_name`, `#unit_name`/`#unit_short_name`, `#variant_name`/`#variant_attribute`, `#cc_name`/`#cc_type`) are unchanged, so the existing `Bank.js`/`Category.js`/`Units.js`/`Variants.js`/`Category_Cash.js` keep working as-is — no JS changes needed for this part.

## Testing
- `php vendor/bin/phpunit tests/Regression/DuplicateNameGuardTest.php` — 6/6 pass
- `php vendor/bin/phpunit --testsuite=Regression` — all green (1 pre-existing skip, unrelated)
- `php vendor/bin/phpunit tests/Smoke/MasterSmokeTest.php tests/Smoke/AkuntansiLaporanSmokeTest.php` — restyled modal pages render 200 (1 pre-existing, unrelated failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Additional: Update Variasi chip layout
The variant-attribute tag chips (bootstrap-tagsinput) wrapped raggedly — long chip text wrapped onto 2 lines inside the pill itself instead of the whole chip moving to a new row, because the plugin's global CSS uses `display:flex` with no `flex-wrap` + `overflow-x:auto`. Added a scoped override under `#add_variant` (flex-wrap + gap on the container, fixed pill shape/padding, centered remove button) so chips lay out in a neat wrapping grid — scoped to this modal only, doesn't touch tagsinput elsewhere in the app.
