### PR TITLE
fix(kategori+satuan): reject duplicate names on insert/update

### DIFF
--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -31,8 +31,27 @@ class Category extends Model
         return $result;
     }
 
+    /**
+     * True kalau ada kategori aktif lain dengan nama yang sama (case-insensitive,
+     * trimmed). $excludeId dipakai saat update supaya baris itu sendiri tidak dianggap
+     * bentrok dengan dirinya sendiri.
+     */
+    function isDuplicateName($name, $excludeId = null)
+    {
+        $query = category::where('status', 1)
+            ->whereRaw('LOWER(TRIM(category_name)) = ?', [strtolower(trim($name))]);
+        if ($excludeId) {
+            $query->where('category_id', '!=', $excludeId);
+        }
+        return $query->exists();
+    }
+
     function insertCategory($data)
     {
+        if ($this->isDuplicateName($data["category_name"])) {
+            return response()->json(['message' => 'Nama kategori sudah digunakan'], 422);
+        }
+
         $t = new category();
         $t->category_name = $data["category_name"];
         $t->created_by = Session::get('user') ? Session::get('user')->staff_id : null;
@@ -43,6 +62,12 @@ class Category extends Model
     function updateCategory($data)
     {
         $t = category::find($data["category_id"]);
+        if (!$t) return null;
+
+        if ($this->isDuplicateName($data["category_name"], $t->category_id)) {
+            return response()->json(['message' => 'Nama kategori sudah digunakan'], 422);
+        }
+
         $t->category_name = $data["category_name"];
         $t->created_by = Session::get('user') ? Session::get('user')->staff_id : null;
         $t->save();

--- a/app/Models/Unit.php
+++ b/app/Models/Unit.php
@@ -64,8 +64,27 @@ class Unit extends Model
             ->select(['unit_id', 'ref_unit_id', 'unit_name', 'unit_short_name']);
     }
 
+    /**
+     * True kalau ada satuan aktif lain dengan nama yang sama (case-insensitive,
+     * trimmed). $excludeId dipakai saat update supaya baris itu sendiri tidak dianggap
+     * bentrok dengan dirinya sendiri.
+     */
+    function isDuplicateName($name, $excludeId = null)
+    {
+        $query = self::where('status', 1)
+            ->whereRaw('LOWER(TRIM(unit_name)) = ?', [strtolower(trim($name))]);
+        if ($excludeId) {
+            $query->where('unit_id', '!=', $excludeId);
+        }
+        return $query->exists();
+    }
+
     function insertUnit($data)
     {
+        if ($this->isDuplicateName($data["unit_name"])) {
+            return response()->json(['message' => 'Nama satuan sudah digunakan'], 422);
+        }
+
         $t = new self();
         $t->unit_short_name = $data["unit_short_name"];
         $t->unit_name = $data["unit_name"];
@@ -77,6 +96,12 @@ class Unit extends Model
     function updateUnit($data)
     {
         $t = self::find($data["unit_id"]);
+        if (!$t) return null;
+
+        if ($this->isDuplicateName($data["unit_name"], $t->unit_id)) {
+            return response()->json(['message' => 'Nama satuan sudah digunakan'], 422);
+        }
+
         $t->unit_short_name = $data["unit_short_name"];
         $t->unit_name = $data["unit_name"];
         $t->created_by = Session::get('user') ? Session::get('user')->staff_id : null;

--- a/public/Custom_js/Backoffice/Product/Category.js
+++ b/public/Custom_js/Backoffice/Product/Category.js
@@ -132,6 +132,8 @@
             error:function(e){
                 ResetLoadingButton('.btn-save', mode == 1?"Tambah Kategori" : "Update Kategori");
                 if (handlePermissionError(e)) return;
+                var msg = (e.responseJSON && e.responseJSON.message) || "Silahkan cek kembali inputan anda";
+                notifikasi('error', mode == 1?"Gagal Insert":"Gagal Update", msg);
                 console.log(e);
             }
         });

--- a/public/Custom_js/Backoffice/Product/Category.js
+++ b/public/Custom_js/Backoffice/Product/Category.js
@@ -133,7 +133,7 @@
                 ResetLoadingButton('.btn-save', mode == 1?"Tambah Kategori" : "Update Kategori");
                 if (handlePermissionError(e)) return;
                 var msg = (e.responseJSON && e.responseJSON.message) || "Silahkan cek kembali inputan anda";
-                showPgErrorModal(mode == 1?"Gagal Insert":"Gagal Update", msg);
+                notifikasi('error', mode == 1?"Gagal Insert":"Gagal Update", msg);
                 console.log(e);
             }
         });

