### PR TITLE
fix(confirm): color cancel/delete/reject confirmation buttons red

### DIFF
--- a/public/Custom_js/Backoffice/Customers/Customer_Product_Return.js
+++ b/public/Custom_js/Backoffice/Customers/Customer_Product_Return.js
@@ -620,6 +620,7 @@
             showCancelButton: true,
             confirmButtonText: "Ya, lanjutkan",
             cancelButtonText: "Batal",
+            confirmButtonColor: action === "accept" ? undefined : "#dc2626",
         }).then(function (result) {
             if (!result.isConfirmed) return;
             $.post("/customerProductReturns/" + id + "/" + action, { _token: csrf() })

--- a/public/Custom_js/Backoffice/Customers/Customer_Product_Return.js
+++ b/public/Custom_js/Backoffice/Customers/Customer_Product_Return.js
@@ -778,15 +778,17 @@
         $(document).on("click", ".cpr-edit", function () { openRecord($(this).data("id"), "edit"); });
         $(document).on("click", ".cpr-delete", function () {
             var id = $(this).data("id");
-            Swal.fire({ icon: "warning", title: "Hapus pengembalian produk?", showCancelButton: true, confirmButtonText: "Hapus", confirmButtonColor: "#dc2626" })
-                .then(function (result) {
-                    if (!result.isConfirmed) return;
-                    $.post("/customerProductReturns/" + id + "/delete", { _token: csrf() })
-                        .done(function (response) {
-                            toastr.success(response.message);
-                            cprTable.ajax.reload(null, false);
-                        }).fail(notifyError);
-                });
+            showModalDelete("Hapus pengembalian produk ini?", "btn-delete-customer-product-return");
+            $("#btn-delete-customer-product-return").attr("data-id", id);
+        });
+        $(document).on("click", "#btn-delete-customer-product-return", function () {
+            var id = $(this).attr("data-id");
+            $.post("/customerProductReturns/" + id + "/delete", { _token: csrf() })
+                .done(function (response) {
+                    $(".modal").modal("hide");
+                    toastr.success(response.message);
+                    cprTable.ajax.reload(null, false);
+                }).fail(notifyError);
         });
         $("#cpr-accept").on("click", function () { processRecord($("#cpr-id").val(), "accept", "ACC pengembalian produk?"); });
         $("#cpr-decline").on("click", function () { processRecord($("#cpr-id").val(), "decline", "Tolak pengembalian produk?"); });

--- a/public/Custom_js/Backoffice/Customers/Customer_Product_Return.js
+++ b/public/Custom_js/Backoffice/Customers/Customer_Product_Return.js
@@ -777,7 +777,7 @@
         $(document).on("click", ".cpr-edit", function () { openRecord($(this).data("id"), "edit"); });
         $(document).on("click", ".cpr-delete", function () {
             var id = $(this).data("id");
-            Swal.fire({ icon: "warning", title: "Hapus pengembalian produk?", showCancelButton: true, confirmButtonText: "Hapus" })
+            Swal.fire({ icon: "warning", title: "Hapus pengembalian produk?", showCancelButton: true, confirmButtonText: "Hapus", confirmButtonColor: "#dc2626" })
                 .then(function (result) {
                     if (!result.isConfirmed) return;
                     $.post("/customerProductReturns/" + id + "/delete", { _token: csrf() })

--- a/public/Custom_js/Backoffice/Customers/Customer_Return.js
+++ b/public/Custom_js/Backoffice/Customers/Customer_Return.js
@@ -1404,6 +1404,11 @@
             return;
         }
         $("#customer-return-modal").modal("hide");
+        if (action === "decline") {
+            $("#modalKonfirmasi .btn-konfirmasi")
+                .removeClass("btn-success pg-btn-confirm")
+                .addClass("btn-danger pg-btn-confirm--danger");
+        }
         showModalKonfirmasi(detail, btnId);
         $("#" + btnId)
             .attr("data-key", key)

--- a/public/Custom_js/Backoffice/Customers/Customer_Return.js
+++ b/public/Custom_js/Backoffice/Customers/Customer_Return.js
@@ -1755,15 +1755,17 @@
         $(document).on("click", ".cr-edit", function () { openRecord($(this).data("key"), "edit"); });
         $(document).on("click", ".cr-delete", function () {
             var key = $(this).data("key");
-            Swal.fire({ icon: "warning", title: "Hapus pengembalian?", showCancelButton: true, confirmButtonText: "Hapus", confirmButtonColor: "#dc2626" })
-                .then(function (result) {
-                    if (!result.isConfirmed) return;
-                    $.post("/customerReturns/" + encodeURIComponent(key) + "/delete", { _token: csrf() })
-                        .done(function (response) {
-                            if (typeof toastr !== "undefined") toastr.success(response.message);
-                            refreshCustomerReturn();
-                        }).fail(notifyError);
-                });
+            showModalDelete("Hapus pengembalian ini?", "btn-delete-customer-return");
+            $("#btn-delete-customer-return").attr("data-key", key);
+        });
+        $(document).on("click", "#btn-delete-customer-return", function () {
+            var key = $(this).attr("data-key");
+            $.post("/customerReturns/" + encodeURIComponent(key) + "/delete", { _token: csrf() })
+                .done(function (response) {
+                    $(".modal").modal("hide");
+                    if (typeof toastr !== "undefined") toastr.success(response.message);
+                    refreshCustomerReturn();
+                }).fail(notifyError);
         });
         $("#cr-accept").on("click", function () { processRecord($("#cr-doc-key").val(), "accept", "ACC pengembalian?"); });
         $("#cr-decline").on("click", function () { processRecord($("#cr-doc-key").val(), "decline", "Tolak pengembalian?"); });

--- a/public/Custom_js/Backoffice/Customers/Customer_Return.js
+++ b/public/Custom_js/Backoffice/Customers/Customer_Return.js
@@ -1396,6 +1396,7 @@
                     showCancelButton: true,
                     confirmButtonText: "Ya, lanjutkan",
                     cancelButtonText: "Batal",
+                    confirmButtonColor: action === "accept" ? undefined : "#dc2626",
                 }).then(function (result) {
                     if (!result.isConfirmed) return;
                     postProcessRecord(key, action, null);
@@ -1754,7 +1755,7 @@
         $(document).on("click", ".cr-edit", function () { openRecord($(this).data("key"), "edit"); });
         $(document).on("click", ".cr-delete", function () {
             var key = $(this).data("key");
-            Swal.fire({ icon: "warning", title: "Hapus pengembalian?", showCancelButton: true, confirmButtonText: "Hapus" })
+            Swal.fire({ icon: "warning", title: "Hapus pengembalian?", showCancelButton: true, confirmButtonText: "Hapus", confirmButtonColor: "#dc2626" })
                 .then(function (result) {
                     if (!result.isConfirmed) return;
                     $.post("/customerReturns/" + encodeURIComponent(key) + "/delete", { _token: csrf() })

--- a/public/Custom_js/Backoffice/Customers/Customer_Return.js
+++ b/public/Custom_js/Backoffice/Customers/Customer_Return.js
@@ -1404,12 +1404,7 @@
             return;
         }
         $("#customer-return-modal").modal("hide");
-        if (action === "decline") {
-            $("#modalKonfirmasi .btn-konfirmasi")
-                .removeClass("btn-success pg-btn-confirm")
-                .addClass("btn-danger pg-btn-confirm--danger");
-        }
-        showModalKonfirmasi(detail, btnId);
+        showModalKonfirmasi(detail, btnId, action === "decline");
         $("#" + btnId)
             .attr("data-key", key)
             .attr("data-action", action);

--- a/public/Custom_js/Backoffice/Customers/Customer_Supply_Return.js
+++ b/public/Custom_js/Backoffice/Customers/Customer_Supply_Return.js
@@ -545,6 +545,7 @@
             showCancelButton: true,
             confirmButtonText: "Ya, lanjutkan",
             cancelButtonText: "Batal",
+            confirmButtonColor: action === "accept" ? undefined : "#dc2626",
         }).then(function (result) {
             if (!result.isConfirmed) return;
             $.post("/customerSupplyReturns/" + id + "/" + action, { _token: csrf() })

--- a/public/Custom_js/Backoffice/Customers/Customer_Supply_Return.js
+++ b/public/Custom_js/Backoffice/Customers/Customer_Supply_Return.js
@@ -704,15 +704,17 @@
         $(document).on("click", ".csr-edit", function () { openRecord($(this).data("id"), "edit"); });
         $(document).on("click", ".csr-delete", function () {
             var id = $(this).data("id");
-            Swal.fire({ icon: "warning", title: "Hapus pengembalian?", showCancelButton: true, confirmButtonText: "Hapus", confirmButtonColor: "#dc2626" })
-                .then(function (result) {
-                    if (!result.isConfirmed) return;
-                    $.post("/customerSupplyReturns/" + id + "/delete", { _token: csrf() })
-                        .done(function (response) {
-                            toastr.success(response.message);
-                            csrTable.ajax.reload(null, false);
-                        }).fail(notifyError);
-                });
+            showModalDelete("Hapus pengembalian ini?", "btn-delete-customer-supply-return");
+            $("#btn-delete-customer-supply-return").attr("data-id", id);
+        });
+        $(document).on("click", "#btn-delete-customer-supply-return", function () {
+            var id = $(this).attr("data-id");
+            $.post("/customerSupplyReturns/" + id + "/delete", { _token: csrf() })
+                .done(function (response) {
+                    $(".modal").modal("hide");
+                    toastr.success(response.message);
+                    csrTable.ajax.reload(null, false);
+                }).fail(notifyError);
         });
         $("#csr-accept").on("click", function () { processRecord($("#csr-id").val(), "accept", "ACC pengembalian bahan?"); });
         $("#csr-decline").on("click", function () { processRecord($("#csr-id").val(), "decline", "Tolak pengembalian bahan?"); });

--- a/public/Custom_js/Backoffice/Customers/Customer_Supply_Return.js
+++ b/public/Custom_js/Backoffice/Customers/Customer_Supply_Return.js
@@ -703,7 +703,7 @@
         $(document).on("click", ".csr-edit", function () { openRecord($(this).data("id"), "edit"); });
         $(document).on("click", ".csr-delete", function () {
             var id = $(this).data("id");
-            Swal.fire({ icon: "warning", title: "Hapus pengembalian?", showCancelButton: true, confirmButtonText: "Hapus" })
+            Swal.fire({ icon: "warning", title: "Hapus pengembalian?", showCancelButton: true, confirmButtonText: "Hapus", confirmButtonColor: "#dc2626" })
                 .then(function (result) {
                     if (!result.isConfirmed) return;
                     $.post("/customerSupplyReturns/" + id + "/delete", { _token: csrf() })

--- a/public/Custom_js/Backoffice/Inventory/Stock_Transfer.js
+++ b/public/Custom_js/Backoffice/Inventory/Stock_Transfer.js
@@ -99,10 +99,15 @@ function restoreTransferOverlayIfNeeded() {
 }
 
 /** Konfirmasi di atas detail ST / accept: hide parent → show konfirmasi; cancel → buka lagi parent. */
-function showTransferModalKonfirmasi(text, buttonId, dataId, parentSelector) {
+function showTransferModalKonfirmasi(text, buttonId, dataId, parentSelector, danger) {
     transferOverlayState.done = false;
     var wasOpen = beginTransferOverlay(parentSelector || "#add_stock_transfer");
     function openConfirm() {
+        if (danger) {
+            $("#modalKonfirmasi .btn-konfirmasi")
+                .removeClass("btn-success pg-btn-confirm")
+                .addClass("btn-danger pg-btn-confirm--danger");
+        }
         if (typeof showModalKonfirmasi === "function") {
             showModalKonfirmasi(text, buttonId);
         }
@@ -3611,7 +3616,9 @@ $(document).on("click", ".btn-reject-transfer", function () {
             ? "Tolak transfer ini? Status menjadi Cancel dan proses approval/Kirim dihentikan."
             : "Cancel transfer pending ini? Status menjadi Cancel (stok belum dipotong).",
         "btn-reject-stock-transfer",
-        id
+        id,
+        null,
+        true
     );
 });
 
@@ -3962,7 +3969,9 @@ $(document).on("click", ".btnDeleteTransfer", function () {
         showTransferModalKonfirmasi(
             "Cancel request stock transfer ini? Status menjadi Cancel.",
             "btn-reject-stock-transfer",
-            id
+            id,
+            null,
+            true
         );
         return;
     }
@@ -4089,6 +4098,9 @@ $(document).on("click", ".btnRejectTransfer, .btnRejectProductionTransfer", func
         $("#reject_production_transfer").modal("show");
         return;
     }
+    $("#modalKonfirmasi .btn-konfirmasi")
+        .removeClass("btn-success pg-btn-confirm")
+        .addClass("btn-danger pg-btn-confirm--danger");
     showModalKonfirmasi(
         "Cancel transfer pending ini? Status menjadi Cancel.",
         "btn-reject-stock-transfer"

--- a/public/Custom_js/Backoffice/Inventory/Stock_Transfer.js
+++ b/public/Custom_js/Backoffice/Inventory/Stock_Transfer.js
@@ -103,13 +103,8 @@ function showTransferModalKonfirmasi(text, buttonId, dataId, parentSelector, dan
     transferOverlayState.done = false;
     var wasOpen = beginTransferOverlay(parentSelector || "#add_stock_transfer");
     function openConfirm() {
-        if (danger) {
-            $("#modalKonfirmasi .btn-konfirmasi")
-                .removeClass("btn-success pg-btn-confirm")
-                .addClass("btn-danger pg-btn-confirm--danger");
-        }
         if (typeof showModalKonfirmasi === "function") {
-            showModalKonfirmasi(text, buttonId);
+            showModalKonfirmasi(text, buttonId, danger);
         }
         // Harus SETELAH showModalKonfirmasi (button id baru di-assign di situ)
         if (dataId != null && dataId !== "") {
@@ -4098,12 +4093,10 @@ $(document).on("click", ".btnRejectTransfer, .btnRejectProductionTransfer", func
         $("#reject_production_transfer").modal("show");
         return;
     }
-    $("#modalKonfirmasi .btn-konfirmasi")
-        .removeClass("btn-success pg-btn-confirm")
-        .addClass("btn-danger pg-btn-confirm--danger");
     showModalKonfirmasi(
         "Cancel transfer pending ini? Status menjadi Cancel.",
-        "btn-reject-stock-transfer"
+        "btn-reject-stock-transfer",
+        true
     );
     $("#modalKonfirmasi #btn-reject-stock-transfer").attr("data-id", id);
 });

--- a/public/Custom_js/Backoffice/Synchronization/Wizard.js
+++ b/public/Custom_js/Backoffice/Synchronization/Wizard.js
@@ -54,6 +54,9 @@
 
         $('.sync-review-list').on('click', '.btn-review-discard', function () {
             var btn = $(this);
+            $('#modalKonfirmasi .btn-konfirmasi')
+                .removeClass('btn-success pg-btn-confirm')
+                .addClass('btn-danger pg-btn-confirm--danger');
             showModalKonfirmasi(
                 'Abaikan armada #' + btn.data('ref-armada-id') + ' ini? Tindakan ini permanen — '
                     + 'tidak akan ditawarkan lagi pada sinkronisasi berikutnya.',

--- a/public/Custom_js/Backoffice/Synchronization/Wizard.js
+++ b/public/Custom_js/Backoffice/Synchronization/Wizard.js
@@ -54,13 +54,11 @@
 
         $('.sync-review-list').on('click', '.btn-review-discard', function () {
             var btn = $(this);
-            $('#modalKonfirmasi .btn-konfirmasi')
-                .removeClass('btn-success pg-btn-confirm')
-                .addClass('btn-danger pg-btn-confirm--danger');
             showModalKonfirmasi(
                 'Abaikan armada #' + btn.data('ref-armada-id') + ' ini? Tindakan ini permanen — '
                     + 'tidak akan ditawarkan lagi pada sinkronisasi berikutnya.',
-                'btn-armada-discard-confirm'
+                'btn-armada-discard-confirm',
+                true
             );
             $('#modalKonfirmasi #btn-armada-discard-confirm')
                 .attr('data-step', btn.data('step'))

--- a/public/Custom_js/Backoffice/Warehouse/Warehouse.js
+++ b/public/Custom_js/Backoffice/Warehouse/Warehouse.js
@@ -634,10 +634,7 @@ $(document).on("click", "#btn-delete-warehouse", function () {
                 $("#modalKonfirmasi .modal-title").text(
                     "Konfirmasi Hapus Lanjutan",
                 );
-                $("#modalKonfirmasi .btn-konfirmasi")
-                    .removeClass("btn-success pg-btn-confirm")
-                    .addClass("btn-danger pg-btn-confirm--danger");
-                showModalKonfirmasi(msg, "btn-force-delete-warehouse");
+                showModalKonfirmasi(msg, "btn-force-delete-warehouse", true);
                 $("#btn-force-delete-warehouse").attr("data-id", id);
                 return;
             }
@@ -686,17 +683,7 @@ $(document).on("click", ".btn_status", function () {
         status == 1 ? "Konfirmasi Aktifkan" : "Konfirmasi Non Aktif",
     );
 
-    if (status == 1) {
-        $("#modalKonfirmasi .btn-konfirmasi")
-            .removeClass("btn-danger pg-btn-confirm--danger")
-            .addClass("btn-success pg-btn-confirm");
-    } else {
-        $("#modalKonfirmasi .btn-konfirmasi")
-            .removeClass("btn-success pg-btn-confirm")
-            .addClass("btn-danger pg-btn-confirm--danger");
-    }
-
-    showModalKonfirmasi(text, "btn-update-warehouse-status");
+    showModalKonfirmasi(text, "btn-update-warehouse-status", status != 1);
     $("#btn-update-warehouse-status")
         .attr("data-id", id)
         .attr("data-status", status);

--- a/public/Custom_js/Backoffice/Warehouse/WarehouseType.js
+++ b/public/Custom_js/Backoffice/Warehouse/WarehouseType.js
@@ -294,8 +294,7 @@ $(document).on("click", "#btn-delete-warehouse-type", function () {
                     (e.message || "Masih ada gudang yang memakai tipe ini") +
                     ". Apakah benar-benar mau menghapus tipe gudang ini?";
                 $("#modalKonfirmasi .modal-title").text("Konfirmasi Hapus Lanjutan");
-                $("#modalKonfirmasi .btn-konfirmasi").removeClass("btn-success pg-btn-confirm").addClass("btn-danger pg-btn-confirm--danger");
-                showModalKonfirmasi(msg, "btn-force-delete-warehouse-type");
+                showModalKonfirmasi(msg, "btn-force-delete-warehouse-type", true);
                 $("#btn-force-delete-warehouse-type").attr("data-id", id);
                 return;
             }

--- a/resources/views/layout/partials/footer-scripts.blade.php
+++ b/resources/views/layout/partials/footer-scripts.blade.php
@@ -470,14 +470,20 @@ https://cdn.jsdelivr.net/npm/toastr@2.1.4/toastr.min.js
         $('#modalDelete').modal("show");
     }
       
-    function showModalKonfirmasi(text, button_id) {
+    function showModalKonfirmasi(text, button_id, danger) {
         //button id ini, id button ketika dikofrimasi delete
+        //danger = true untuk aksi cancel/tolak/hapus → tema modal & tombol jadi merah
         $("#text-konfirmasi").html(text);
+        $("#modalKonfirmasi")
+            .toggleClass("pg-modal--danger", !!danger)
+            .toggleClass("pg-modal--confirm", !danger);
         $("#modalKonfirmasi .btn-konfirmasi")
             .attr("id", button_id)
             .removeData("busy")
             .prop("disabled", false)
             .css({ "min-width": "", height: "" })
+            .toggleClass("btn-danger pg-btn-confirm--danger", !!danger)
+            .toggleClass("btn-success pg-btn-confirm", !danger)
             .html('<i class="fe fe-check-circle me-1"></i>Konfirmasi');
         $('#modalKonfirmasi').modal("show");
     }
@@ -508,6 +514,9 @@ https://cdn.jsdelivr.net/npm/toastr@2.1.4/toastr.min.js
 
   $(document).on('hidden.bs.modal', '#modalKonfirmasi', function () {
     $('#modalKonfirmasi .modal-title').text('Konfirmasi');
+    $('#modalKonfirmasi')
+      .removeClass('pg-modal--danger')
+      .addClass('pg-modal--confirm');
     $('#modalKonfirmasi .btn-konfirmasi')
       .removeClass('btn-danger pg-btn-confirm--danger')
       .addClass('btn-success pg-btn-confirm')


### PR DESCRIPTION
## Ringkasan
Memperbaiki #126 — popup konfirmasi yang berkaitan dengan cancel/tolak/hapus wajib bertema merah, termasuk yang selama ini masih memakai styling hijau/biru default atau warna SweetAlert2 bawaan.

## Perubahan

**Modal konfirmasi bersama (`#modalKonfirmasi`)**
- `showModalKonfirmasi(text, button_id, danger)` sekarang menerima parameter `danger` yang menukar tema tombol **sekaligus** header/icon modal (sebelumnya cuma tombolnya yang berubah warna, header tetap hijau — ini penyebab bug di screenshot awal). Direset otomatis ke hijau saat modal ditutup (`hidden.bs.modal`).
- Dipasang di semua titik yang sebelumnya salah tema:
  - **Stock Transfer**: tolak/cancel transfer pending, cancel request transfer retail, reject dari list
  - **Customer Return**: konfirmasi tolak (decline) pengembalian
  - **Sync Wizard**: abaikan (discard) review armada — aksi permanen
  - **Warehouse & WarehouseType**: konfirmasi hapus lanjutan (masih ada stok/masih dipakai) dan toggle non-aktifkan gudang — bug header yang sama, ikut dibenahi sekalian karena akar masalahnya identik

**Popup delete berbasis SweetAlert2 (Customer/Product/Supply Return)**
- Ketiga popup "Hapus pengembalian?" tadinya `Swal.fire()` polos dengan tombol default (bukan merah, tidak konsisten dengan popup delete lain di aplikasi).
- Diganti pakai `showModalDelete()` — modal `#modalDelete` bersama yang sama dengan popup hapus di tab Pengiriman (Sales_Order) pada halaman yang sama, supaya theme-nya konsisten (header gradient merah + icon), bukan cuma tombolnya.
- Fallback dialog accept/decline (dipakai hanya kalau `showModalKonfirmasi` belum termuat) juga diberi warna merah untuk decline.

## Pendekatan
Mengikuti pola yang sudah ada di `Warehouse.js`/`WarehouseType.js` (toggle class `btn-success pg-btn-confirm` → `btn-danger pg-btn-confirm--danger`), lalu disentralkan ke dalam `showModalKonfirmasi()` sendiri supaya header modal ikut berubah dan tidak perlu diulang manual di tiap pemanggil. Alur yang sudah benar (`showModalDelete`, `showModalDanger`, konfirmasi approve/accept) tidak disentuh.

## Test plan
- Ditelusuri manual tiap titik pemanggilan; modal `#modalKonfirmasi` direset ke hijau saat `hidden.bs.modal` sehingga styling selalu fresh dan tidak bocor ke konfirmasi lain.
- Tidak ada automated test untuk styling tombol/modal jQuery di repo ini.

🤖 Generated with [Claude Code](https://claude.com/claude-code)