### PR TITLE
fix(role): confirm before detaching role from users on delete

### DIFF
--- a/app/Models/Role.php
+++ b/app/Models/Role.php
@@ -79,19 +79,33 @@ class Role extends Model
             return ['status' => -1, 'message' => 'Peran tidak ditemukan'];
         }
 
+        $force = filter_var($data['force'] ?? false, FILTER_VALIDATE_BOOLEAN);
+
         $staffCount = Staff::query()
             ->where('status', 1)
             ->where('role_id', $roleId)
             ->count();
-        if ($staffCount > 0) {
+
+        if ($staffCount > 0 && !$force) {
             return [
                 'status' => -1,
-                'message' => "Masih ada {$staffCount} pengguna yang memakai peran ini",
+                'need_confirmation' => true,
+                'staff_count' => $staffCount,
+                'message' => "Masih ada {$staffCount} pengguna yang memakai peran ini. Lepas peran dari pengguna tersebut dan hapus peran?",
             ];
         }
 
-        $t->status = 0;
-        $t->save();
+        \DB::transaction(function () use ($t, $roleId, $staffCount) {
+            if ($staffCount > 0) {
+                Staff::query()
+                    ->where('status', 1)
+                    ->where('role_id', $roleId)
+                    ->update(['role_id' => null]);
+            }
+
+            $t->status = 0;
+            $t->save();
+        });
 
         return 1;
     }

--- a/app/Models/Role.php
+++ b/app/Models/Role.php
@@ -21,9 +21,34 @@ class Role extends Model
         $result = self::where('status', '=', 1);
         if($data["role_name"]) $result->where('role_name','like','%'.$data["role_name"].'%');
         $result->orderBy('created_at', 'asc');
-       
+
         $result = $result->get();
+
+        $userCounts = Staff::query()
+            ->where('status', 1)
+            ->whereNotNull('role_id')
+            ->selectRaw('role_id, count(*) as total')
+            ->groupBy('role_id')
+            ->pluck('total', 'role_id');
+
+        foreach ($result as $role) {
+            $role->user_count = (int) ($userCounts[$role->role_id] ?? 0);
+        }
+
         return $result;
+    }
+
+    /**
+     * Daftar pengguna aktif yang memakai suatu peran, dipakai untuk
+     * mengisi tabel konfirmasi hapus peran (per-user pengalihan peran).
+     */
+    function getRoleUsers($roleId)
+    {
+        return Staff::query()
+            ->where('status', 1)
+            ->where('role_id', $roleId)
+            ->orderBy('staff_name')
+            ->get(['staff_id', 'staff_name']);
     }
 
     function insertRole($data)
@@ -79,28 +104,47 @@ class Role extends Model
             return ['status' => -1, 'message' => 'Peran tidak ditemukan'];
         }
 
-        $force = filter_var($data['force'] ?? false, FILTER_VALIDATE_BOOLEAN);
-
-        $staffCount = Staff::query()
+        $affectedStaff = Staff::query()
             ->where('status', 1)
             ->where('role_id', $roleId)
-            ->count();
+            ->get(['staff_id', 'role_id']);
 