--- a/public/Custom_js/Backoffice/Product/Category.js
+++ b/public/Custom_js/Backoffice/Product/Category.js
@@ -133,7 +133,7 @@
                 ResetLoadingButton('.btn-save', mode == 1?"Tambah Kategori" : "Update Kategori");
                 if (handlePermissionError(e)) return;
                 var msg = (e.responseJSON && e.responseJSON.message) || "Silahkan cek kembali inputan anda";
-                notifikasi('error', mode == 1?"Gagal Insert":"Gagal Update", msg);
+                showPgErrorModal(mode == 1?"Gagal Insert":"Gagal Update", msg);
                 console.log(e);
             }
         });

--- a/public/Custom_js/Backoffice/Product/Units.js
+++ b/public/Custom_js/Backoffice/Product/Units.js
@@ -138,7 +138,7 @@
                 ResetLoadingButton('.btn-save', mode == 1?"Tambah Satuan" : "Update Satuan");
                 if (handlePermissionError(e)) return;
                 var msg = (e.responseJSON && e.responseJSON.message) || "Silahkan cek kembali inputan anda";
-                showPgErrorModal(mode == 1?"Gagal Insert":"Gagal Update", msg);
+                notifikasi('error', mode == 1?"Gagal Insert":"Gagal Update", msg);
                 console.log(e);
             }
         });

--- a/public/Custom_js/Backoffice/Product/Units.js
+++ b/public/Custom_js/Backoffice/Product/Units.js
@@ -138,7 +138,7 @@
                 ResetLoadingButton('.btn-save', mode == 1?"Tambah Satuan" : "Update Satuan");
                 if (handlePermissionError(e)) return;
                 var msg = (e.responseJSON && e.responseJSON.message) || "Silahkan cek kembali inputan anda";
-                notifikasi('error', mode == 1?"Gagal Insert":"Gagal Update", msg);
+                showPgErrorModal(mode == 1?"Gagal Insert":"Gagal Update", msg);
                 console.log(e);
             }
         });

--- a/public/Custom_js/Backoffice/Product/Units.js
+++ b/public/Custom_js/Backoffice/Product/Units.js
@@ -137,6 +137,8 @@
             error:function(e){
                 ResetLoadingButton('.btn-save', mode == 1?"Tambah Satuan" : "Update Satuan");
                 if (handlePermissionError(e)) return;
+                var msg = (e.responseJSON && e.responseJSON.message) || "Silahkan cek kembali inputan anda";
+                notifikasi('error', mode == 1?"Gagal Insert":"Gagal Update", msg);
                 console.log(e);
             }
         });

--- a/tests/Regression/DuplicateNameGuardTest.php
+++ b/tests/Regression/DuplicateNameGuardTest.php
@@ -4,6 +4,8 @@ namespace Tests\Regression;
 
 use App\Models\Bank;
 use App\Models\CashCategory;
+use App\Models\Category;
+use App\Models\Unit;
 use Tests\Support\ActingAsStaff;
 use Tests\TestCase;
 
@@ -15,6 +17,9 @@ use Tests\TestCase;
  * now reject a duplicate name (case-insensitive, trimmed, scoped to active/`status=1` rows) with a
  * 422 + message, matching the `response()->json(['message' => ...], 422)` convention used
  * elsewhere in this codebase.
+ *
+ * ✅ FIXED (GitHub #128, 2026-09-03): same bug in `Category::insertCategory()`/`updateCategory()`
+ * (Master Kategori) and `Unit::insertUnit()`/`updateUnit()` (Master Satuan) — mirrors the fix above.
  */
 class DuplicateNameGuardTest extends TestCase
 {
@@ -122,6 +127,93 @@ class DuplicateNameGuardTest extends TestCase
         $response->assertStatus(422);
         $categoryB->refresh();
         $this->assertSame('Regression Category B', $categoryB->cc_name);
+    }
+
+    public function test_inserting_a_category_with_a_duplicate_name_is_rejected(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $category = new Category();
+        $category->category_name = 'Regression Master Category Dup';
+        $category->status = 1;
+        $category->save();
+
+        $response = $this->post('/insertCategory', [
+            'category_name' => ' regression master category dup ',
+        ]);
+
+        $response->assertStatus(422);
+        $this->assertSame(1, Category::where('category_name', 'Regression Master Category Dup')->where('status', 1)->count());
+    }
+
+    public function test_updating_a_category_into_another_categorys_name_is_rejected(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $categoryA = new Category();
+        $categoryA->category_name = 'Regression Master Category A';
+        $categoryA->status = 1;
+        $categoryA->save();
+
+        $categoryB = new Category();
+        $categoryB->category_name = 'Regression Master Category B';
+        $categoryB->status = 1;
+        $categoryB->save();
+
+        $response = $this->post('/updateCategory', [
+            'category_id' => $categoryB->category_id,
+            'category_name' => 'Regression Master Category A',
+        ]);
+
+        $response->assertStatus(422);
+        $categoryB->refresh();
+        $this->assertSame('Regression Master Category B', $categoryB->category_name);
+    }
+
+    public function test_inserting_a_unit_with_a_duplicate_name_is_rejected(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $unit = new Unit();
+        $unit->unit_name = 'Regression Master Unit Dup';
+        $unit->unit_short_name = 'RMUD';
+        $unit->status = 1;
+        $unit->save();
+
+        $response = $this->post('/insertUnit', [
+            'unit_name' => ' regression master unit dup ',
+            'unit_short_name' => 'RMUD2',
+        ]);
+
+        $response->assertStatus(422);
+        $this->assertSame(1, Unit::where('unit_name', 'Regression Master Unit Dup')->where('status', 1)->count());
+    }
+
+    public function test_updating_a_unit_into_another_units_name_is_rejected(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $unitA = new Unit();
+        $unitA->unit_name = 'Regression Master Unit A';
+        $unitA->unit_short_name = 'RMUA';
+        $unitA->status = 1;
+        $unitA->save();
+
+        $unitB = new Unit();
+        $unitB->unit_name = 'Regression Master Unit B';
+        $unitB->unit_short_name = 'RMUB';
+        $unitB->status = 1;
+        $unitB->save();
+
+        $response = $this->post('/updateUnit', [
+            'unit_id' => $unitB->unit_id,
+            'unit_name' => 'Regression Master Unit A',
+            'unit_short_name' => 'RMUB',
+        ]);
+
+        $response->assertStatus(422);
+        $unitB->refresh();
+        $this->assertSame('Regression Master Unit B', $unitB->unit_name);
     }
 
     public function test_a_soft_deleted_bank_name_can_be_reused(): void


### PR DESCRIPTION
## Summary
Fixes #128 — Master Kategori and Master Satuan allowed inserting/renaming into duplicate names.

## What was broken
`Category::insertCategory()`/`updateCategory()` and `Unit::insertUnit()`/`updateUnit()` had zero uniqueness check, same root cause already fixed for Bank/CashCategory in #122.

## Fix
- Added `isDuplicateName($name, $excludeId = null)` to both `Category` and `Unit` models — case-insensitive, trimmed match scoped to active (`status=1`) rows, excluding the row's own id on update.
- On a hit, returns `response()->json(['message' => '...'], 422)`, matching the existing convention.
- `Category.js` / `Units.js` save error handlers now surface `xhr.responseJSON.message` via `notifikasi('error', ...)` instead of only `console.log`.

## Tests
Added 4 cases to `tests/Regression/DuplicateNameGuardTest.php` (insert duplicate rejected + rename-into-another-row rejected, for both Category and Unit). Full file + `MasterSmokeTest` pass.

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)