-        if ($staffCount > 0 && !$force) {
+        if ($affectedStaff->count() > 0 && !array_key_exists('reassignments', $data)) {
             return [
                 'status' => -1,
                 'need_confirmation' => true,
-                'staff_count' => $staffCount,
-                'message' => "Masih ada {$staffCount} pengguna yang memakai peran ini. Lepas peran dari pengguna tersebut dan hapus peran?",
+                'staff_count' => $affectedStaff->count(),
+                'users' => (new self())->getRoleUsers($roleId),
+                'message' => "Masih ada {$affectedStaff->count()} pengguna yang memakai peran ini. Pilih peran pengganti untuk tiap pengguna (boleh dikosongkan), lalu hapus peran.",
             ];
         }
 
-        \DB::transaction(function () use ($t, $roleId, $staffCount) {
-            if ($staffCount > 0) {
-                Staff::query()
-                    ->where('status', 1)
-                    ->where('role_id', $roleId)
-                    ->update(['role_id' => null]);
+        $reassignments = $data['reassignments'] ?? [];
+        if (is_string($reassignments)) {
+            $decoded = json_decode($reassignments, true);
+            $reassignments = is_array($decoded) ? $decoded : [];
+        }
+        $validRoleIds = self::where('status', 1)->where('role_id', '!=', $roleId)->pluck('role_id')->all();
+
+        // staff_id => new_role_id (null diperbolehkan)
+        $reassignById = [];
+        foreach ($reassignments as $row) {
+            $staffId = (int) ($row['staff_id'] ?? 0);
+            if ($staffId <= 0) continue;
+            $newRoleId = $row['role_id'] ?? null;
+            $newRoleId = ($newRoleId === '' || $newRoleId === null) ? null : (int) $newRoleId;
+            if ($newRoleId !== null && !in_array($newRoleId, $validRoleIds, true)) {
+                $newRoleId = null; // abaikan peran pengganti yang tidak valid
+            }
+            $reassignById[$staffId] = $newRoleId;
+        }
+
+        \DB::transaction(function () use ($t, $affectedStaff, $reassignById) {
+            foreach ($affectedStaff as $staff) {
+                $staff->role_id = array_key_exists($staff->staff_id, $reassignById)
+                    ? $reassignById[$staff->staff_id]
+                    : null;
+                $staff->save();
             }
 
             $t->status = 0;

--- a/app/Models/Role.php
+++ b/app/Models/Role.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Support\RoleAccess;
 use App\Support\RoleIds;
 use Illuminate\Database\Eloquent\Model;
 
@@ -109,17 +110,24 @@ class Role extends Model
             ->where('role_id', $roleId)
             ->get(['staff_id', 'role_id']);
 
+        // GitHub #124: siapa yang boleh melihat/mengganti daftar pengguna terdampak
+        // mengikuti akses modul "Pengguna" milik SI PENGHAPUS peran, bukan "Peran &
+        // Perizinan" (yang dia jelas punya, karena sedang menghapus peran).
+        $currentUser = RoleAccess::userFromSession();
+        $canViewUsers = RoleAccess::can($currentUser, 'Pengguna', 'view');
+        $canEditUsers = RoleAccess::can($currentUser, 'Pengguna', 'edit');
+
         if ($affectedStaff->count() > 0 && !array_key_exists('reassignments', $data)) {
             return [
                 'status' => -1,
                 'need_confirmation' => true,
                 'staff_count' => $affectedStaff->count(),
-                'users' => (new self())->getRoleUsers($roleId),
+                'users' => $canViewUsers ? (new self())->getRoleUsers($roleId) : [],
                 'message' => "Masih ada {$affectedStaff->count()} pengguna yang memakai peran ini. Pilih peran pengganti untuk tiap pengguna (boleh dikosongkan), lalu hapus peran.",
             ];
         }
 
-        $reassignments = $data['reassignments'] ?? [];
+        $reassignments = $canEditUsers ? ($data['reassignments'] ?? []) : [];
         if (is_string($reassignments)) {
             $decoded = json_decode($reassignments, true);
             $reassignments = is_array($decoded) ? $decoded : [];

--- a/public/Custom_js/Backoffice/User/Role.js
+++ b/public/Custom_js/Backoffice/User/Role.js
@@ -2,6 +2,7 @@
     var table;
     var selectedRoleForWidgets = null;
     var protectedRoleIds = [1, 4, 7];
+    var latestRoles = [];
     $(document).ready(function(){
         inisialisasi();
         refreshRole();
@@ -35,6 +36,7 @@
             columns: [
                 { data: "role_id" },
                 { data: "role_name" },
+                { data: "user_count", class: "text-center" },
                 { data: "role_date" },
                 { data: "action", class: "d-flex align-items-center" },
             ],
@@ -55,10 +57,12 @@
                     e = e.original || [];
                 }
                 console.log(e);
-                table.clear().draw(); 
+                latestRoles = e;
+                table.clear().draw();
                 // Manipulasi data sebelum masuk ke tabel
                 for (let i = 0; i < e.length; i++) {
                     e[i].role_date = moment(e[i].created_at).format('D MMM YYYY');
+                    e[i].user_count = e[i].user_count || 0;
                     var rp = "";
                     if (hasAccessAction("Peran & Perizinan", "edit")) {
                         rp +=
@@ -216,28 +220,57 @@
         var data = $('#tableRole').DataTable().row($(this).parents('tr')).data();
         showModalDelete("Apakah yakin ingin menghapus peran ini?", "btn-delete-role");
         $('#btn-delete-role').attr("role_id", data.role_id);
-        $('#btn-delete-role').attr("force", "0");
+        $('#btn-delete-role').attr("role_name", data.role_name);
     });
 
-    function submitDeleteRole(force) {
+    function buildReassignRoleOptions(excludeRoleId) {
+        var options = '<option value="">— Tidak ada peran —</option>';
+        for (var i = 0; i < latestRoles.length; i++) {
+            var r = latestRoles[i];
+            if (parseInt(r.role_id, 10) === parseInt(excludeRoleId, 10)) continue;
+            options += '<option value="' + r.role_id + '">' + $('<div>').text(r.role_name).html() + '</option>';
+        }
+        return options;
+    }
+
+    function openReassignModal(roleId, roleName, users) {
+        $('#reassign_role_name').text(roleName || "-");
+        var optionsHtml = buildReassignRoleOptions(roleId);
+        var rows = '';
+        for (var i = 0; i < users.length; i++) {
+            var u = users[i];
+            rows +=
+                '<tr data-staff-id="' + u.staff_id + '">' +
+                '<td>' + $('<div>').text(u.staff_name).html() + '</td>' +
+                '<td><select class="form-select reassign-role-select">' + optionsHtml + '</select></td>' +
+                '</tr>';
+        }
+        $('#reassign_role_users_body').html(rows);
+        $('#btn-confirm-reassign-delete-role').attr("role_id", roleId);
+        $('#modalDelete').modal("hide");
+        $('#role_reassign_modal').modal("show");
+    }
+
+    function submitDeleteRole(roleId, reassignments) {
+        var payload = {
+            role_id: roleId,
+            _token: token
+        };
+        if (reassignments) payload.reassignments = reassignments;
+
         $.ajax({
             url: "/deleteRole",
-            data: {
-                role_id: $('#btn-delete-role').attr('role_id'),
-                force: force ? 1 : 0,
-                _token: token
-            },
+            data: payload,
             method: "post",
             success: function (e) {
                 if (e && e.status == -1) {
-                    $('.modal').modal("hide");
                     if (e.need_confirmation) {
-                        // Ada pengguna yang masih memakai peran ini, minta konfirmasi
-                        // untuk melepas peran dari pengguna tersebut sekaligus hapus peran.
-                        $('#btn-delete-role').attr("force", "1");
-                        showModalDelete(e.message, "btn-delete-role");
+                        // Ada pengguna yang masih memakai peran ini, minta pilihan
+                        // peran pengganti per pengguna sebelum benar-benar dihapus.
+                        openReassignModal(roleId, $('#btn-delete-role').attr('role_name'), e.users || []);
                         return;
                     }
+                    $('.modal').modal("hide");
                     notifikasi('error', "Gagal Delete", e.message || "Gagal hapus peran");
                     return;
                 }
@@ -254,8 +287,19 @@
     }
 
     $(document).on("click", "#btn-delete-role", function () {
-        var force = $(this).attr("force") === "1";
-        submitDeleteRole(force);
+        submitDeleteRole($(this).attr('role_id'), null);
+    });
+
+    $(document).on("click", "#btn-confirm-reassign-delete-role", function () {
+        var roleId = $(this).attr('role_id');
+        var reassignments = [];
+        $('#reassign_role_users_body tr').each(function () {
+            reassignments.push({
+                staff_id: $(this).data('staff-id'),
+                role_id: $(this).find('.reassign-role-select').val() || null
+            });
+        });
+        submitDeleteRole(roleId, JSON.stringify(reassignments));
     });
 
     $(document).on("click", "#btn_save_dash_widgets", function () {

--- a/public/Custom_js/Backoffice/User/Role.js
+++ b/public/Custom_js/Backoffice/User/Role.js
@@ -216,19 +216,28 @@
         var data = $('#tableRole').DataTable().row($(this).parents('tr')).data();
         showModalDelete("Apakah yakin ingin menghapus peran ini?", "btn-delete-role");
         $('#btn-delete-role').attr("role_id", data.role_id);
+        $('#btn-delete-role').attr("force", "0");
     });
 
-    $(document).on("click", "#btn-delete-role", function () {
+    function submitDeleteRole(force) {
         $.ajax({
             url: "/deleteRole",
             data: {
                 role_id: $('#btn-delete-role').attr('role_id'),
+                force: force ? 1 : 0,
                 _token: token
             },
             method: "post",
             success: function (e) {
                 if (e && e.status == -1) {
                     $('.modal').modal("hide");
+                    if (e.need_confirmation) {
+                        // Ada pengguna yang masih memakai peran ini, minta konfirmasi
+                        // untuk melepas peran dari pengguna tersebut sekaligus hapus peran.
+                        $('#btn-delete-role').attr("force", "1");
+                        showModalDelete(e.message, "btn-delete-role");
+                        return;
+                    }
                     notifikasi('error', "Gagal Delete", e.message || "Gagal hapus peran");
                     return;
                 }
@@ -242,6 +251,11 @@
                 notifikasi('error', "Gagal Delete", "Gagal hapus peran");
             }
         });
+    }
+
+    $(document).on("click", "#btn-delete-role", function () {
+        var force = $(this).attr("force") === "1";
+        submitDeleteRole(force);
     });
 
     $(document).on("click", "#btn_save_dash_widgets", function () {

--- a/public/Custom_js/Backoffice/User/Role.js
+++ b/public/Custom_js/Backoffice/User/Role.js
@@ -233,22 +233,43 @@
         return options;
     }
 
-    function openReassignModal(roleId, roleName, users) {
+    function openReassignModal(roleId, roleName, users, staffCount) {
         $('#reassign_role_name').text(roleName || "-");
-        var optionsHtml = buildReassignRoleOptions(roleId);
-        var rows = '';
-        for (var i = 0; i < users.length; i++) {
-            var u = users[i];
-            rows +=
-                '<tr data-staff-id="' + u.staff_id + '">' +
-                '<td>' + $('<div>').text(u.staff_name).html() + '</td>' +
-                '<td><select class="form-select reassign-role-select">' + optionsHtml + '</select></td>' +
-                '</tr>';
+
+        // Kontrol akses (GitHub #124): tanpa "Pengguna|view" daftar user tidak
+        // boleh ditampilkan sama sekali, hanya jumlahnya. Dengan "view" tapi
+        // tanpa "edit", daftar boleh tampil tapi kolom Peran Pengganti tidak
+        // (user tidak boleh mengubah peran pengguna lain tanpa akses edit).
+        var canViewUsers = hasAccessAction("Pengguna", "view");
+        var canEditUsers = hasAccessAction("Pengguna", "edit");
+
+        if (!canViewUsers) {
+            $('#reassign_no_access_count').text(staffCount != null ? staffCount : (users || []).length);
+            $('#reassign_no_access_notice').show();
+            $('#reassign_table_section').hide();
+            $('#reassign_role_users_body').html('');
+        } else {
+            $('#reassign_no_access_notice').hide();
+            $('#reassign_table_section').show();
+            $('#reassign_col_role_header').toggle(canEditUsers);
+
+            var optionsHtml = canEditUsers ? buildReassignRoleOptions(roleId) : '';
+            var rows = '';
+            for (var i = 0; i < users.length; i++) {
+                var u = users[i];
+                rows += '<tr data-staff-id="' + u.staff_id + '">';
+                rows += '<td>' + $('<div>').text(u.staff_name).html() + '</td>';
+                if (canEditUsers) {
+                    rows += '<td><select class="form-select reassign-role-select">' + optionsHtml + '</select></td>';
+                }
+                rows += '</tr>';
+            }
+            if (!rows) {
+                rows = '<tr class="pg-popup-table-empty"><td colspan="2">Tidak ada pengguna yang memakai peran ini.</td></tr>';
+            }
+            $('#reassign_role_users_body').html(rows);
         }
-        if (!rows) {
-            rows = '<tr class="pg-popup-table-empty"><td colspan="2">Tidak ada pengguna yang memakai peran ini.</td></tr>';
-        }
-        $('#reassign_role_users_body').html(rows);
+
         $('#btn-confirm-reassign-delete-role').attr("role_id", roleId);
         $('.modal').modal("hide");
         $('#role_reassign_modal').modal("show");
@@ -256,7 +277,8 @@
 
     // Dropdown peran pengganti dibuat searchable (select2), sama seperti pola
     // #staff_position di insertStaff.js — lokal, bukan AJAX, karena daftar
-    // peran sudah dimuat lewat refreshRole().
+    // peran sudah dimuat lewat refreshRole(). Hanya ada kalau user punya akses
+    // "Pengguna|edit" (lihat openReassignModal).
     $('#role_reassign_modal').on('shown.bs.modal', function () {
         $('#reassign_role_users_body .reassign-role-select').each(function () {
             if (!$(this).hasClass('select2-hidden-accessible')) {
@@ -292,7 +314,7 @@
                     if (e.need_confirmation) {
                         // Ada pengguna yang masih memakai peran ini, minta pilihan
                         // peran pengganti per pengguna sebelum benar-benar dihapus.
-                        openReassignModal(roleId, $('#btn-delete-role').attr('role_name'), e.users || []);
+                        openReassignModal(roleId, $('#btn-delete-role').attr('role_name'), e.users || [], e.staff_count);
                         return;
                     }
                     $('.modal').modal("hide");

--- a/public/Custom_js/Backoffice/User/Role.js
+++ b/public/Custom_js/Backoffice/User/Role.js
@@ -245,13 +245,16 @@
 
         if (!canViewUsers) {
             $('#reassign_no_access_count').text(staffCount != null ? staffCount : (users || []).length);
-            $('#reassign_no_access_notice').show();
-            $('#reassign_table_section').hide();
+            // NB: pakai toggleClass('d-none'), bukan .show()/.hide() — elemen ini
+            // punya class Bootstrap "d-flex" (display:flex !important) yang menang
+            // atas inline style non-!important yang dipasang .show()/.hide().
+            $('#reassign_no_access_notice').removeClass('d-none');
+            $('#reassign_table_section').addClass('d-none');
             $('#reassign_role_users_body').html('');
         } else {
-            $('#reassign_no_access_notice').hide();
-            $('#reassign_table_section').show();
-            $('#reassign_col_role_header').toggle(canEditUsers);
+            $('#reassign_no_access_notice').addClass('d-none');
+            $('#reassign_table_section').removeClass('d-none');
+            $('#reassign_col_role_header').toggleClass('d-none', !canEditUsers);
 
             var optionsHtml = canEditUsers ? buildReassignRoleOptions(roleId) : '';
             var rows = '';

--- a/public/Custom_js/Backoffice/User/Role.js
+++ b/public/Custom_js/Backoffice/User/Role.js
@@ -245,11 +245,36 @@
                 '<td><select class="form-select reassign-role-select">' + optionsHtml + '</select></td>' +
                 '</tr>';
         }
+        if (!rows) {
+            rows = '<tr class="pg-popup-table-empty"><td colspan="2">Tidak ada pengguna yang memakai peran ini.</td></tr>';
+        }
         $('#reassign_role_users_body').html(rows);
         $('#btn-confirm-reassign-delete-role').attr("role_id", roleId);
-        $('#modalDelete').modal("hide");
+        $('.modal').modal("hide");
         $('#role_reassign_modal').modal("show");
     }
+
+    // Dropdown peran pengganti dibuat searchable (select2), sama seperti pola
+    // #staff_position di insertStaff.js — lokal, bukan AJAX, karena daftar
+    // peran sudah dimuat lewat refreshRole().
+    $('#role_reassign_modal').on('shown.bs.modal', function () {
+        $('#reassign_role_users_body .reassign-role-select').each(function () {
+            if (!$(this).hasClass('select2-hidden-accessible')) {
+                $(this).select2({
+                    placeholder: "Pilih Peran Pengganti",
+                    allowClear: true,
+                    width: "100%",
+                    dropdownParent: $('body'),
+                });
+            }
+        });
+    });
+
+    $('#role_reassign_modal').on('hidden.bs.modal', function () {
+        $('#reassign_role_users_body .reassign-role-select.select2-hidden-accessible').each(function () {
+            $(this).select2("destroy");
+        });
+    });
 
     function submitDeleteRole(roleId, reassignments) {
         var payload = {

--- a/resources/views/Backoffice/User/Role.blade.php
+++ b/resources/views/Backoffice/User/Role.blade.php
@@ -22,6 +22,7 @@
                                         <tr>
                                             <th>ID</th>
                                             <th>Nama Peran</th>
+                                            <th>Jumlah Pengguna</th>
                                             <th>Dibuat Pada</th>
                                             <th class="no-sort">Aksi</th>
                                         </tr>
@@ -122,6 +123,39 @@
                 <div class="modal-footer">
                     <button type="button" class="btn btn-secondary me-2" data-bs-dismiss="modal">Batal</button>
                     <button type="button" class="btn btn-primary" id="btn_save_dash_widgets">Simpan Widget</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="modal fade" id="role_reassign_modal" tabindex="-1" aria-hidden="true" data-bs-backdrop="static" data-bs-keyboard="false">
+        <div class="modal-dialog modal-lg modal-dialog-centered">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Hapus Peran "<span id="reassign_role_name">-</span>"</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <p class="mb-3" id="reassign_role_message">
+                        Peran ini masih dipakai oleh beberapa pengguna. Pilih peran pengganti untuk tiap
+                        pengguna (boleh dikosongkan bila tidak ingin diberi peran lain), lalu hapus peran.
+                    </p>
+                    <div class="table-responsive">
+                        <table class="table table-bordered mb-0">
+                            <thead class="thead-light">
+                                <tr>
+                                    <th>Nama Pengguna</th>
+                                    <th style="min-width: 220px;">Peran Pengganti</th>
+                                </tr>
+                            </thead>
+                            <tbody id="reassign_role_users_body">
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary me-2" data-bs-dismiss="modal">Batal</button>
+                    <button type="button" class="btn btn-danger" id="btn-confirm-reassign-delete-role">Lepas & Hapus Peran</button>
                 </div>
             </div>
         </div>

--- a/resources/views/Backoffice/User/Role.blade.php
+++ b/resources/views/Backoffice/User/Role.blade.php
@@ -159,7 +159,7 @@
                     <div class="p-4">
                         <!-- Tanpa akses "Pengguna|view": daftar user tidak boleh ditampilkan,
                              cukup jumlahnya saja. -->
-                        <div id="reassign_no_access_notice" class="d-none d-flex align-items-start gap-2 p-3 mb-4 rounded border"
+                        <div id="reassign_no_access_notice" class="d-none d-flex align-items-start gap-2 p-3 rounded border"
                             style="background:#fff7ed; border-color:#fed7aa !important;">
                             <i class="fe fe-alert-triangle text-warning mt-1"></i>
                             <div style="font-size:13px; color:#334155;">

--- a/resources/views/Backoffice/User/Role.blade.php
+++ b/resources/views/Backoffice/User/Role.blade.php
@@ -157,26 +157,39 @@
                 </div>
                 <div class="modal-body p-0 bg-light">
                     <div class="p-4">
-                        <div class="d-flex align-items-center gap-2 mb-3">
-                            <i class="fe fe-users text-primary"></i>
-                            <span class="fw-bold text-dark" style="font-size:14px;">Pengguna yang memakai peran ini</span>
+                        <!-- Tanpa akses "Pengguna|view": daftar user tidak boleh ditampilkan,
+                             cukup jumlahnya saja. -->
+                        <div id="reassign_no_access_notice" class="d-flex align-items-start gap-2 p-3 rounded border"
+                            style="display:none; background:#fff7ed; border-color:#fed7aa !important;">
+                            <i class="fe fe-alert-triangle text-warning mt-1"></i>
+                            <div style="font-size:13px; color:#334155;">
+                                Peran ini masih dipakai oleh <strong id="reassign_no_access_count">0</strong> pengguna.
+                                Menghapus peran akan melepas peran tersebut dari pengguna-pengguna itu.
+                            </div>
                         </div>
-                        <div class="table-responsive rounded border bg-white">
-                            <table class="table table-center custom-table-scroll mb-0" id="tableReassignRoleUsers">
-                                <thead style="background: #f1f5f9;">
-                                    <tr>
-                                        <th style="width: 45%; padding: 12px 16px; color: #64748b; font-size: 11px; font-weight: 700; text-transform: uppercase;">
-                                            Nama Pengguna</th>
-                                        <th style="width: 55%; padding: 12px 16px; color: #64748b; font-size: 11px; font-weight: 700; text-transform: uppercase;">
-                                            Peran Pengganti</th>
-                                    </tr>
-                                </thead>
-                                <tbody id="reassign_role_users_body">
-                                    <tr class="pg-popup-table-empty">
-                                        <td colspan="2">Memuat daftar pengguna...</td>
-                                    </tr>
-                                </tbody>
-                            </table>
+
+                        <div id="reassign_table_section">
+                            <div class="d-flex align-items-center gap-2 mb-3">
+                                <i class="fe fe-users text-primary"></i>
+                                <span class="fw-bold text-dark" style="font-size:14px;">Pengguna yang memakai peran ini</span>
+                            </div>
+                            <div class="table-responsive rounded border bg-white">
+                                <table class="table table-center custom-table-scroll mb-0" id="tableReassignRoleUsers">
+                                    <thead style="background: #f1f5f9;">
+                                        <tr>
+                                            <th id="reassign_col_name_header" style="width: 45%; padding: 12px 16px; color: #64748b; font-size: 11px; font-weight: 700; text-transform: uppercase;">
+                                                Nama Pengguna</th>
+                                            <th id="reassign_col_role_header" style="width: 55%; padding: 12px 16px; color: #64748b; font-size: 11px; font-weight: 700; text-transform: uppercase;">
+                                                Peran Pengganti</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody id="reassign_role_users_body">
+                                        <tr class="pg-popup-table-empty">
+                                            <td colspan="2">Memuat daftar pengguna...</td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/resources/views/Backoffice/User/Role.blade.php
+++ b/resources/views/Backoffice/User/Role.blade.php
@@ -159,7 +159,7 @@
                     <div class="p-4">
                         <!-- Tanpa akses "Pengguna|view": daftar user tidak boleh ditampilkan,
                              cukup jumlahnya saja. -->
-                        <div id="reassign_no_access_notice" class="d-flex align-items-start gap-2 p-3 rounded border"
+                        <div id="reassign_no_access_notice" class="d-flex align-items-start gap-2 p-3 mb-4 rounded border"
                             style="display:none; background:#fff7ed; border-color:#fed7aa !important;">
                             <i class="fe fe-alert-triangle text-warning mt-1"></i>
                             <div style="font-size:13px; color:#334155;">

--- a/resources/views/Backoffice/User/Role.blade.php
+++ b/resources/views/Backoffice/User/Role.blade.php
@@ -128,34 +128,63 @@
         </div>
     </div>
 
-    <div class="modal fade" id="role_reassign_modal" tabindex="-1" aria-hidden="true" data-bs-backdrop="static" data-bs-keyboard="false">
-        <div class="modal-dialog modal-lg modal-dialog-centered">
+    <style>
+        /* Select2 peran-pengganti di-append ke body (dropdownParent) supaya tidak
+           kepotong overflow modal — samakan pola dengan add-production.blade.php. */
+        #role_reassign_modal .select2-dropdown {
+            z-index: 1065 !important;
+        }
+        #tableReassignRoleUsers tbody td {
+            padding: 10px 16px;
+            vertical-align: middle;
+        }
+    </style>
+    <div class="modal custom-modal fade pg-modal--danger" id="role_reassign_modal" aria-modal="true" role="dialog"
+        tabindex="-1" data-bs-backdrop="static" data-bs-focus="false">
+        <div class="modal-dialog modal-dialog-centered modal-lg">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title">Hapus Peran "<span id="reassign_role_name">-</span>"</h5>
-                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                    <div class="d-flex align-items-center gap-3">
+                        <div class="pg-modal-icon">
+                            <i class="fe fe-trash-2"></i>
+                        </div>
+                        <div>
+                            <h5 class="mb-0 modal-title">Hapus Peran "<span id="reassign_role_name">-</span>"</h5>
+                            <small class="modal-subtitle">Pilih peran pengganti untuk tiap pengguna sebelum peran ini dihapus</small>
+                        </div>
+                    </div>
+                    <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
-                <div class="modal-body">
-                    <p class="mb-3" id="reassign_role_message">
-                        Peran ini masih dipakai oleh beberapa pengguna. Pilih peran pengganti untuk tiap
-                        pengguna (boleh dikosongkan bila tidak ingin diberi peran lain), lalu hapus peran.
-                    </p>
-                    <div class="table-responsive">
-                        <table class="table table-bordered mb-0">
-                            <thead class="thead-light">
-                                <tr>
-                                    <th>Nama Pengguna</th>
-                                    <th style="min-width: 220px;">Peran Pengganti</th>
-                                </tr>
-                            </thead>
-                            <tbody id="reassign_role_users_body">
-                            </tbody>
-                        </table>
+                <div class="modal-body p-0 bg-light">
+                    <div class="p-4">
+                        <div class="d-flex align-items-center gap-2 mb-3">
+                            <i class="fe fe-users text-primary"></i>
+                            <span class="fw-bold text-dark" style="font-size:14px;">Pengguna yang memakai peran ini</span>
+                        </div>
+                        <div class="table-responsive rounded border bg-white">
+                            <table class="table table-center custom-table-scroll mb-0" id="tableReassignRoleUsers">
+                                <thead style="background: #f1f5f9;">
+                                    <tr>
+                                        <th style="width: 45%; padding: 12px 16px; color: #64748b; font-size: 11px; font-weight: 700; text-transform: uppercase;">
+                                            Nama Pengguna</th>
+                                        <th style="width: 55%; padding: 12px 16px; color: #64748b; font-size: 11px; font-weight: 700; text-transform: uppercase;">
+                                            Peran Pengganti</th>
+                                    </tr>
+                                </thead>
+                                <tbody id="reassign_role_users_body">
+                                    <tr class="pg-popup-table-empty">
+                                        <td colspan="2">Memuat daftar pengguna...</td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
                     </div>
                 </div>
-                <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary me-2" data-bs-dismiss="modal">Batal</button>
-                    <button type="button" class="btn btn-danger" id="btn-confirm-reassign-delete-role">Lepas & Hapus Peran</button>
+                <div class="modal-footer pg-modal-footer">
+                    <button type="button" data-bs-dismiss="modal" class="btn pg-btn-cancel btn-cancel">Batal</button>
+                    <button type="button" class="btn pg-btn-confirm pg-btn-confirm--danger" id="btn-confirm-reassign-delete-role">
+                        <i class="fe fe-trash-2"></i> Lepas & Hapus Peran
+                    </button>
                 </div>
             </div>
         </div>

--- a/resources/views/Backoffice/User/Role.blade.php
+++ b/resources/views/Backoffice/User/Role.blade.php
@@ -159,8 +159,8 @@
                     <div class="p-4">
                         <!-- Tanpa akses "Pengguna|view": daftar user tidak boleh ditampilkan,
                              cukup jumlahnya saja. -->
-                        <div id="reassign_no_access_notice" class="d-flex align-items-start gap-2 p-3 mb-4 rounded border"
-                            style="display:none; background:#fff7ed; border-color:#fed7aa !important;">
+                        <div id="reassign_no_access_notice" class="d-none d-flex align-items-start gap-2 p-3 mb-4 rounded border"
+                            style="background:#fff7ed; border-color:#fed7aa !important;">
                             <i class="fe fe-alert-triangle text-warning mt-1"></i>
                             <div style="font-size:13px; color:#334155;">
                                 Peran ini masih dipakai oleh <strong id="reassign_no_access_count">0</strong> pengguna.


### PR DESCRIPTION
## Summary
Requirement issue #124 diperjelas: konfirmasi hapus peran yang masih dipakai user sekarang menampilkan **tabel per-user** dengan dropdown peran pengganti (boleh dikosongkan), bukan sekadar lepas semua ke null. Tabel Peran & Perizinan juga dapat kolom baru "Jumlah Pengguna" antara Nama Peran dan Dibuat Pada.

## Changes
- `app/Models/Role.php`
  - `getRole()`: melampirkan `user_count` (jumlah staff aktif) per role, dipakai kolom baru di tabel.
  - `getRoleUsers()`: daftar staff aktif yang memakai suatu role, dipakai untuk mengisi tabel konfirmasi.
  - `deleteRole()`: kalau masih ada user memakai role dan belum ada `reassignments`, kembalikan `need_confirmation` + daftar user. Kalau sudah ada `reassignments` (staff_id → role_id baru, boleh null, divalidasi terhadap role aktif), terapkan tiap pengalihan lalu nonaktifkan role — semua dalam satu transaksi.
- `resources/views/Backoffice/User/Role.blade.php`: kolom "Jumlah Pengguna" baru + modal `role_reassign_modal` berisi tabel nama pengguna + dropdown peran pengganti per baris.
- `public/Custom_js/Backoffice/User/Role.js`: alur hapus dua-langkah — konfirmasi umum dulu, lalu jika backend minta reassignment, tampilkan modal tabel dengan dropdown per user (opsi diambil dari daftar role aktif, role yang sedang dihapus dikecualikan), dan submit ulang dengan payload `reassignments`.

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)