### PR TITLE
fix(kas): Modul Akuntansi — poin 29, 32-39 (GitHub #130)

### DIFF
--- a/app/Http/Controllers/AutocompleteController.php
+++ b/app/Http/Controllers/AutocompleteController.php
@@ -428,6 +428,11 @@ class AutocompleteController extends Controller
         $p = new Customer();
         $data_city = $p->getCustomer([
             "customer_notes" => $keyword,
+            // GitHub #130 (item 37): optional exact lookup, dipakai Cash_Operational.js untuk
+            // ambil customer_saldo TERBARU sebelum mengisi default nominal "Pengembalian Dana
+            // Langsung" — opsi Select2 di modal itu sering dibuat dari data cache filter halaman
+            // (bisa basi kalau saldo berubah sejak filter terakhir di-refresh).
+            "customer_id" => $req->customer_id ?? null,
         ]);
 
 

--- a/app/Http/Controllers/ReportController.php
+++ b/app/Http/Controllers/ReportController.php
@@ -592,21 +592,57 @@ class ReportController extends Controller
         return response()->json($data);
     }
 
+    /**
+     * GitHub #130 (item 33/34): satu tempat untuk menyusun pesan kegagalan ACC/Tolak yang
+     * seragam di semua modul Kas — sebelum ini, "record dihapus" (status jadi 0 lewat
+     * deleteCash()/deleteCashAdmin()/dst, `acc_by` tidak pernah diisi) dan "sudah
+     * diterima/ditolak orang lain" (status 2/3) menghasilkan pesan yang SAMA persis
+     * ("Pengajuan sudah diterima/ditolak oleh staff lain"), jadi ambigu/menyesatkan — user
+     * tidak bisa tahu yang mana yang sebenarnya terjadi. Sekarang dibedakan berdasarkan
+     * `status` yang sebenarnya: 0 = sudah dihapus, 2 = sudah diterima, 3 = sudah ditolak,
+     * record tidak ditemukan sama sekali = kemungkinan sudah dihapus.
+     */
+    private function pengajuanFailureMessage($record): string
+    {
+        if (! $record) {
+            return 'Pengajuan tidak ditemukan, kemungkinan sudah dihapus';
+        }
+
+        $status = (int) $record->status;
+        if ($status === 0) {
+            return 'Pengajuan ini sudah dihapus oleh pengaju';
+        }
+
+        $staff = $record->acc_by ? Staff::find($record->acc_by) : null;
+        $staffName = $staff->staff_name ?? 'staff lain';
+        if ($status === 3) {
+            return 'Pengajuan sudah ditolak oleh ' . $staffName;
+        }
+        if ($status === 2) {
+            return 'Pengajuan sudah diterima oleh ' . $staffName;
+        }
+
+        // status lain yang tak terduga — fallback ke pesan lama, tetap lebih baik daripada crash.
+        return 'Pengajuan sudah diterima/ditolak oleh ' . $staffName;
+    }
+
     function acceptCashBesar(Request $req)
     {
         $data = $req->all();
         $cash = Cash::find($data['cash_id'] ?? null);
         if (! $cash || (int) $cash->status !== 1) {
-            $staff = ($cash && $cash->acc_by) ? Staff::find($cash->acc_by) : null;
-
             return response()->json([
                 'status' => -2,
                 'header' => 'Gagal ACC',
-                'message' => 'Pengajuan sudah diterima/ditolak oleh ' . ($staff->staff_name ?? 'staff lain'),
+                'message' => $this->pengajuanFailureMessage($cash),
             ]);
         }
 
-        $uid = Session::get('user')->staff_id ?? null;
+        // GitHub #130: was `Session::get('user')` — this file never `use`s the Session facade
+        // (everywhere else uses the session() helper, see below), so this crashed 500 with
+        // "Class App\Http\Controllers\Session not found" on every successful ACC/Tolak via the
+        // Kas Besar page, not just the deleted-record case above.
+        $uid = session('user')->staff_id ?? null;
         $cash->status = 2;
         $cash->acc_by = $uid;
         $cash->save();
@@ -619,16 +655,18 @@ class ReportController extends Controller
         $data = $req->all();
         $cash = Cash::find($data['cash_id'] ?? null);
         if (! $cash || (int) $cash->status !== 1) {
-            $staff = ($cash && $cash->acc_by) ? Staff::find($cash->acc_by) : null;
-
             return response()->json([
                 'status' => -2,
                 'header' => 'Gagal Tolak',
-                'message' => 'Pengajuan sudah diterima/ditolak oleh ' . ($staff->staff_name ?? 'staff lain'),
+                'message' => $this->pengajuanFailureMessage($cash),
             ]);
         }
 
-        $uid = Session::get('user')->staff_id ?? null;
+        // GitHub #130: was `Session::get('user')` — this file never `use`s the Session facade
+        // (everywhere else uses the session() helper, see below), so this crashed 500 with
+        // "Class App\Http\Controllers\Session not found" on every successful ACC/Tolak via the
+        // Kas Besar page, not just the deleted-record case above.
+        $uid = session('user')->staff_id ?? null;
         $cash->status = 3;
         $cash->acc_by = $uid;
         $cash->save();
@@ -1226,18 +1264,16 @@ class ReportController extends Controller
         } else {
             $q = CashAdmin::where('cash_id', $data['cash_id'])->first();
         }
-        // GitHub #130: kalau pengajuan/pengembaliannya sudah dihapus (mis. staff yang
-        // mengajukan menghapusnya sendiri sebelum sempat di-ACC), $q null dan
+        // GitHub #130 (item 33): kalau pengajuan/pengembaliannya sudah dihapus (mis. staff
+        // yang mengajukan menghapusnya sendiri sebelum sempat di-ACC), $q null dan
         // `$q->status` dulu crash 500 — muncul di UI sebagai error generik tanpa
-        // penjelasan. Sekarang ditangani seperti acceptCashGudang().
+        // penjelasan. Sekarang ditangani + pesannya membedakan "sudah dihapus" dari "sudah
+        // diterima/ditolak orang lain" (lihat pengajuanFailureMessage()).
         if (!$q || $q->status != 1) {
-            $staff = ($q && $q->acc_by) ? Staff::find($q->acc_by) : null;
             return response()->json([
                 "status" => -2,
                 "header" => "Gagal ACC",
-                "message" => !$q
-                    ? "Pengajuan tidak ditemukan, kemungkinan sudah dihapus"
-                    : "Pengajuan sudah diterima/ditolak oleh " . ($staff->staff_name ?? 'staff lain')
+                "message" => $this->pengajuanFailureMessage($q)
             ]);
         }
         return (new CashAdmin())->acceptCashAdmin($data);
@@ -1251,15 +1287,12 @@ class ReportController extends Controller
         } else {
             $q = CashAdmin::where('cash_id', $data['cash_id'])->first();
         }
-        // GitHub #130: lihat catatan yang sama di acceptCashAdmin() di atas.
+        // GitHub #130 (item 33): lihat catatan yang sama di acceptCashAdmin() di atas.
         if (!$q || $q->status != 1) {
-            $staff = ($q && $q->acc_by) ? Staff::find($q->acc_by) : null;
             return response()->json([
                 "status" => -2,
                 "header" => "Gagal ACC",
-                "message" => !$q
-                    ? "Pengajuan tidak ditemukan, kemungkinan sudah dihapus"
-                    : "Pengajuan sudah diterima/ditolak oleh " . ($staff->staff_name ?? 'staff lain')
+                "message" => $this->pengajuanFailureMessage($q)
             ]);
         }
         return (new CashAdmin())->declineCashAdmin($data);
@@ -1551,11 +1584,10 @@ class ReportController extends Controller
 
             if (!$cg || $cg->status != 1) {
                 DB::rollBack();
-                $staff = ($cg && $cg->acc_by) ? Staff::find($cg->acc_by) : null;
                 return response()->json([
                     "status" => -2,
                     "header" => "Gagal ACC",
-                    "message" => "Pengajuan sudah diterima/ditolak oleh " . ($staff->staff_name ?? 'staff lain')
+                    "message" => $this->pengajuanFailureMessage($cg)
                 ]);
             }
 
@@ -1609,16 +1641,14 @@ class ReportController extends Controller
         } else {
             $cg = CashGudang::where('cash_id', $data["cash_id"])->first();
         }
-        // GitHub #130: sama seperti acceptCashAdmin/declineCashAdmin — $cg bisa null
-        // kalau pengajuannya sudah dihapus, jangan crash 500.
+        // GitHub #130 (item 34): sama seperti acceptCashAdmin/declineCashAdmin — $cg bisa
+        // null kalau pengajuannya sudah dihapus, jangan crash 500; pesannya juga sekarang
+        // membedakan "sudah dihapus" dari "sudah diterima/ditolak orang lain".
         if (!$cg || $cg->status != 1) {
-            $staff = ($cg && $cg->acc_by) ? Staff::find($cg->acc_by) : null;
             return response()->json([
                 "status" => -2,
                 "header" => "Gagal ACC",
-                "message" => !$cg
-                    ? "Pengajuan tidak ditemukan, kemungkinan sudah dihapus"
-                    : "Pengajuan sudah diterima/ditolak oleh " . ($staff->staff_name ?? 'staff lain')
+                "message" => $this->pengajuanFailureMessage($cg)
             ]);
         }
         return (new CashGudang())->declineCashGudang($data);
@@ -1837,13 +1867,14 @@ class ReportController extends Controller
         } else {
             $cr = CashArmada::where('cash_id', $data["cash_id"])->first();
         }
-        // Pengecekan ACC
-        if ($cr->status != 1) {
-            $staff = Staff::find($cr->acc_by)->staff_name;
+        // Pengecekan ACC — GitHub #130: sama seperti Kas Admin/Gudang, $cr bisa null kalau
+        // pengajuannya sudah dihapus; pesannya membedakan "sudah dihapus" dari "sudah
+        // diterima/ditolak orang lain".
+        if (!$cr || $cr->status != 1) {
             return response()->json([
                 "status" => -2,
                 "header" => "Gagal ACC",
-                "message" => "Pengajuan sudah diterma/ditolak oleh " . $staff
+                "message" => $this->pengajuanFailureMessage($cr)
             ]);
         }
 
@@ -1872,13 +1903,12 @@ class ReportController extends Controller
         } else {
             $cr = CashArmada::where('cash_id', $data["cash_id"])->first();
         }
-        // Pengecekan Acc
-        if ($cr->status != 1) {
-            $staff = Staff::find($cr->acc_by)->staff_name;
+        // Pengecekan Acc — GitHub #130: lihat catatan yang sama di acceptCashArmada() di atas.
+        if (!$cr || $cr->status != 1) {
             return response()->json([
                 "status" => -2,
                 "header" => "Gagal ACC",
-                "message" => "Pengajuan sudah diterma/ditolak oleh " . $staff
+                "message" => $this->pengajuanFailureMessage($cr)
             ]);
         }
         return (new CashArmada())->declineCashArmada($data);
@@ -1897,6 +1927,21 @@ class ReportController extends Controller
     function insertCashSales(Request $req)
     {
         $data = $req->all();
+
+        // GitHub #130 (item 39): "Setor ke Bank" (cs_aksi==2) defaults its nominal from the sales
+        // rep's staff_saldo, which can itself be negative — but a bank deposit can never sensibly
+        // be negative. Server-side guard mirrors the new JS one (Cash_Operational.js's
+        // .btn-save-sales handler); this is intentionally a SEPARATE check from the
+        // pengembalian/negative-balance guards elsewhere in this file that stay disabled per PM's
+        // 2026-08-05 decision (that one is about letting balances run into deficit, not about
+        // accepting a literally-negative deposit amount).
+        if (($data['oc_transaksi'] ?? null) == "saldo" && ($data['cs_aksi'] ?? null) == "2" && (int) ($data['cs_nominal'] ?? 0) < 0) {
+            return response()->json([
+                "status" => -1,
+                "header" => "Gagal Insert",
+                "message" => "Setor ke Bank tidak boleh minus"
+            ]);
+        }
 
         $total = 0;
         $sales = Staff::find($data['staff_id']);
@@ -2014,6 +2059,15 @@ class ReportController extends Controller
     {
         $data = $req->all();
 
+        // GitHub #130 (item 39): same guard as insertCashSales() — see the comment there.
+        if (($data['oc_transaksi'] ?? null) == "saldo" && ($data['cs_aksi'] ?? null) == "2" && (int) ($data['cs_nominal'] ?? 0) < 0) {
+            return response()->json([
+                "status" => -1,
+                "header" => "Gagal Update",
+                "message" => "Setor ke Bank tidak boleh minus"
+            ]);
+        }
+
         // Ditambahkan: same gap as updateCashArmada above — acceptCashSales/declineCashSales
         // already refuse if status != 1, but updateCashSales() never checked at all. Worse here:
         // CashSales::updateCashSales()'s status-revival logic (meant only for reviving a declined
@@ -2093,13 +2147,14 @@ class ReportController extends Controller
         } else {
             $cs = CashSales::where('cash_id', $data["cash_id"])->first();
         }
-        // Pengecekan acc
-        if ($cs->status != 1) {
-            $staff = Staff::find($cs->acc_by)->staff_name;
+        // Pengecekan acc — GitHub #130: sama seperti Kas Admin/Gudang/Armada, $cs bisa null
+        // kalau pengajuannya sudah dihapus; pesannya membedakan "sudah dihapus" dari "sudah
+        // diterima/ditolak orang lain".
+        if (!$cs || $cs->status != 1) {
             return response()->json([
                 "status" => -2,
                 "header" => "Gagal ACC",
-                "message" => "Pengajuan sudah diterma/ditolak oleh " . $staff
+                "message" => $this->pengajuanFailureMessage($cs)
             ]);
         }
 
@@ -2132,13 +2187,12 @@ class ReportController extends Controller
         } else {
             $cs = CashSales::where('cash_id', $data["cash_id"])->first();
         }
-        // Pengecekan acc
-        if ($cs->status != 1) {
-            $staff = Staff::find($cs->acc_by)->staff_name;
+        // Pengecekan acc — GitHub #130: lihat catatan yang sama di acceptCashSales() di atas.
+        if (!$cs || $cs->status != 1) {
             return response()->json([
                 "status" => -2,
                 "header" => "Gagal ACC",
-                "message" => "Pengajuan sudah diterma/ditolak oleh " . $staff
+                "message" => $this->pengajuanFailureMessage($cs)
             ]);
         }
 

--- a/app/Http/Controllers/ReportController.php
+++ b/app/Http/Controllers/ReportController.php
@@ -1226,12 +1226,18 @@ class ReportController extends Controller
         } else {
             $q = CashAdmin::where('cash_id', $data['cash_id'])->first();
         }
-        if ($q->status != 1) {
-            $staff = Staff::find($q->acc_by)->staff_name;
+        // GitHub #130: kalau pengajuan/pengembaliannya sudah dihapus (mis. staff yang
+        // mengajukan menghapusnya sendiri sebelum sempat di-ACC), $q null dan
+        // `$q->status` dulu crash 500 — muncul di UI sebagai error generik tanpa
+        // penjelasan. Sekarang ditangani seperti acceptCashGudang().
+        if (!$q || $q->status != 1) {
+            $staff = ($q && $q->acc_by) ? Staff::find($q->acc_by) : null;
             return response()->json([
                 "status" => -2,
                 "header" => "Gagal ACC",
-                "message" => "Pengajuan sudah diterma/ditolak oleh " . $staff
+                "message" => !$q
+                    ? "Pengajuan tidak ditemukan, kemungkinan sudah dihapus"
+                    : "Pengajuan sudah diterima/ditolak oleh " . ($staff->staff_name ?? 'staff lain')
             ]);
         }
         return (new CashAdmin())->acceptCashAdmin($data);
@@ -1245,12 +1251,15 @@ class ReportController extends Controller
         } else {
             $q = CashAdmin::where('cash_id', $data['cash_id'])->first();
         }
-        if ($q->status != 1) {
-            $staff = Staff::find($q->acc_by)->staff_name;
+        // GitHub #130: lihat catatan yang sama di acceptCashAdmin() di atas.
+        if (!$q || $q->status != 1) {
+            $staff = ($q && $q->acc_by) ? Staff::find($q->acc_by) : null;
             return response()->json([
                 "status" => -2,
                 "header" => "Gagal ACC",
-                "message" => "Pengajuan sudah diterma/ditolak oleh " . $staff
+                "message" => !$q
+                    ? "Pengajuan tidak ditemukan, kemungkinan sudah dihapus"
+                    : "Pengajuan sudah diterima/ditolak oleh " . ($staff->staff_name ?? 'staff lain')
             ]);
         }
         return (new CashAdmin())->declineCashAdmin($data);
@@ -1600,12 +1609,16 @@ class ReportController extends Controller
         } else {
             $cg = CashGudang::where('cash_id', $data["cash_id"])->first();
         }
-        if ($cg->status != 1) {
-            $staff = Staff::find($cg->acc_by)->staff_name;
+        // GitHub #130: sama seperti acceptCashAdmin/declineCashAdmin — $cg bisa null
+        // kalau pengajuannya sudah dihapus, jangan crash 500.
+        if (!$cg || $cg->status != 1) {
+            $staff = ($cg && $cg->acc_by) ? Staff::find($cg->acc_by) : null;
             return response()->json([
                 "status" => -2,
                 "header" => "Gagal ACC",
-                "message" => "Pengajuan sudah diterima/ditolak oleh " . $staff
+                "message" => !$cg
+                    ? "Pengajuan tidak ditemukan, kemungkinan sudah dihapus"
+                    : "Pengajuan sudah diterima/ditolak oleh " . ($staff->staff_name ?? 'staff lain')
             ]);
         }
         return (new CashGudang())->declineCashGudang($data);

--- a/app/Support/CashBesarPresenter.php
+++ b/app/Support/CashBesarPresenter.php
@@ -80,10 +80,14 @@ class CashBesarPresenter
         if ((int) $row->status === 1 && self::can($user, 'others')) {
             $cashId = (int) $row->cash_id;
             $cashTujuan = (int) ($row->cash_tujuan ?? 0);
+            // GitHub #117/#130: bg-success/bg-danger + text-light are Bootstrap utility classes,
+            // which lose to header.blade.php's global `.btn-action-icon { ... !important }` reset
+            // — these rendered plain/uncolored in practice. Use the dedicated
+            // .btn-action-approve/.btn-action-reject classes instead.
             $action =
                 '<div class="d-flex align-items-center gap-1">' .
-                '<a class="btn-action-icon p-2 btn_acc bg-success text-light" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Terima" cash_id="' . $cashId . '" cash_tujuan="' . $cashTujuan . '"><i class="fe fe-check"></i></a>' .
-                '<a class="btn-action-icon p-2 btn_decline bg-danger text-light" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Tolak" cash_id="' . $cashId . '" cash_tujuan="' . $cashTujuan . '"><i class="fe fe-x"></i></a></div>';
+                '<a class="btn-action-icon btn-action-approve p-2 btn_acc" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Terima" cash_id="' . $cashId . '" cash_tujuan="' . $cashTujuan . '"><i class="fe fe-check"></i></a>' .
+                '<a class="btn-action-icon btn-action-reject p-2 btn_decline" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Tolak" cash_id="' . $cashId . '" cash_tujuan="' . $cashTujuan . '"><i class="fe fe-x"></i></a></div>';
         }
 
         return [

--- a/app/Support/CashOperasionalPresenter.php
+++ b/app/Support/CashOperasionalPresenter.php
@@ -44,12 +44,31 @@ class CashOperasionalPresenter
     }
 
     /**
+     * GitHub #130 (item 35): `ca_nominal`/`cg_nominal` are stored RAW (whatever sign the request
+     * sent — see the linked Cash row's own sign-flip at insert time in ReportController), but a
+     * "saldo" (`ca_type`/`cg_type` == 1) row's Masuk/Keluar column here was always decided purely
+     * by `ca_aksi`/`cg_aksi` (1=Pengajuan→Masuk, 2=Pengembalian→Keluar), ignoring the sign
+     * entirely. A NEGATIVE nominal reverses what actually happened (a negative Pengembalian is
+     * functionally a Pengajuan, and vice versa), so it must flip which column the row lands in —
+     * only for saldo rows; "operasional" (type 2, expense) rows are untouched, out of scope here.
+     */
+    private static function isDebitColumn(int $aksi, int $type, int $nominal): bool
+    {
+        $isDebit = $aksi === 1;
+        if ($type === 1 && $nominal < 0) {
+            $isDebit = !$isDebit;
+        }
+
+        return $isDebit;
+    }
+
+    /**
      * @return array<string, mixed>
      */
     public static function adminRow(object $row, $user): array
     {
         $nominal = (int) ($row->ca_nominal ?? 0);
-        $isDebit = (int) ($row->ca_aksi ?? 0) === 1;
+        $isDebit = self::isDebitColumn((int) ($row->ca_aksi ?? 0), (int) ($row->ca_type ?? 0), $nominal);
         $debit = $isDebit ? 'Rp ' . self::money($nominal) : 'Rp 0';
         $credit = $isDebit ? 'Rp 0' : '(Rp ' . self::money($nominal) . ')';
 
@@ -98,7 +117,7 @@ class CashOperasionalPresenter
     public static function gudangRow(object $row, $user): array
     {
         $nominal = (int) ($row->cg_nominal ?? 0);
-        $isDebit = (int) ($row->cg_aksi ?? 0) === 1;
+        $isDebit = self::isDebitColumn((int) ($row->cg_aksi ?? 0), (int) ($row->cg_type ?? 0), $nominal);
         $debit = $isDebit ? 'Rp ' . self::money($nominal) : 'Rp 0';
         $credit = $isDebit ? 'Rp 0' : '(Rp ' . self::money($nominal) . ')';
 
@@ -147,7 +166,17 @@ class CashOperasionalPresenter
     public static function armadaRow(object $row, $user): array
     {
         $nominal = (int) ($row->cr_nominal ?? 0);
-        $isDebit = (int) ($row->cr_type ?? 0) === 1;
+        // GitHub #130 (item 36): `cr_type` carries real meaning for "operasional" rows (1 =
+        // Setoran/Masuk, else Keluar) AND for rows CashGudang::acceptCashGudang() cross-creates
+        // directly (cr_type explicitly 1, cr_aksi left at its 0 default) — both must keep using
+        // `cr_type` exactly as before. Only the "saldo" / Pengembalian Dana Langsung branch
+        // (`cr_aksi` == 1) never sets `cr_type` at all (model defaults it to 3), so ITS Masuk/Keluar
+        // column must come from the nominal's own sign instead: a normal (positive) pengembalian
+        // reduces the wallet (Keluar), a negative one reverses that and is functionally an addition
+        // (Masuk).
+        $isDebit = (int) ($row->cr_aksi ?? 0) === 1
+            ? $nominal < 0
+            : (int) ($row->cr_type ?? 0) === 1;
         $debit = $isDebit ? 'Rp ' . self::money($nominal) : 'Rp 0';
         $credit = $isDebit ? 'Rp 0' : '(Rp ' . self::money($nominal) . ')';
 
@@ -191,7 +220,14 @@ class CashOperasionalPresenter
     public static function salesRow(object $row, $user): array
     {
         $nominal = (int) ($row->cs_nominal ?? 0);
-        $isDebit = (int) ($row->cs_transaction ?? 0) === 1 && (int) ($row->cs_aksi ?? 0) === 1;
+        // GitHub #130 (item 38): only the "Pengembalian" saldo action (`cs_aksi` == 3) needs the
+        // sign-based flip — a negative pengembalian is functionally an addition, so it belongs in
+        // Masuk instead of Keluar. "Pemasukan" (aksi 1), "Setor ke Bank" (aksi 2, and per item 39
+        // now guarded against ever being negative) and "operasional" rows (aksi left at its 0
+        // default) all keep their original logic untouched.
+        $isDebit = (int) ($row->cs_aksi ?? 0) === 3
+            ? $nominal < 0
+            : ((int) ($row->cs_transaction ?? 0) === 1 && (int) ($row->cs_aksi ?? 0) === 1);
         $debit = $isDebit ? 'Rp ' . self::money($nominal) : 'Rp 0';
         $credit = $isDebit ? 'Rp 0' : '(Rp ' . self::money($nominal) . ')';
 

--- a/app/Support/CashOperasionalPresenter.php
+++ b/app/Support/CashOperasionalPresenter.php
@@ -74,19 +74,24 @@ class CashOperasionalPresenter
 
         $action = '';
         if (self::can($user, 'view')) {
-            $action .= '<a class="me-2 btn-action-icon p-2 btn_view_admin" data-id="' . (int) $row->ca_id . '" data-bs-target="#view-cash"><i class="fe fe-eye"></i></a>';
+            $action .= '<a class="me-2 btn-action-icon btn-action-view p-2 btn_view_admin" data-id="' . (int) $row->ca_id . '" data-bs-target="#view-cash"><i class="fe fe-eye"></i></a>';
         }
         if ((int) $row->status === 1) {
             if ((int) $row->ca_type === 1) {
                 if (self::can($user, 'edit')) {
-                    $action .= '<a class="me-2 btn-action-icon p-2 btn_edit_admin" data-id="' . (int) $row->ca_id . '" data-bs-target="#edit-category"><i class="fe fe-edit"></i></a>';
+                    $action .= '<a class="me-2 btn-action-icon btn-action-edit p-2 btn_edit_admin" data-id="' . (int) $row->ca_id . '" data-bs-target="#edit-category"><i class="fe fe-edit"></i></a>';
                 }
                 if (self::can($user, 'delete')) {
-                    $action .= '<a class="p-2 btn-action-icon btn_delete_admin" data-id="' . (int) $row->ca_id . '" href="javascript:void(0);"><i class="fe fe-trash-2"></i></a>';
+                    $action .= '<a class="p-2 btn-action-icon btn-action-delete btn_delete_admin" data-id="' . (int) $row->ca_id . '" href="javascript:void(0);"><i class="fe fe-trash-2"></i></a>';
                 }
             } elseif ((int) $row->ca_type === 2 && self::can($user, 'others')) {
-                $action .= '<a class="me-2 btn-action-icon p-2 btn_acc bg-success text-light" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Terima" cash_id="' . (int) $row->cash_id . '"><i class="fe fe-check"></i></a>';
-                $action .= '<a class="me-2 btn-action-icon p-2 btn_decline bg-danger text-light" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Tolak" cash_id="' . (int) $row->cash_id . '"><i class="fe fe-x"></i></a>';
+                // GitHub #117/#130: bg-success/bg-danger + text-light are Bootstrap utility
+                // classes, which lose to header.blade.php's global `.btn-action-icon { ...
+                // !important }` reset — these rendered plain/uncolored in practice. Use the
+                // dedicated .btn-action-approve/.btn-action-reject classes instead (same rollout
+                // that already fixed this for other tables' row-level ACC/Tolak icons).
+                $action .= '<a class="me-2 btn-action-icon btn-action-approve p-2 btn_acc" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Terima" cash_id="' . (int) $row->cash_id . '"><i class="fe fe-check"></i></a>';
+                $action .= '<a class="me-2 btn-action-icon btn-action-reject p-2 btn_decline" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Tolak" cash_id="' . (int) $row->cash_id . '"><i class="fe fe-x"></i></a>';
             }
         }
         if ($action === '') {
@@ -123,19 +128,20 @@ class CashOperasionalPresenter
 
         $action = '';
         if (self::can($user, 'view')) {
-            $action .= '<a class="me-2 btn-action-icon p-2 btn_view_gudang" data-id="' . (int) $row->cg_id . '" data-bs-target="#view-cash"><i class="fe fe-eye"></i></a>';
+            $action .= '<a class="me-2 btn-action-icon btn-action-view p-2 btn_view_gudang" data-id="' . (int) $row->cg_id . '" data-bs-target="#view-cash"><i class="fe fe-eye"></i></a>';
         }
         if ((int) $row->status === 1) {
             if ((int) $row->cg_type === 1) {
                 if (self::can($user, 'edit')) {
-                    $action .= '<a class="me-2 btn-action-icon p-2 btn_edit_gudang" data-id="' . (int) $row->cg_id . '" data-bs-target="#edit-category"><i class="fe fe-edit"></i></a>';
+                    $action .= '<a class="me-2 btn-action-icon btn-action-edit p-2 btn_edit_gudang" data-id="' . (int) $row->cg_id . '" data-bs-target="#edit-category"><i class="fe fe-edit"></i></a>';
                 }
                 if (self::can($user, 'delete')) {
-                    $action .= '<a class="p-2 btn-action-icon btn_delete_gudang" data-id="' . (int) $row->cg_id . '" href="javascript:void(0);"><i class="fe fe-trash-2"></i></a>';
+                    $action .= '<a class="p-2 btn-action-icon btn-action-delete btn_delete_gudang" data-id="' . (int) $row->cg_id . '" href="javascript:void(0);"><i class="fe fe-trash-2"></i></a>';
                 }
             } elseif ((int) $row->cg_type === 2 && self::can($user, 'others')) {
-                $action .= '<a class="me-2 btn-action-icon p-2 btn_acc bg-success text-light" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Terima" cash_id="' . (int) $row->cash_id . '"><i class="fe fe-check"></i></a>';
-                $action .= '<a class="me-2 btn-action-icon p-2 btn_decline bg-danger text-light" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Tolak" cash_id="' . (int) $row->cash_id . '"><i class="fe fe-x"></i></a>';
+                // GitHub #117/#130: see the same note in adminRow() above.
+                $action .= '<a class="me-2 btn-action-icon btn-action-approve p-2 btn_acc" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Terima" cash_id="' . (int) $row->cash_id . '"><i class="fe fe-check"></i></a>';
+                $action .= '<a class="me-2 btn-action-icon btn-action-reject p-2 btn_decline" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Tolak" cash_id="' . (int) $row->cash_id . '"><i class="fe fe-x"></i></a>';
             }
         }
         if ($action === '') {
@@ -183,11 +189,12 @@ class CashOperasionalPresenter
         $action = '';
         $hideView = (int) $row->status === 2 && (int) $row->cr_type === 1;
         if (!$hideView && self::can($user, 'view')) {
-            $action .= '<a class="me-2 btn-action-icon p-2 btn_view_armada" data-id="' . (int) $row->cr_id . '" data-bs-target="#view-cash"><i class="fe fe-eye"></i></a>';
+            $action .= '<a class="me-2 btn-action-icon btn-action-view p-2 btn_view_armada" data-id="' . (int) $row->cr_id . '" data-bs-target="#view-cash"><i class="fe fe-eye"></i></a>';
         }
         if ((int) $row->status === 1 && (int) ($row->cr_aksi ?? 0) === 2 && self::can($user, 'others')) {
-            $action .= '<a class="me-2 btn-action-icon p-2 btn_acc bg-success text-light" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Terima" cash_id="' . (int) $row->cash_id . '"><i class="fe fe-check"></i></a>';
-            $action .= '<a class="me-2 btn-action-icon p-2 btn_decline bg-danger text-light" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Tolak" cash_id="' . (int) $row->cash_id . '"><i class="fe fe-x"></i></a>';
+            // GitHub #117/#130: see the same note in adminRow() above.
+            $action .= '<a class="me-2 btn-action-icon btn-action-approve p-2 btn_acc" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Terima" cash_id="' . (int) $row->cash_id . '"><i class="fe fe-check"></i></a>';
+            $action .= '<a class="me-2 btn-action-icon btn-action-reject p-2 btn_decline" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Tolak" cash_id="' . (int) $row->cash_id . '"><i class="fe fe-x"></i></a>';
         }
         if ($action === '' && !$hideView) {
             $action = '<span class="text-muted small">—</span>';
@@ -233,11 +240,12 @@ class CashOperasionalPresenter
 
         $action = '';
         if (self::can($user, 'view')) {
-            $action .= '<a class="me-2 btn-action-icon p-2 btn_view_sales" data-id="' . (int) $row->cs_id . '" data-bs-target="#view-cash"><i class="fe fe-eye"></i></a>';
+            $action .= '<a class="me-2 btn-action-icon btn-action-view p-2 btn_view_sales" data-id="' . (int) $row->cs_id . '" data-bs-target="#view-cash"><i class="fe fe-eye"></i></a>';
         }
         if ((int) $row->status === 1 && (int) ($row->cs_aksi ?? 0) === 1 && self::can($user, 'others')) {
-            $action .= '<a class="me-2 btn-action-icon p-2 btn_acc bg-success text-light" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Terima" cash_id="' . (int) $row->cash_id . '"><i class="fe fe-check"></i></a>';
-            $action .= '<a class="me-2 btn-action-icon p-2 btn_decline bg-danger text-light" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Tolak" cash_id="' . (int) $row->cash_id . '"><i class="fe fe-x"></i></a>';
+            // GitHub #117/#130: see the same note in adminRow() above.
+            $action .= '<a class="me-2 btn-action-icon btn-action-approve p-2 btn_acc" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Terima" cash_id="' . (int) $row->cash_id . '"><i class="fe fe-check"></i></a>';
+            $action .= '<a class="me-2 btn-action-icon btn-action-reject p-2 btn_decline" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Tolak" cash_id="' . (int) $row->cash_id . '"><i class="fe fe-x"></i></a>';
         }
         if ($action === '') {
             $action = '<span class="text-muted small">—</span>';

--- a/docs/popup-table-modal-rollout.md
+++ b/docs/popup-table-modal-rollout.md
@@ -29,10 +29,10 @@ lose track of what's left. Check off + note the PR/commit when a row ships.
 | # | Modal | File(s) | Variant | Notes | Status |
 |---|---|---|---|---|---|
 | 1 | Produksi → Tambah Produksi | `components/modals/production/add-production.blade.php` + `Production.js` | A | Pilot — reference implementation | ✅ Done (`feat/popup-table-produksi`) |
-| 2 | Kas Operasional → Kas Admin | `components/modals/operational-cash/add-cash-admin.blade.php` | A | `btn-add-catatan` | ⬜ To do |
-| 3 | Kas Operasional → Kas Armada | `components/modals/operational-cash/add-cash-armada.blade.php` | A | already uses `input_table` class | ⬜ To do |
-| 4 | Kas Operasional → Kas Gudang | `components/modals/operational-cash/add-cash-gudang.blade.php` | A | already uses `input_table` class | ⬜ To do |
-| 5 | Kas Operasional → Kas Sales | `components/modals/operational-cash/add-cash-sales.blade.php` | A | already uses `input_table` class | ⬜ To do |
+| 2 | Kas Operasional → Kas Admin | `components/modals/operational-cash/add-cash-admin.blade.php` | A | `btn-add-catatan` | ✅ Done (GitHub #130 branch `fix/kas-operasional-module-130`) |
+| 3 | Kas Operasional → Kas Armada | `components/modals/operational-cash/add-cash-armada.blade.php` | A | already uses `input_table` class | ✅ Done (GitHub #130 branch `fix/kas-operasional-module-130`) |
+| 4 | Kas Operasional → Kas Gudang | `components/modals/operational-cash/add-cash-gudang.blade.php` | A | already uses `input_table` class | ✅ Done (GitHub #130 branch `fix/kas-operasional-module-130`) |
+| 5 | Kas Operasional → Kas Sales | `components/modals/operational-cash/add-cash-sales.blade.php` | A | already uses `input_table` class | ✅ Done (GitHub #130 branch `fix/kas-operasional-module-130`) |
 | 6 | Purchase Order → Tambah Purchase Order | `components/modals/purchase-order/add-purchase-order.blade.php` | A | SKU/scan input above table, no scroll cap today | ⬜ To do |
 | 7 | Purchase Order Detail → Retur | `components/modals/purchase-order-detail/add-retur.blade.php` | A | already uses `input_table` class | ⬜ To do |
 | 8 | Sales Order → Tambah Sales Order | `components/modals/sales-order/add-sales-order.blade.php` | A | has its own **broken** ad-hoc `max-height:300px` cap — blade has a comment admitting it doesn't actually apply; migrating fixes this as a side effect | ⬜ To do |

--- a/docs/table-action-button-color-rollout.md
+++ b/docs/table-action-button-color-rollout.md
@@ -10,8 +10,9 @@ distinct from the plain edit/view/delete icons next to it.
 icons on that same row were still using the same defeated inline-`style=` pattern (only their color
 was forced, background stayed white per the base rule) — so per-row requests came in to fix those too.
 `.btn-action-view`/`.btn-action-edit`/`.btn-action-delete` were added alongside approve/reject for this
-(see Root cause). Applied so far only to `Customer_Return.js` (Pengiriman → Pengembalian tab); other
-tables' view/edit/delete icons haven't been swept yet — do it opportunistically per-row like the rest
+(see Root cause). Applied so far to `Customer_Return.js` (Pengiriman → Pengembalian tab) and row #8's
+Kas Operasional presenters below; other tables' view/edit/delete icons haven't been swept yet — do it
+opportunistically per-row like the rest
 of this tracker, not as a blanket pass.
 
 ## ⚠️ Root cause (found while fixing row #6, Tanda Terima PO)
@@ -73,8 +74,9 @@ Out of scope (not "di table"):
 | 5 | ~~Product Issue (Produk Bermasalah) list~~ → Terima / Tolak | `Inventory/Product_Issues.js` (`.btn_acc`/`.btn_decline`) | **Miscategorized in the original pass** — the table row only ever renders a "Lihat" icon; Terima/Tolak are static buttons (`#btn-terima`/`#btn-tolak`) inside `add-product-issues.blade.php`'s modal footer, not a table row icon | ➡️ Moved to "Not in scope" below |
 | 6 | Tanda Terima PO (`tt`) list → Terima / Tolak | `Suppliers/tt.js` (`btn_acc_tt` / `btn_decline_tt`) | root-caused here; found the global `!important` override | ✅ Done — `.btn-action-approve`/`.btn-action-reject` classes (defined in `header.blade.php`), gradient matches `.pg-btn-accept`/`.pg-btn-decline`; also got shimmer loading + PG modal styling for its Konfirmasi Terima popup |
 | 7 | Stock Transfer list → ACC Terkirim | `Inventory/Stock_Transfer.js` (`btnAccept`, ~line 664) | was `text-info` only, then inline style (also defeated) | ✅ Done — switched to `.btn-action-approve` class |
+| 8 | Kas Operasional (Admin/Gudang/Armada/Sales) → Terima/Tolak, **plus** Kas → Kas Besar → Terima/Tolak | `app/Support/CashOperasionalPresenter.php` (`adminRow`/`gudangRow`/`armadaRow`/`salesRow`), `app/Support/CashBesarPresenter.php` (`row`) — server-rendered PHP, not JS-built like the other rows here | **Miscategorized as "Modal buttons, not row icons" in the original pass** — these ARE row-level `.btn_acc`/`.btn_decline` icons DataTables renders per row (built server-side by the presenter classes, unlike every other row in this table which builds the `action` HTML in JS); they used the same defeated `bg-success`/`bg-danger text-light` Bootstrap-utility pattern as everything else here. Found while investigating GitHub #130 (2026-09-03). While in there, also swept that same presenter's view/edit/delete icons onto `.btn-action-view`/`.btn-action-edit`/`.btn-action-delete` (all 4 Kas Operasional row types) since they were sitting right next to the now-fixed approve/reject icons on the same row. | ✅ Done — switched to `.btn-action-approve`/`.btn-action-reject` (+ `.btn-action-view`/`.btn-action-edit`/`.btn-action-delete`) |
 
-All 5 real table-row targets (rows #1, #2, #6, #7, plus the two orphaned files #3/#4) are now on the
+All 6 real table-row targets (rows #1, #2, #6, #7, #8, plus the two orphaned files #3/#4) are now on the
 shared `.btn-action-approve`/`.btn-action-reject` classes with the gradient fill from `header.blade.php`.
 
 ### Not in scope (checked, excluded)
@@ -84,7 +86,6 @@ shared `.btn-action-approve`/`.btn-action-reject` classes with the gradient fill
 | Produksi → Terima/Tolak Produksi | `components/modals/production/add-production.blade.php` + `Production.js` | Modal footer button, not a table row icon |
 | Purchase Order Detail → Terima/Tolak PO | `Suppliers/Purchase_Order_Detail.js` (`#btn-acc-po`, `#btn-tolak-po`) | Modal footer button |
 | Stock Opname / Stock Opname Bahan → Konfirmasi ACC | `Inventory/CreateStockOpname(Supplies).js` (`#btn-acc-sto` / `#btn-acc-stob`) | Modal footer button |
-| Kas Operasional (Admin/Gudang/Armada/Sales) → ACC/Tolak | `Reports/Cash.js`, `Reports/Cash_Operational.js` (`.btn_acc`, `.btn_decline`) | Modal buttons, not row icons |
 | Sales Order Detail → Tolak (delivery/invoice) | `Customers/Sales_Order_detail.js` (`.btn-decline`) | Modal footer button |
 | ReportEfisiensiProduksi / ReportProduction "Tolak" | `Reports/ReportEfisiensiProduksi.js`, `Reports/ReportProduction.js` | Read-only status badge, not an action button |
 | Purchase Order list (Suppliers) | `Suppliers/Purchase_Order.js` | Only has Lihat/Hapus row icons; ACC/Tolak happens in the PO Detail modal instead |

--- a/public/Custom_js/Backoffice/Reports/Cash_Operational.js
+++ b/public/Custom_js/Backoffice/Reports/Cash_Operational.js
@@ -8,6 +8,27 @@
     var cashTableReady = false;
     var cashPendingDeepLink = null;
 
+    /**
+     * cr_img/cs_img are supposed to be a JSON-encoded array of filenames, but some rows (older
+     * data, or rows inserted by another path such as the External API) store a single bare
+     * filename string instead, or leave the field null/empty. `JSON.parse()` throws on a bare
+     * filename or an empty string, and indexing `img[0]` on the resulting `null` throws too — both
+     * were uncaught, silently aborting the whole click handler before it ever reached
+     * `.modal("show")`, which is why the "Lihat"/"Update" eye/edit icon on Dompet Armada/Sales
+     * appeared to do nothing. Always returns a plain array, empty when there's nothing usable.
+     */
+    function parseCashPhotoList(raw) {
+        if (!raw) return [];
+        try {
+            var parsed = JSON.parse(raw);
+            if (Array.isArray(parsed)) return parsed;
+            if (parsed) return [parsed];
+            return [];
+        } catch (e) {
+            return [raw];
+        }
+    }
+
     function updateCashOperationalFooter(debits, credits) {
         var sisa = (parseInt(debits, 10) || 0) - (parseInt(credits, 10) || 0);
         $('#tableCash tfoot .debits').html(`Rp ${formatRupiahMinus(debits)}`);
@@ -2277,16 +2298,20 @@
             $('.foto').show();
             $('#btn-foto-bukti-armada').hide();
             $('#btn-lihat-bukti-armada').show();
-            var img = JSON.parse(data.cr_img);
-            list_photo = img || null;
+            var img = parseCashPhotoList(data.cr_img);
+            list_photo = img;
             console.log(list_photo);
-    
-            $('#modalViewPhoto .modal-footer').show();
-            $('#fotoProduksiImage').attr('src', public+"kas_admin/armada/"+img[0]);
-            $('#fotoProduksiImage').attr('index', 0);
-            $('#btn_download_photo').attr('href', public+"kas_admin/armada/"+img[0]);
-            $('#check_foto_armada').show();
-            $('#jumlahFoto').html(list_photo.length);
+
+            if (img.length) {
+                $('#modalViewPhoto .modal-footer').show();
+                $('#fotoProduksiImage').attr('src', public+"kas_admin/armada/"+img[0]);
+                $('#fotoProduksiImage').attr('index', 0);
+                $('#btn_download_photo').attr('href', public+"kas_admin/armada/"+img[0]);
+                $('#check_foto_armada').show();
+                $('#jumlahFoto').html(list_photo.length);
+            } else {
+                $('#check_foto_armada').hide();
+            }
             $('#bukti_armada').val(data.cr_img);
             
         } else {
@@ -2339,16 +2364,20 @@
             $('.foto').show();
             $('#btn-foto-bukti-armada').hide();
             $('#btn-lihat-bukti-armada').show();
-            var img = JSON.parse(data.cr_img);
-            list_photo = img || null;
+            var img = parseCashPhotoList(data.cr_img);
+            list_photo = img;
             console.log(list_photo);
-    
-            $('#modalViewPhoto .modal-footer').show();
-            $('#fotoProduksiImage').attr('src', public+"kas_admin/armada/"+img[0]);
-            $('#fotoProduksiImage').attr('index', 0);
-            $('#btn_download_photo').attr('href', public+"kas_admin/armada/"+img[0]);
-            $('#check_foto_armada').show();
-            $('#jumlahFoto').html(list_photo.length);
+
+            if (img.length) {
+                $('#modalViewPhoto .modal-footer').show();
+                $('#fotoProduksiImage').attr('src', public+"kas_admin/armada/"+img[0]);
+                $('#fotoProduksiImage').attr('index', 0);
+                $('#btn_download_photo').attr('href', public+"kas_admin/armada/"+img[0]);
+                $('#check_foto_armada').show();
+                $('#jumlahFoto').html(list_photo.length);
+            } else {
+                $('#check_foto_armada').hide();
+            }
             $('#bukti_armada').val(data.cr_img);
             
         } else {
@@ -2435,16 +2464,20 @@
             $('.foto').show();
             $('#btn-foto-bukti-sales').hide();
             $('#btn-lihat-bukti-sales').show();
-            var img = JSON.parse(data.cs_img);
-            list_photo = img || null;
+            var img = parseCashPhotoList(data.cs_img);
+            list_photo = img;
             console.log(list_photo);
-    
-            $('#modalViewPhoto .modal-footer').show();
-            $('#fotoProduksiImage').attr('src', public+"kas_admin/sales/"+img[0]);
-            $('#fotoProduksiImage').attr('index', 0);
-            $('#btn_download_photo').attr('href', public+"kas_admin/sales/"+img[0]);
-            $('#check_foto_sales').show();
-            $('#jumlahFoto').html(list_photo.length);
+
+            if (img.length) {
+                $('#modalViewPhoto .modal-footer').show();
+                $('#fotoProduksiImage').attr('src', public+"kas_admin/sales/"+img[0]);
+                $('#fotoProduksiImage').attr('index', 0);
+                $('#btn_download_photo').attr('href', public+"kas_admin/sales/"+img[0]);
+                $('#check_foto_sales').show();
+                $('#jumlahFoto').html(list_photo.length);
+            } else {
+                $('#check_foto_sales').hide();
+            }
             $('#bukti_sales').val(data.cs_img);
             
         } else {
@@ -2496,16 +2529,20 @@
             $('.foto').show();
             $('#btn-foto-bukti-sales').hide();
             $('#btn-lihat-bukti-sales').show();
-            var img = JSON.parse(data.cs_img);
-            list_photo = img || null;
+            var img = parseCashPhotoList(data.cs_img);
+            list_photo = img;
             console.log(list_photo);
-    
-            $('#modalViewPhoto .modal-footer').show();
-            $('#fotoProduksiImage').attr('src', public+"kas_admin/sales/"+img[0]);
-            $('#fotoProduksiImage').attr('index', 0);
-            $('#btn_download_photo').attr('href', public+"kas_admin/sales/"+img[0]);
-            $('#check_foto_sales').show();
-            $('#jumlahFoto').html(list_photo.length);
+
+            if (img.length) {
+                $('#modalViewPhoto .modal-footer').show();
+                $('#fotoProduksiImage').attr('src', public+"kas_admin/sales/"+img[0]);
+                $('#fotoProduksiImage').attr('index', 0);
+                $('#btn_download_photo').attr('href', public+"kas_admin/sales/"+img[0]);
+                $('#check_foto_sales').show();
+                $('#jumlahFoto').html(list_photo.length);
+            } else {
+                $('#check_foto_sales').hide();
+            }
             $('#bukti_sales').val(data.cs_img);
             
         } else {

--- a/public/Custom_js/Backoffice/Reports/Cash_Operational.js
+++ b/public/Custom_js/Backoffice/Reports/Cash_Operational.js
@@ -1096,7 +1096,7 @@
             "cad_notes": $('#cad_notes').val(),
             "cad_nominal": convertToAngkaMinus($('#cad_nominal').val()),
         };
-        items.push(data);
+        pgPopupTableInsert(items, data);
 
         var total = 0;
         items.forEach(element => {
@@ -1105,20 +1105,24 @@
         $('.total').html(`Rp ${formatRupiahMinus(total)}`)
 
         addRow();
+        pgPopupTableScrollToEdge($('#tableDetail').closest('.pg-popup-table-scroll'));
 
         $('#cad_notes').val("");
         $('#cad_nominal').val("");
     })
 
     function addRow() {
-        $('#tableDetail tr.row-detail').html(" ");
+        $('#tableDetail tbody').html("");
+        if (items.length === 0) {
+            $('#tableDetail tbody').html('<tr class="pg-popup-table-empty"><td colspan="4">Belum ada aktivitas. Tambahkan lewat form di atas.</td></tr>');
+        }
         items.forEach((e, index) => {
             $('#tableDetail tbody').append(`
                 <tr class="row-detail" data-id="${index}">
                     <td>${index+1}</td>
                     <td style="width: 25%">${e.cad_notes}</td>
                     <td class="text-end">Rp ${formatRupiahMinus(e.cad_nominal)}</td>
-                    <td class="text-center d-flex align-items-center">
+                    <td class="text-center d-flex align-items-center col-aksi">
                         ${mode === 3 ? '' : `
                         <a class="p-2 btn-action-icon btn_delete_row mx-auto"  href="javascript:void(0);">
                                 <i class="fe fe-trash-2"></i>
@@ -1127,6 +1131,7 @@
                 </tr>
             `);
         });
+        $('#tableDetail .col-aksi').toggle(mode !== 3);
     }
 
     $(document).on("click", ".btn_delete_row", function() {
@@ -1300,7 +1305,7 @@
             "cgd_notes": $('#cgd_notes').val(),
             "cgd_nominal": convertToAngkaMinus($('#cgd_nominal').val()),
         };
-        items.push(data);
+        pgPopupTableInsert(items, data);
 
         var total = 0;
         items.forEach(element => {
@@ -1309,6 +1314,7 @@
         $('.total_gudang').html(`Rp ${formatRupiahMinus(total)}`)
 
         addRowGudang();
+        pgPopupTableScrollToEdge($('#tableDetailGudang').closest('.pg-popup-table-scroll'));
 
         $('#customer_id').empty(null);
         $('#cgd_notes').val("");
@@ -1318,7 +1324,10 @@
     })
 
     function addRowGudang() {
-        $('#tableDetailGudang tr.row-detail').html(" ");
+        $('#tableDetailGudang tbody').html("");
+        if (items.length === 0) {
+            $('#tableDetailGudang tbody').html('<tr class="pg-popup-table-empty"><td colspan="5">Belum ada aktivitas. Tambahkan lewat form di atas.</td></tr>');
+        }
         console.log(items);
         items.forEach((e, index) => {
             $('#tableDetailGudang tbody').append(`
@@ -1327,7 +1336,7 @@
                     <td>${e.customer_notes}</td>
                     <td style="width: 25%">${e.cgd_notes}</td>
                     <td class="text-end">Rp ${formatRupiahMinus(e.cgd_nominal)}</td>
-                    <td class="text-center d-flex align-items-center">
+                    <td class="text-center d-flex align-items-center col-aksi">
                         ${mode === 3 ? '' : `
                         <a class="p-2 btn-action-icon btn_delete_row_gudang mx-auto"  href="javascript:void(0);">
                                 <i class="fe fe-trash-2"></i>
@@ -1336,6 +1345,7 @@
                 </tr>
             `);
         });
+        $('#tableDetailGudang .col-aksi').toggle(mode !== 3);
     }
 
     $(document).on("click", ".btn_delete_row_gudang", function() {
@@ -1498,19 +1508,19 @@
         };
 
         if (items.length === 0) {
-            items.push(data);
+            pgPopupTableInsert(items, data);
         } else {
             if (
                 (newType == 1 && firstType == 1) ||
                 (newType == 2 && firstType == 2) ||
                 (newType == 3 && firstType == 3)
             ) {
-                items.push(data);
+                pgPopupTableInsert(items, data);
             }
             else {
                 $('#oc_transaksi_armada').addClass('is-invalid');
                 notifikasi('error', "Gagal Insert", 'Tipe yang diinputkan wajib satu kategori');
-                ResetLoadingButton('.btn-save-armada', mode == 1?"Tambah Aktivitas" : "Update Aktivitas"); 
+                ResetLoadingButton('.btn-save-armada', mode == 1?"Tambah Aktivitas" : "Update Aktivitas");
                 return false;
             }
         }
@@ -1522,6 +1532,7 @@
         $('.total_armada').html(`Rp ${formatRupiahMinus(total)}`)
 
         addRowArmada();
+        pgPopupTableScrollToEdge($('#tableDetailArmada').closest('.pg-popup-table-scroll'));
 
         $('#customer_id').empty(null);
         $('#cc_id').empty(null);
@@ -1529,7 +1540,10 @@
     })
 
     function addRowArmada() {
-        $('#tableDetailArmada tr.row-detail').html(" ");
+        $('#tableDetailArmada tbody').html("");
+        if (items.length === 0) {
+            $('#tableDetailArmada tbody').html('<tr class="pg-popup-table-empty"><td colspan="5">Belum ada aktivitas. Tambahkan lewat form di atas.</td></tr>');
+        }
         console.log(items);
         items.forEach((e, index) => {
             let type = "";
@@ -1544,7 +1558,7 @@
                     <td>${type}</td>
                     <td style="width: 25%">${e.crd_notes}</td>
                     <td class="text-end">Rp ${formatRupiahMinus(e.crd_nominal)}</td>
-                    <td class="text-center d-flex align-items-center">
+                    <td class="text-center d-flex align-items-center col-aksi">
                         ${mode === 3 ? '' : `
                         <a class="p-2 btn-action-icon btn_delete_row_armada mx-auto"  href="javascript:void(0);">
                                 <i class="fe fe-trash-2"></i>
@@ -1553,6 +1567,7 @@
                 </tr>
             `);
         });
+        $('#tableDetailArmada .col-aksi').toggle(mode !== 3);
     }
 
     $(document).on("click", ".btn_delete_row_armada", function() {
@@ -1709,19 +1724,19 @@
         };
 
         if (items.length === 0) {
-            items.push(data);
+            pgPopupTableInsert(items, data);
         } else {
             if (
                 (newType == 1 && firstType == 1) ||
                 (newType == 2 && firstType == 2) ||
                 (newType == 3 && firstType == 3)
             ) {
-                items.push(data);
+                pgPopupTableInsert(items, data);
             }
             else {
                 $('#oc_transaksi_sales').addClass('is-invalid');
                 notifikasi('error', "Gagal Insert", 'Tipe yang diinputkan wajib satu kategori');
-                ResetLoadingButton('.btn-save-sales', mode == 1?"Tambah Aktivitas" : "Update Aktivitas"); 
+                ResetLoadingButton('.btn-save-sales', mode == 1?"Tambah Aktivitas" : "Update Aktivitas");
                 return false;
             }
         }
@@ -1733,6 +1748,7 @@
         $('.total_sales').html(`Rp ${formatRupiahMinus(total)}`)
 
         addRowSales();
+        pgPopupTableScrollToEdge($('#tableDetailSales').closest('.pg-popup-table-scroll'));
 
         $('#customer_id').empty(null);
         $('#cc_id_sales').empty(null);
@@ -1740,7 +1756,10 @@
     })
 
     function addRowSales() {
-        $('#tableDetailSales tr.row-detail').html(" ");
+        $('#tableDetailSales tbody').html("");
+        if (items.length === 0) {
+            $('#tableDetailSales tbody').html('<tr class="pg-popup-table-empty"><td colspan="5">Belum ada aktivitas. Tambahkan lewat form di atas.</td></tr>');
+        }
         console.log(items);
         items.forEach((e, index) => {
             let type = "";
@@ -1753,7 +1772,7 @@
                     <td>${type}</td>
                     <td style="width: 25%">${e.csd_notes}</td>
                     <td class="text-end">Rp ${formatRupiahMinus(e.csd_nominal)}</td>
-                    <td class="text-center d-flex align-items-center">
+                    <td class="text-center d-flex align-items-center col-aksi">
                         ${mode === 3 ? '' : `
                         <a class="p-2 btn-action-icon btn_delete_row_sales mx-auto"  href="javascript:void(0);">
                                 <i class="fe fe-trash-2"></i>
@@ -1761,7 +1780,8 @@
                     </td>
                 </tr>
             `);
-        }); 
+        });
+        $('#tableDetailSales .col-aksi').toggle(mode !== 3);
     }
 
     $(document).on("click", ".btn_delete_row_sales", function() {

--- a/public/Custom_js/Backoffice/Reports/Cash_Operational.js
+++ b/public/Custom_js/Backoffice/Reports/Cash_Operational.js
@@ -646,9 +646,29 @@
 
     $(document).on('change', '#customer_id_armada', function(){
         if (mode == 1 && $('#jenis_input_armada').val() == "saldo"){
-            if ($(this).val()){
-                var temp = $('#customer_id_armada').select2("data")[0];
-                $('#oc_nominal_armada').val(formatRupiahMinus(temp.customer_saldo)).attr('disabled', false);
+            var customerId = $(this).val();
+            if (customerId){
+                // GitHub #130 (item 37): jangan pakai select2("data") di sini — kalau opsi ini
+                // dibuat dari data cache filter halaman (lihat pemanggilan .btn-add-armada di
+                // atas), customer_saldo-nya bisa basi (mis. sudah berubah + gara-gara aktivitas
+                // "Uang Masuk Customer" yang baru saja di-ACC), jadi default nominal pengembalian
+                // salah tanda (minus padahal seharusnya plus). Ambil ulang dari server.
+                $.ajax({
+                    url: '/autocompleteCustomer',
+                    method: 'post',
+                    data: { customer_id: customerId, _token: token },
+                    success: function (res) {
+                        var rows = (res && res.data) ? res.data : [];
+                        var fresh = rows.find(function (r) { return String(r.customer_id) == String(customerId); }) || rows[0];
+                        var saldo = fresh ? fresh.customer_saldo : 0;
+                        $('#oc_nominal_armada').val(formatRupiahMinus(saldo)).attr('disabled', false);
+                    },
+                    error: function () {
+                        // fallback ke data lama daripada mengosongkan field kalau request gagal
+                        var temp = $('#customer_id_armada').select2("data")[0];
+                        $('#oc_nominal_armada').val(formatRupiahMinus(temp.customer_saldo)).attr('disabled', false);
+                    }
+                });
             } else {
                 $('#oc_nominal_armada').val("").attr('disabled', false);
             }
@@ -1131,7 +1151,10 @@
                 </tr>
             `);
         });
-        $('#tableDetail .col-aksi').toggle(mode !== 3);
+        // Jangan .toggle() seluruh kolom — menyembunyikan <th> tapi tidak <td> (atau sebaliknya)
+        // bikin header/body tidak sejajar lagi. Kolomnya tetap ada, cuma judulnya dikosongkan;
+        // isi selnya sendiri sudah otomatis kosong di mode view lewat ternary di atas.
+        $('#tableDetail thead .col-aksi').text(mode === 3 ? '' : 'Aksi');
     }
 
     $(document).on("click", ".btn_delete_row", function() {
@@ -1345,7 +1368,8 @@
                 </tr>
             `);
         });
-        $('#tableDetailGudang .col-aksi').toggle(mode !== 3);
+        // Lihat catatan di addRow() (Kas Admin) di atas — jangan .toggle() seluruh kolom.
+        $('#tableDetailGudang thead .col-aksi').text(mode === 3 ? '' : 'Aksi');
     }
 
     $(document).on("click", ".btn_delete_row_gudang", function() {
@@ -1567,7 +1591,8 @@
                 </tr>
             `);
         });
-        $('#tableDetailArmada .col-aksi').toggle(mode !== 3);
+        // Lihat catatan di addRow() (Kas Admin) di atas — jangan .toggle() seluruh kolom.
+        $('#tableDetailArmada thead .col-aksi').text(mode === 3 ? '' : 'Aksi');
     }
 
     $(document).on("click", ".btn_delete_row_armada", function() {
@@ -1781,7 +1806,8 @@
                 </tr>
             `);
         });
-        $('#tableDetailSales .col-aksi').toggle(mode !== 3);
+        // Lihat catatan di addRow() (Kas Admin) di atas — jangan .toggle() seluruh kolom.
+        $('#tableDetailSales thead .col-aksi').text(mode === 3 ? '' : 'Aksi');
     }
 
     $(document).on("click", ".btn_delete_row_sales", function() {
@@ -1847,6 +1873,19 @@
             ResetLoadingButton('.btn-save-sales', mode == 1?"Tambah Aktivitas" : "Update Aktivitas");
             return false;
         };
+
+        // GitHub #130 (item 39): "Setor ke Bank" (aksi_sales==2) defaults its nominal from the
+        // sales rep's current staff_saldo, which can itself be negative — but a bank deposit
+        // itself can never sensibly be negative. This is a NEW, separate guard from the
+        // pengembalian-negative-balance one below (which stays disabled per PM's 2026-08-05
+        // decision that negative balances are allowed by design) — that decision was about letting
+        // an account run into a deficit, not about accepting a literally-negative deposit amount.
+        if ($('#aksi_sales').val() == 2 && jenis_input == "saldo" && convertToAngkaMinus($('#oc_nominal_sales').val()) < 0){
+            notifikasi('error', "Gagal Insert", 'Setor ke Bank tidak boleh minus');
+            ResetLoadingButton('.btn-save-sales', mode == 1?"Tambah Aktivitas" : "Update Aktivitas");
+            $('#oc_nominal_sales').addClass('is-invalid');
+            return false;
+        }
 
         // if ($('#aksi_sales').val() == 3 && convertToAngkaMinus($('#oc_nominal_sales').val()) < 0){
         //     notifikasi('error', "Gagal Insert", 'Pengembalian tidak boleh kurang dari 0');

--- a/public/Custom_js/Backoffice/Reports/Cash_Operational.js
+++ b/public/Custom_js/Backoffice/Reports/Cash_Operational.js
@@ -1119,13 +1119,14 @@
                     <td style="width: 25%">${e.cad_notes}</td>
                     <td class="text-end">Rp ${formatRupiahMinus(e.cad_nominal)}</td>
                     <td class="text-center d-flex align-items-center">
+                        ${mode === 3 ? '' : `
                         <a class="p-2 btn-action-icon btn_delete_row mx-auto"  href="javascript:void(0);">
                                 <i class="fe fe-trash-2"></i>
-                        </a>
+                        </a>`}
                     </td>
-                </tr>    
+                </tr>
             `);
-        }); 
+        });
     }
 
     $(document).on("click", ".btn_delete_row", function() {
@@ -1327,13 +1328,14 @@
                     <td style="width: 25%">${e.cgd_notes}</td>
                     <td class="text-end">Rp ${formatRupiahMinus(e.cgd_nominal)}</td>
                     <td class="text-center d-flex align-items-center">
+                        ${mode === 3 ? '' : `
                         <a class="p-2 btn-action-icon btn_delete_row_gudang mx-auto"  href="javascript:void(0);">
                                 <i class="fe fe-trash-2"></i>
-                        </a>
+                        </a>`}
                     </td>
-                </tr>    
+                </tr>
             `);
-        }); 
+        });
     }
 
     $(document).on("click", ".btn_delete_row_gudang", function() {
@@ -1543,13 +1545,14 @@
                     <td style="width: 25%">${e.crd_notes}</td>
                     <td class="text-end">Rp ${formatRupiahMinus(e.crd_nominal)}</td>
                     <td class="text-center d-flex align-items-center">
+                        ${mode === 3 ? '' : `
                         <a class="p-2 btn-action-icon btn_delete_row_armada mx-auto"  href="javascript:void(0);">
                                 <i class="fe fe-trash-2"></i>
-                        </a>
+                        </a>`}
                     </td>
                 </tr>
             `);
-        }); 
+        });
     }
 
     $(document).on("click", ".btn_delete_row_armada", function() {
@@ -1751,9 +1754,10 @@
                     <td style="width: 25%">${e.csd_notes}</td>
                     <td class="text-end">Rp ${formatRupiahMinus(e.csd_nominal)}</td>
                     <td class="text-center d-flex align-items-center">
+                        ${mode === 3 ? '' : `
                         <a class="p-2 btn-action-icon btn_delete_row_sales mx-auto"  href="javascript:void(0);">
                                 <i class="fe fe-trash-2"></i>
-                        </a>
+                        </a>`}
                     </td>
                 </tr>
             `);
@@ -1949,7 +1953,7 @@
         else {
             $('#jenis_input').val("saldo").trigger('change').attr('disabled', true);
             $('#oc_transaksi').val(data.ca_aksi).attr('disabled', true);
-            $('#oc_nominal').val(data.ca_nominal).attr('disabled', false);
+            $('#oc_nominal').val(formatRupiahMinus(data.ca_nominal)).attr('disabled', false);
             $('#oc_notes').val(data.ca_notes).attr('disabled', false);
             $('#oc_date').val(data.ca_date).attr('disabled', true);
         }
@@ -2004,7 +2008,7 @@
         else {
             $('#jenis_input').val("saldo").trigger('change').attr('disabled', true);
             $('#oc_transaksi').val(data.ca_aksi).attr('disabled', true);
-            $('#oc_nominal').val(data.ca_nominal).attr('disabled', true);
+            $('#oc_nominal').val(formatRupiahMinus(data.ca_nominal)).attr('disabled', true);
             $('#oc_notes').val(data.ca_notes).attr('disabled', true);
             $('#oc_date').val(data.ca_date).attr('disabled', true);
         }
@@ -2087,7 +2091,7 @@
         else {
             $('#jenis_input_gudang').val("saldo").trigger('change').attr('disabled', true);
             $('#oc_transaksi_gudang').val(data.cg_aksi).attr('disabled', true);
-            $('#oc_nominal_gudang').val(data.cg_nominal).attr('disabled', false);
+            $('#oc_nominal_gudang').val(formatRupiahMinus(data.cg_nominal)).attr('disabled', false);
             $('#oc_notes_gudang').val(data.cg_notes).attr('disabled', false);
         }
         $('#staff_id_gudang').append(`<option value="${data.staff_id}">${data.staff_name}</option>`).attr('disabled', true);
@@ -2138,7 +2142,7 @@
         else {
             $('#jenis_input_gudang').val("saldo").trigger('change').attr('disabled', true);
             $('#oc_transaksi_gudang').val(data.cg_aksi).attr('disabled', true);
-            $('#oc_nominal_gudang').val(data.cg_nominal).attr('disabled', true);
+            $('#oc_nominal_gudang').val(formatRupiahMinus(data.cg_nominal)).attr('disabled', true);
             $('#oc_notes_gudang').val(data.cg_notes).attr('disabled', true);
         }
         $('#staff_id_gudang').append(`<option value="${data.staff_id}">${data.staff_name}</option>`).attr('disabled', true);

--- a/resources/views/components/modals/operational-cash/add-cash-admin.blade.php
+++ b/resources/views/components/modals/operational-cash/add-cash-admin.blade.php
@@ -93,7 +93,7 @@
                       <h5 class="form-title mb-2 text-black pb-2">Detail Pengeluaran</h5>
                     </div>
 
-                    <div class="col-12 operasional mb-3" id="row-add-catatan-admin">
+                    <div class="col-12 operasional mb-3 pg-popup-table-input" id="row-add-catatan-admin">
                       <div class="row g-2 align-items-end p-2 rounded">
                         <div class="col-12 col-lg-6">
                           <div class="input-block">
@@ -113,6 +113,7 @@
                           </div>
                         </div>
                         <div class="col-12 col-lg-1">
+                          <label class="small mb-2 d-none d-lg-block">&nbsp;</label>
                           <button type="button" class="btn btn-primary w-100 btn-add-catatan">
                             <i class="fa fa-plus"></i>
                           </button>
@@ -121,17 +122,21 @@
                     </div>
 
                     <div class="col-12 operasional">
-                      <div class="table-responsive">
+                      <div class="table-responsive pg-popup-table-scroll">
                         <table class="table table-center" id="tableDetail" style="min-width: 400px;">
                           <thead>
                             <tr>
                               <th width="50">No</th>
                               <th>Keterangan</th>
                               <th class="text-end">Nominal</th>
-                              <th class="text-center">Aksi</th>
+                              <th class="text-center col-aksi">Aksi</th>
                             </tr>
                           </thead>
-                          <tbody></tbody>
+                          <tbody>
+                            <tr class="pg-popup-table-empty">
+                              <td colspan="4">Belum ada aktivitas. Tambahkan lewat form di atas.</td>
+                            </tr>
+                          </tbody>
                           <tfoot>
                             <tr class="fw-bold">
                               <td colspan="2" class="text-end">Total :</td>

--- a/resources/views/components/modals/operational-cash/add-cash-armada.blade.php
+++ b/resources/views/components/modals/operational-cash/add-cash-armada.blade.php
@@ -72,7 +72,7 @@
                     </div>
                   </div>
                   <div class="col-12 px-2 mb-3 operasional">
-                    <div class="row input_table g-3 align-items-end px-1">
+                    <div class="row input_table pg-popup-table-input g-3 align-items-end px-1">
                       {{-- <div class="col-12 col-lg-3">
                                                 <div class="input-block mb-3">
                                                     <label>Tipe<span class="text-danger">*</span></label>
@@ -106,6 +106,7 @@
                         </div>
                       </div>
                       <div class="col-12 col-md-12 col-lg-1 add">
+                        <label class="mb-2 d-none d-lg-block">&nbsp;</label>
                         <button type="button" class="btn btn-primary w-100 btn-add-armada mb-3">
                           +
                         </button>
@@ -113,16 +114,20 @@
                     </div>
                   </div>
                   <div class="col-12 py-3 mb-3 operasional">
-                    <div class="table-responsive">
+                    <div class="table-responsive pg-popup-table-scroll">
                       <table class="table table-center" id="tableDetailArmada" style="min-height: 15vh">
                         <thead>
                           <th>No</th>
                           <th>Tipe</th>
                           <th style="width: 25%">Keterangan</th>
                           <th class="text-end">Nominal</th>
-                          <th class="no-sort text-center">Aksi</th>
+                          <th class="no-sort text-center col-aksi">Aksi</th>
                         </thead>
-                        <tbody></tbody>
+                        <tbody>
+                          <tr class="pg-popup-table-empty">
+                            <td colspan="5">Belum ada aktivitas. Tambahkan lewat form di atas.</td>
+                          </tr>
+                        </tbody>
                         <tfoot>
                           <tr>
                             <td colspan="3" class="text-end fw-bold">Total : </td>

--- a/resources/views/components/modals/operational-cash/add-cash-gudang.blade.php
+++ b/resources/views/components/modals/operational-cash/add-cash-gudang.blade.php
@@ -84,7 +84,7 @@
                     <h5 class="form-title mb-2 text-black">Detail</h5>
                   </div>
                   <div class="col-12 px-2 mb-3 operasional">
-                    <div class="row input_table g-3 align-items-end px-1">
+                    <div class="row input_table pg-popup-table-input g-3 align-items-end px-1">
                       <div class="col-12 col-lg-6 add">
                         <div class="input-block mb-3" id="row-gudang">
                           <label>Nama Armada<span class="text-danger">*</span></label>
@@ -122,6 +122,7 @@
                         </div>
                       </div>
                       <div class="col-12 col-md-12 col-lg-1 add">
+                        <label class="mb-2 d-none d-lg-block">&nbsp;</label>
                         <button type="button" class="btn btn-primary w-100 btn-add-gudang mb-3">
                           +
                         </button>
@@ -129,16 +130,20 @@
                     </div>
                   </div>
                   <div class="col-12 py-3 mb-3 operasional">
-                    <div class="table-responsive">
+                    <div class="table-responsive pg-popup-table-scroll">
                       <table class="table table-center" id="tableDetailGudang" style="min-height: 15vh">
                         <thead>
                           <th>No</th>
                           <th>Armada</th>
                           <th style="width: 25%">Nama</th>
                           <th class="text-end">Nominal</th>
-                          <th class="no-sort text-center">Aksi</th>
+                          <th class="no-sort text-center col-aksi">Aksi</th>
                         </thead>
-                        <tbody></tbody>
+                        <tbody>
+                          <tr class="pg-popup-table-empty">
+                            <td colspan="5">Belum ada aktivitas. Tambahkan lewat form di atas.</td>
+                          </tr>
+                        </tbody>
                         <tfoot>
                           <tr>
                             <td colspan="3" class="text-end fw-bold">Total : </td>

--- a/resources/views/components/modals/operational-cash/add-cash-sales.blade.php
+++ b/resources/views/components/modals/operational-cash/add-cash-sales.blade.php
@@ -88,7 +88,7 @@
                     </div>
                   </div>
                   <div class="col-12 px-2 mb-3 operasional">
-                    <div class="row input_table g-3 align-items-end px-1">
+                    <div class="row input_table pg-popup-table-input g-3 align-items-end px-1">
                       <div class="col-lg-6 col-12">
                         <div class="input-block mb-3" id="row-product">
                           <label>Nama Pencatatan<span class="text-danger">*</span></label>
@@ -106,6 +106,7 @@
                         </div>
                       </div>
                       <div class="col-12 col-md-12 col-lg-1 add">
+                        <label class="mb-2 d-none d-lg-block">&nbsp;</label>
                         <button type="button" class="btn btn-primary w-100 btn-add-sales mb-3">
                           +
                         </button>
@@ -113,16 +114,20 @@
                     </div>
                   </div>
                   <div class="col-12 py-3 mb-3 operasional">
-                    <div class="table-responsive">
+                    <div class="table-responsive pg-popup-table-scroll">
                       <table class="table table-center" id="tableDetailSales" style="min-height: 15vh">
                         <thead>
                           <th>No</th>
                           <th>Tipe</th>
                           <th style="width: 25%">Keterangan</th>
                           <th class="text-end">Nominal</th>
-                          <th class="no-sort text-center">Aksi</th>
+                          <th class="no-sort text-center col-aksi">Aksi</th>
                         </thead>
-                        <tbody></tbody>
+                        <tbody>
+                          <tr class="pg-popup-table-empty">
+                            <td colspan="5">Belum ada aktivitas. Tambahkan lewat form di atas.</td>
+                          </tr>
+                        </tbody>
                         <tfoot>
                           <tr>
                             <td colspan="3" class="text-end fw-bold">Total : </td>

--- a/tests/Regression/AutocompleteCustomerFreshSaldoTest.php
+++ b/tests/Regression/AutocompleteCustomerFreshSaldoTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Tests\Regression;
+
+use App\Http\Controllers\AutocompleteController;
+use App\Models\Customer;
+use Illuminate\Http\Request;
+use Tests\Support\ActingAsStaff;
+use Tests\TestCase;
+
+/**
+ * GitHub #130 (item 37): opening "Tambah Aktivitas" for a Dompet Armada pre-selected from the page
+ * filter used to reuse that filter dropdown's cached Select2 option data for `customer_saldo` —
+ * stale the moment an "Uang Masuk Customer" activity changed the real balance in between, so the
+ * default "Pengembalian Dana Langsung" nominal could show the wrong sign (Minus when the current
+ * saldo was actually Plus). Cash_Operational.js now re-fetches via `/autocompleteCustomer` with an
+ * exact `customer_id` right before filling that field. This covers the new `customer_id` filter
+ * `autocompleteCustomer()` needed to make that fresh lookup possible.
+ *
+ * Called directly against the controller (rather than through `$this->post()`) because this
+ * endpoint's `echo json_encode(...)` — not `return response()->json(...)` — response isn't
+ * captured by `TestResponse` under this test harness; that's a pre-existing quirk of this one
+ * controller method, unrelated to the fix under test here.
+ */
+class AutocompleteCustomerFreshSaldoTest extends TestCase
+{
+    use ActingAsStaff;
+
+    /** @return array<int, array<string, mixed>> */
+    private function callAutocomplete(array $params): array
+    {
+        ob_start();
+        app(AutocompleteController::class)->autocompleteCustomer(new Request($params));
+        $body = ob_get_clean();
+
+        $decoded = json_decode($body, true);
+        $this->assertIsArray($decoded, 'autocompleteCustomer must echo valid JSON, got: ' . $body);
+
+        return $decoded['data'] ?? [];
+    }
+
+    public function test_autocomplete_customer_by_exact_id_returns_the_current_saldo(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $customer = Customer::where('status', 1)->firstOrFail();
+        $customer->customer_saldo = -200000;
+        $customer->save();
+
+        $rows = $this->callAutocomplete(['customer_id' => $customer->customer_id]);
+        $this->assertNotEmpty($rows, 'a valid customer_id must return exactly that customer');
+        $this->assertSame($customer->customer_id, (int) $rows[0]['customer_id']);
+        $this->assertSame(-200000, (int) $rows[0]['customer_saldo']);
+
+        // Saldo changes (e.g. via an accepted "Uang Masuk Customer" activity) — the very next
+        // lookup by the same customer_id must reflect it immediately, not a cached value.
+        $customer->customer_saldo = 300000;
+        $customer->save();
+
+        $rows = $this->callAutocomplete(['customer_id' => $customer->customer_id]);
+        $this->assertSame(300000, (int) $rows[0]['customer_saldo'], 'must reflect the current saldo, not a stale cached value');
+    }
+
+    public function test_autocomplete_customer_without_customer_id_still_works_as_a_keyword_search(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $customer = Customer::where('status', 1)->firstOrFail();
+
+        $rows = $this->callAutocomplete(['keyword' => $customer->customer_notes]);
+        $this->assertNotEmpty($rows, 'the customer_id filter is additive — plain keyword search must keep working');
+    }
+}

--- a/tests/Regression/CashAdminAccDeclineDeletedRecordCrashesTest.php
+++ b/tests/Regression/CashAdminAccDeclineDeletedRecordCrashesTest.php
@@ -2,21 +2,32 @@
 
 namespace Tests\Regression;
 
+use App\Models\Cash;
 use App\Models\CashAdmin;
 use App\Models\CashGudang;
 use Tests\Support\ActingAsStaff;
 use Tests\TestCase;
 
 /**
- * GitHub #130: acceptCashAdmin()/declineCashAdmin() (and declineCashGudang()) crashed 500 instead
- * of failing cleanly whenever the pengajuan/pengembalian had been deleted (e.g. by its own staff,
- * via /deleteCashAdmin) before an approver ACC'd/menolak it. `deleteCashAdmin()`/`deleteCashGudang()`
- * only soft-flag `status = 0` — they never set `acc_by` — so the old code's
- * `Staff::find($q->acc_by)->staff_name` ran `Staff::find(null)` and crashed on
- * "Attempt to read property 'staff_name' on null" instead of returning the usual
- * {status:-2, header, message} shape the frontend already knows how to render as a notifikasi().
- * acceptCashGudang() already guarded this correctly (see its lockForUpdate transaction) — this
- * mirrors that null-safety into the three siblings that didn't have it.
+ * GitHub #130 (items 33/34): acceptCashAdmin()/declineCashAdmin()/acceptCashGudang()/
+ * declineCashGudang()/acceptCashBesar()/declineCashBesar() (and the Armada/Sales siblings) had two
+ * separate problems:
+ *
+ * 1. Several of them had NO null-guard on the lookup — if the pengajuan/pengembalian had been
+ *    deleted (e.g. by its own staff, via /deleteCashAdmin) before an approver ACC'd/menolak it,
+ *    `$q->status` crashed 500 ("Attempt to read property 'status' on null") instead of returning
+ *    the usual {status:-2, header, message} shape the frontend already renders via notifikasi().
+ * 2. Even the ones that DID guard against this returned the exact same message
+ *    ("Pengajuan sudah diterima/ditolak oleh staff lain") for a genuinely deleted record as for one
+ *    someone else had already accepted/declined — because deleteCashAdmin()/deleteCashGudang()/
+ *    deleteCash() only soft-flag status=0 and never set acc_by, `Staff::find(null)` always resolved
+ *    to "staff lain" regardless of the real reason. PM flagged this directly on the issue: the
+ *    message must say "sudah dihapus" when that's what actually happened, not "diterima/ditolak
+ *    oleh staff lain".
+ *
+ * Both are now handled by the shared `ReportController::pengajuanFailureMessage()` helper, which
+ * branches on the record's actual status (0=dihapus, 2=diterima, 3=ditolak, not found=mungkin
+ * sudah dihapus) instead of collapsing everything into one generic sentence.
  */
 class CashAdminAccDeclineDeletedRecordCrashesTest extends TestCase
 {
@@ -27,7 +38,7 @@ class CashAdminAccDeclineDeletedRecordCrashesTest extends TestCase
         return (int) \Illuminate\Support\Facades\DB::table('staffs')->where('status', 1)->value('staff_id');
     }
 
-    public function test_accepting_a_deleted_cash_admin_entry_fails_cleanly_instead_of_crashing(): void
+    public function test_accepting_a_deleted_cash_admin_entry_reports_it_was_deleted(): void
     {
         $this->actingAsSuperAdminStaff();
 
@@ -49,9 +60,10 @@ class CashAdminAccDeclineDeletedRecordCrashesTest extends TestCase
 
         $response->assertStatus(200);
         $response->assertJsonPath('status', -2);
+        $response->assertJsonPath('message', 'Pengajuan ini sudah dihapus oleh pengaju');
     }
 
-    public function test_declining_a_deleted_cash_admin_entry_fails_cleanly_instead_of_crashing(): void
+    public function test_declining_a_deleted_cash_admin_entry_reports_it_was_deleted(): void
     {
         $this->actingAsSuperAdminStaff();
 
@@ -73,9 +85,10 @@ class CashAdminAccDeclineDeletedRecordCrashesTest extends TestCase
 
         $response->assertStatus(200);
         $response->assertJsonPath('status', -2);
+        $response->assertJsonPath('message', 'Pengajuan ini sudah dihapus oleh pengaju');
     }
 
-    public function test_declining_a_deleted_cash_gudang_entry_fails_cleanly_instead_of_crashing(): void
+    public function test_declining_a_deleted_cash_gudang_entry_reports_it_was_deleted(): void
     {
         $this->actingAsSuperAdminStaff();
 
@@ -97,5 +110,89 @@ class CashAdminAccDeclineDeletedRecordCrashesTest extends TestCase
 
         $response->assertStatus(200);
         $response->assertJsonPath('status', -2);
+        $response->assertJsonPath('message', 'Pengajuan ini sudah dihapus oleh pengaju');
+    }
+
+    public function test_accepting_a_deleted_cash_besar_entry_reports_it_was_deleted(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $this->post('/insertCashAdmin', [
+            'staff_id' => $this->staffId(),
+            'jenis_input' => 'saldo',
+            'oc_transaksi' => 1,
+            'ca_nominal' => 60000,
+            'ca_notes' => 'Regression test - Kas Besar linked row will be deleted before ACC',
+        ])->assertStatus(200);
+
+        $cashAdmin = CashAdmin::orderByDesc('ca_id')->firstOrFail();
+        $cashId = $cashAdmin->cash_id;
+        $this->assertGreaterThan(0, $cashId, 'precondition: a saldo entry must link to a real cashes row');
+
+        // Deleting the CashAdmin entry also soft-deletes its linked Cash row (ca_type == 1 branch
+        // of deleteCashAdmin()) — this is the exact path issue #130 item 33 describes.
+        $this->post('/deleteCashAdmin', ['ca_id' => $cashAdmin->ca_id])->assertStatus(200);
+        $this->assertSame(0, (int) Cash::find($cashId)->status, 'precondition: deleteCash only soft-flags status=0, acc_by stays null');
+
+        $response = $this->post('/acceptCashBesar', ['cash_id' => $cashId]);
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('status', -2);
+        $response->assertJsonPath('message', 'Pengajuan ini sudah dihapus oleh pengaju');
+    }
+
+    public function test_declining_a_deleted_cash_besar_entry_reports_it_was_deleted(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $this->post('/insertCashGudang', [
+            'staff_id' => $this->staffId(),
+            'jenis_input' => 'saldo',
+            'oc_transaksi' => 1,
+            'cg_nominal' => 45000,
+            'cg_notes' => 'Regression test - Kas Besar linked row will be deleted before decline',
+        ])->assertStatus(200);
+
+        $cashGudang = CashGudang::orderByDesc('cg_id')->firstOrFail();
+        $cashId = $cashGudang->cash_id;
+        $this->assertGreaterThan(0, $cashId, 'precondition: a saldo entry must link to a real cashes row');
+
+        $this->post('/deleteCashGudang', ['cg_id' => $cashGudang->cg_id])->assertStatus(200);
+        $this->assertSame(0, (int) Cash::find($cashId)->status, 'precondition: deleteCash only soft-flags status=0, acc_by stays null');
+
+        $response = $this->post('/declineCashBesar', ['cash_id' => $cashId]);
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('status', -2);
+        $response->assertJsonPath('message', 'Pengajuan ini sudah dihapus oleh pengaju');
+    }
+
+    public function test_accepting_an_already_accepted_cash_besar_entry_names_the_real_reason_not_deleted(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $this->post('/insertCashAdmin', [
+            'staff_id' => $this->staffId(),
+            'jenis_input' => 'saldo',
+            'oc_transaksi' => 1,
+            'ca_nominal' => 70000,
+            'ca_notes' => 'Regression test - already accepted, not deleted',
+        ])->assertStatus(200);
+
+        $cashAdmin = CashAdmin::orderByDesc('ca_id')->firstOrFail();
+        $cashId = $cashAdmin->cash_id;
+
+        $this->post('/acceptCashBesar', ['cash_id' => $cashId])->assertStatus(200);
+        $this->assertSame(2, (int) Cash::find($cashId)->status, 'precondition: the row is accepted, not deleted');
+
+        // Accepting it again must say it was already ACCEPTED, never "already deleted" — those are
+        // two different, non-interchangeable reasons per PM's item 34.
+        $response = $this->post('/acceptCashBesar', ['cash_id' => $cashId]);
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('status', -2);
+        $message = $response->json('message');
+        $this->assertStringContainsString('diterima', $message);
+        $this->assertStringNotContainsString('dihapus', $message);
     }
 }

--- a/tests/Regression/CashAdminAccDeclineDeletedRecordCrashesTest.php
+++ b/tests/Regression/CashAdminAccDeclineDeletedRecordCrashesTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Tests\Regression;
+
+use App\Models\CashAdmin;
+use App\Models\CashGudang;
+use Tests\Support\ActingAsStaff;
+use Tests\TestCase;
+
+/**
+ * GitHub #130: acceptCashAdmin()/declineCashAdmin() (and declineCashGudang()) crashed 500 instead
+ * of failing cleanly whenever the pengajuan/pengembalian had been deleted (e.g. by its own staff,
+ * via /deleteCashAdmin) before an approver ACC'd/menolak it. `deleteCashAdmin()`/`deleteCashGudang()`
+ * only soft-flag `status = 0` — they never set `acc_by` — so the old code's
+ * `Staff::find($q->acc_by)->staff_name` ran `Staff::find(null)` and crashed on
+ * "Attempt to read property 'staff_name' on null" instead of returning the usual
+ * {status:-2, header, message} shape the frontend already knows how to render as a notifikasi().
+ * acceptCashGudang() already guarded this correctly (see its lockForUpdate transaction) — this
+ * mirrors that null-safety into the three siblings that didn't have it.
+ */
+class CashAdminAccDeclineDeletedRecordCrashesTest extends TestCase
+{
+    use ActingAsStaff;
+
+    private function staffId(): int
+    {
+        return (int) \Illuminate\Support\Facades\DB::table('staffs')->where('status', 1)->value('staff_id');
+    }
+
+    public function test_accepting_a_deleted_cash_admin_entry_fails_cleanly_instead_of_crashing(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $this->post('/insertCashAdmin', [
+            'staff_id' => $this->staffId(),
+            'jenis_input' => 'saldo',
+            'oc_transaksi' => 1,
+            'ca_nominal' => 100000,
+            'ca_notes' => 'Regression test - will be deleted before ACC',
+        ])->assertStatus(200);
+
+        $cashAdmin = CashAdmin::orderByDesc('ca_id')->firstOrFail();
+        $caId = $cashAdmin->ca_id;
+
+        $this->post('/deleteCashAdmin', ['ca_id' => $caId])->assertStatus(200);
+        $this->assertSame(0, (int) CashAdmin::find($caId)->status, 'precondition: deleteCashAdmin only soft-flags status=0, acc_by stays null');
+
+        $response = $this->post('/acceptCashAdmin', ['ca_id' => $caId]);
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('status', -2);
+    }
+
+    public function test_declining_a_deleted_cash_admin_entry_fails_cleanly_instead_of_crashing(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $this->post('/insertCashAdmin', [
+            'staff_id' => $this->staffId(),
+            'jenis_input' => 'saldo',
+            'oc_transaksi' => 2,
+            'ca_nominal' => 50000,
+            'ca_notes' => 'Regression test - will be deleted before decline',
+        ])->assertStatus(200);
+
+        $cashAdmin = CashAdmin::orderByDesc('ca_id')->firstOrFail();
+        $caId = $cashAdmin->ca_id;
+
+        $this->post('/deleteCashAdmin', ['ca_id' => $caId])->assertStatus(200);
+        $this->assertSame(0, (int) CashAdmin::find($caId)->status, 'precondition: deleteCashAdmin only soft-flags status=0, acc_by stays null');
+
+        $response = $this->post('/declineCashAdmin', ['ca_id' => $caId]);
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('status', -2);
+    }
+
+    public function test_declining_a_deleted_cash_gudang_entry_fails_cleanly_instead_of_crashing(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $this->post('/insertCashGudang', [
+            'staff_id' => $this->staffId(),
+            'jenis_input' => 'saldo',
+            'oc_transaksi' => 1,
+            'cg_nominal' => 75000,
+            'cg_notes' => 'Regression test - will be deleted before decline',
+        ])->assertStatus(200);
+
+        $cashGudang = CashGudang::orderByDesc('cg_id')->firstOrFail();
+        $cgId = $cashGudang->cg_id;
+
+        $this->post('/deleteCashGudang', ['cg_id' => $cgId])->assertStatus(200);
+        $this->assertSame(0, (int) CashGudang::find($cgId)->status, 'precondition: deleteCashGudang only soft-flags status=0, acc_by stays null');
+
+        $response = $this->post('/declineCashGudang', ['cg_id' => $cgId]);
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('status', -2);
+    }
+}

--- a/tests/Unit/CashOperasionalPresenterSignFlipTest.php
+++ b/tests/Unit/CashOperasionalPresenterSignFlipTest.php
@@ -1,0 +1,198 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Support\CashOperasionalPresenter;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Pure-logic tests for `CashOperasionalPresenter`'s Masuk/Keluar (debit/credit) column decision —
+ * no DB, a plain stdClass row is enough since the presenter only reads named properties off it.
+ *
+ * GitHub #130 items 35/36/38: `ca_nominal`/`cg_nominal`/`cs_nominal` (and `cr_nominal`) are stored
+ * RAW — a negative nominal on a "saldo" row means the opposite of what the aksi/type flag alone
+ * says happened (a negative Pengembalian is functionally a Pengajuan, and vice versa), so the
+ * column it lands in must flip too. `$user = null` throughout — RoleAccess::canAny() treats a null
+ * user as "no access to anything", which only affects the `action` column, not `debit`/`credit`.
+ */
+class CashOperasionalPresenterSignFlipTest extends TestCase
+{
+    private function row(array $fields): object
+    {
+        return (object) array_merge([
+            'status' => 1,
+            'staff_id' => 1,
+            'created_by' => null,
+            'acc_by' => null,
+            'detail' => null,
+        ], $fields);
+    }
+
+    // ---- Kas Admin (item 35) ----
+
+    public function test_admin_positive_pengajuan_is_debit(): void
+    {
+        $row = CashOperasionalPresenter::adminRow($this->row([
+            'ca_id' => 1, 'ca_date' => '2026-09-03', 'ca_type' => 1, 'ca_aksi' => 1, 'ca_nominal' => 100000,
+        ]), null);
+
+        $this->assertSame('Rp 100.000', $row['debit']);
+        $this->assertSame('Rp 0', $row['credit']);
+    }
+
+    public function test_admin_positive_pengembalian_is_credit(): void
+    {
+        $row = CashOperasionalPresenter::adminRow($this->row([
+            'ca_id' => 1, 'ca_date' => '2026-09-03', 'ca_type' => 1, 'ca_aksi' => 2, 'ca_nominal' => 100000,
+        ]), null);
+
+        $this->assertSame('Rp 0', $row['debit']);
+        $this->assertSame('(Rp 100.000)', $row['credit']);
+    }
+
+    public function test_admin_negative_pengembalian_flips_to_debit(): void
+    {
+        $row = CashOperasionalPresenter::adminRow($this->row([
+            'ca_id' => 1, 'ca_date' => '2026-09-03', 'ca_type' => 1, 'ca_aksi' => 2, 'ca_nominal' => -100000,
+        ]), null);
+
+        $this->assertSame('Rp 100.000', $row['debit'], 'a negative pengembalian is functionally a pengajuan — must land in Masuk');
+        $this->assertSame('Rp 0', $row['credit']);
+    }
+
+    public function test_admin_negative_pengajuan_flips_to_credit(): void
+    {
+        $row = CashOperasionalPresenter::adminRow($this->row([
+            'ca_id' => 1, 'ca_date' => '2026-09-03', 'ca_type' => 1, 'ca_aksi' => 1, 'ca_nominal' => -100000,
+        ]), null);
+
+        $this->assertSame('Rp 0', $row['debit']);
+        $this->assertSame('(Rp 100.000)', $row['credit']);
+    }
+
+    public function test_admin_operasional_expense_rows_are_untouched_by_the_sign_flip(): void
+    {
+        // ca_type==2 (aktivitas operasional/expense) rows are out of scope for item 35 — a stray
+        // ca_aksi==1 default (see insertCashAdmin's operasional branch, which never overrides it)
+        // must keep behaving exactly as before: no sign-based flip applied.
+        $row = CashOperasionalPresenter::adminRow($this->row([
+            'ca_id' => 1, 'ca_date' => '2026-09-03', 'ca_type' => 2, 'ca_aksi' => 1, 'ca_nominal' => -50000,
+        ]), null);
+
+        $this->assertSame('Rp 50.000', $row['debit'], 'unchanged: ca_type!=1 rows never get the sign flip');
+        $this->assertSame('Rp 0', $row['credit']);
+    }
+
+    // ---- Kas Gudang (item 35) ----
+
+    public function test_gudang_negative_pengembalian_flips_to_debit(): void
+    {
+        $row = CashOperasionalPresenter::gudangRow($this->row([
+            'cg_id' => 1, 'cg_date' => '2026-09-03', 'cg_type' => 1, 'cg_aksi' => 2, 'cg_nominal' => -75000,
+        ]), null);
+
+        $this->assertSame('Rp 75.000', $row['debit']);
+        $this->assertSame('Rp 0', $row['credit']);
+    }
+
+    // ---- Dompet Armada (item 36) ----
+
+    public function test_armada_saldo_positive_pengembalian_is_credit(): void
+    {
+        // saldo branch never sets cr_type (defaults to 3), cr_aksi is forced to 1 by insertCashArmada().
+        $row = CashOperasionalPresenter::armadaRow($this->row([
+            'cr_id' => 1, 'cr_date' => '2026-09-03', 'cr_type' => 3, 'cr_aksi' => 1, 'cr_nominal' => 200000,
+            'customer_id' => 1,
+        ]), null);
+
+        $this->assertSame('Rp 0', $row['debit']);
+        $this->assertSame('(Rp 200.000)', $row['credit']);
+    }
+
+    public function test_armada_saldo_negative_pengembalian_flips_to_debit(): void
+    {
+        $row = CashOperasionalPresenter::armadaRow($this->row([
+            'cr_id' => 1, 'cr_date' => '2026-09-03', 'cr_type' => 3, 'cr_aksi' => 1, 'cr_nominal' => -200000,
+            'customer_id' => 1,
+        ]), null);
+
+        $this->assertSame('Rp 200.000', $row['debit'], 'a negative pengembalian dompet armada is functionally an addition — must land in Masuk');
+        $this->assertSame('Rp 0', $row['credit']);
+    }
+
+    public function test_armada_operasional_setoran_is_unaffected_by_the_saldo_sign_flip(): void
+    {
+        // operasional/Setoran rows (cr_aksi==2, cr_type==1) must keep using cr_type exactly as
+        // before — the sign-flip only applies to the saldo (cr_aksi==1) branch.
+        $row = CashOperasionalPresenter::armadaRow($this->row([
+            'cr_id' => 1, 'cr_date' => '2026-09-03', 'cr_type' => 1, 'cr_aksi' => 2, 'cr_nominal' => 50000,
+            'customer_id' => 1,
+        ]), null);
+
+        $this->assertSame('Rp 50.000', $row['debit']);
+        $this->assertSame('Rp 0', $row['credit']);
+    }
+
+    public function test_armada_cross_created_gudang_delivery_row_is_unaffected(): void
+    {
+        // CashGudang::acceptCashGudang() cross-creates CashArmada rows with cr_type explicitly 1
+        // and cr_aksi left at its 0 default — must still resolve to Masuk via cr_type, not get
+        // caught by the cr_aksi==1 sign-flip branch (which is for the saldo flow specifically).
+        $row = CashOperasionalPresenter::armadaRow($this->row([
+            'cr_id' => 1, 'cr_date' => '2026-09-03', 'cr_type' => 1, 'cr_aksi' => 0, 'cr_nominal' => 60000,
+            'customer_id' => 1,
+        ]), null);
+
+        $this->assertSame('Rp 60.000', $row['debit']);
+        $this->assertSame('Rp 0', $row['credit']);
+    }
+
+    // ---- Dompet Sales (item 38) ----
+
+    public function test_sales_saldo_positive_pengembalian_is_credit(): void
+    {
+        $row = CashOperasionalPresenter::salesRow($this->row([
+            'cs_id' => 1, 'cs_date' => '2026-09-03', 'cs_type' => 1, 'cs_transaction' => 2, 'cs_aksi' => 3,
+            'cs_nominal' => 150000,
+        ]), null);
+
+        $this->assertSame('Rp 0', $row['debit']);
+        $this->assertSame('(Rp 150.000)', $row['credit']);
+    }
+
+    public function test_sales_saldo_negative_pengembalian_flips_to_debit(): void
+    {
+        $row = CashOperasionalPresenter::salesRow($this->row([
+            'cs_id' => 1, 'cs_date' => '2026-09-03', 'cs_type' => 1, 'cs_transaction' => 2, 'cs_aksi' => 3,
+            'cs_nominal' => -150000,
+        ]), null);
+
+        $this->assertSame('Rp 150.000', $row['debit']);
+        $this->assertSame('Rp 0', $row['credit']);
+    }
+
+    public function test_sales_setor_ke_bank_is_unaffected_by_the_pengembalian_sign_flip(): void
+    {
+        // aksi==2 (Setor ke Bank) is guarded against ever being negative at insert/update time
+        // (item 39) — its own column logic (unaffected by the pengembalian-only sign flip) must
+        // keep behaving exactly as before.
+        $row = CashOperasionalPresenter::salesRow($this->row([
+            'cs_id' => 1, 'cs_date' => '2026-09-03', 'cs_type' => 1, 'cs_transaction' => 3, 'cs_aksi' => 2,
+            'cs_nominal' => 90000,
+        ]), null);
+
+        $this->assertSame('Rp 0', $row['debit']);
+        $this->assertSame('(Rp 90.000)', $row['credit']);
+    }
+
+    public function test_sales_pemasukan_is_unaffected_by_the_pengembalian_sign_flip(): void
+    {
+        $row = CashOperasionalPresenter::salesRow($this->row([
+            'cs_id' => 1, 'cs_date' => '2026-09-03', 'cs_type' => 1, 'cs_transaction' => 1, 'cs_aksi' => 1,
+            'cs_nominal' => 40000,
+        ]), null);
+
+        $this->assertSame('Rp 40.000', $row['debit']);
+        $this->assertSame('Rp 0', $row['credit']);
+    }
+}

--- a/tests/Workflow/CashSalesFlowTest.php
+++ b/tests/Workflow/CashSalesFlowTest.php
@@ -22,10 +22,14 @@ use Tests\TestCase;
  *     mirroring the operasional branch's own `csd_type==1` Setoran case.
  *   - `cs_aksi=="2"` and `cs_aksi=="3"`: both create a linked Cash row and both fall through to the
  *     SAME `acceptCashSales()` branch (`staff_saldo -= cs_nominal`) — they are indistinguishable in
- *     every balance/aggregate effect. The only difference between them is which way the linked
- *     Cash row's own `cash_type` is flipped for a given nominal sign, and `cs_transaction` (2 vs 3,
- *     both `>= 2` so identical in `CashSales::getCashSales()`'s own `sisa_kas` aggregate too) — pure
- *     ledger-display bookkeeping, not a functional difference.
+ *     every balance/aggregate effect. `cs_transaction` (2 vs 3, both `>= 2` so identical in
+ *     `CashSales::getCashSales()`'s own `sisa_kas` aggregate too) is pure ledger-display
+ *     bookkeeping, not a functional difference. They DO still differ on nominal sign, though
+ *     (GitHub #130 item 39, 2026-09-03): `cs_aksi=="3"` (Pengembalian) legitimately flips the
+ *     linked Cash row's `cash_type` on a negative nominal — a return can go either direction.
+ *     `cs_aksi=="2"` (Setor ke Bank) used to do the same flip but a bank deposit can never
+ *     sensibly be negative, so insertCashSales()/updateCashSales() now reject a negative nominal
+ *     outright instead (see the rejection test below).
  */
 class CashSalesFlowTest extends TestCase
 {
@@ -208,32 +212,34 @@ class CashSalesFlowTest extends TestCase
         );
     }
 
-    public function test_saldo_aksi_2_with_a_negative_nominal_flips_the_linked_cash_row_type(): void
+    /**
+     * GitHub #130 (item 39, 2026-09-03): this used to document the same sign-flip trick as
+     * CashAdmin/CashArmada for aksi=="2" ("Setor ke Bank") — PM decided a bank deposit can never
+     * sensibly be negative (unlike a pengajuan/pengembalian, which legitimately flips direction),
+     * so insertCashSales()/updateCashSales() now reject it outright instead of flipping cash_type.
+     */
+    public function test_saldo_aksi_2_with_a_negative_nominal_is_rejected_instead_of_flipping_cash_type(): void
     {
         $this->actingAsSuperAdminStaff();
 
         $staff = $this->pickStaff();
         $staff->staff_saldo = 1000000;
         $staff->save();
-        $nominal = -300000;
+        $countBefore = CashSales::count();
 
-        $csId = $this->insertSaldoCashSales($staff, csAksi: '2', csNominal: $nominal);
+        $response = $this->post('/insertCashSales', [
+            'staff_id' => $staff->staff_id,
+            'bank_id' => 0,
+            'oc_transaksi' => 'saldo',
+            'photo' => '',
+            'cs_aksi' => '2',
+            'cs_notes' => 'Workflow test saldo entry',
+            'cs_nominal' => -300000,
+        ]);
 
-        $cs = CashSales::findOrFail($csId);
-        $this->assertSame($nominal, (int) $cs->cs_nominal, 'cs_nominal is stored RAW, same as CashAdmin\'s ca_nominal');
-
-        $cash = Cash::find($cs->cash_id);
-        $this->assertSame(1, (int) $cash->cash_type, 'a negative cs_nominal flips aksi=="2" from cash_type 3 to 1');
-        $this->assertSame(-$nominal, (int) $cash->cash_nominal, 'the linked Cash row normalizes cash_nominal to a positive value, same pattern as CashAdmin/CashArmada');
-
-        $this->post('/acceptCashSales', ['cs_id' => $csId])->assertStatus(200);
-
-        $staff->refresh();
-        $this->assertSame(
-            1000000 - $nominal,
-            (int) $staff->staff_saldo,
-            'staff_saldo -= cs_nominal with a negative cs_nominal is a double negation: this INCREASES staff_saldo, the same sign trick as CashArmada\'s saldo branch'
-        );
+        $response->assertStatus(200);
+        $response->assertJsonPath('status', -1);
+        $this->assertSame($countBefore, CashSales::count(), 'a rejected Setor ke Bank must not insert any row');
     }
 
     public function test_saldo_aksi_3_has_an_oppositely_typed_cash_row_but_the_identical_balance_effect_as_aksi_2(): void


### PR DESCRIPTION
## Ringkasan
Memperbaiki GitHub #130 (Modul Akuntansi — Kas Operasional + Kas Besar). Issue ini bertambah cakupannya di tengah pengerjaan (PM menambahkan beberapa poin di atas laporan awal); PR ini sudah mencakup semuanya: **29, 32, 33, 34, 35, 36, 37, 38, 39**, plus 2 bug tambahan yang ditemukan saat verifikasi.

### Kas Operasional (semua tipe kas) — poin 29
Tombol hapus masih muncul di baris detail pengeluaran saat melihat aktivitas operasional yang sudah diajukan (mode Lihat). Diperbaiki dengan menyembunyikan markup tombol hapus saat mode Lihat (`mode !== 3`), bukan lewat `.hide()` belakangan. Tindak lanjut: menyembunyikan seluruh kolom "Aksi" bikin header dan body tidak sejajar — kolomnya tetap dipertahankan, hanya teks headernya yang dikosongkan.

### Kas Admin / Kas Gudang — poin 32
Modal edit/lihat tidak menampilkan pemisah ribuan pada kolom nominal. Sudah diperbaiki di kedua alur (edit & lihat).

### Kas Besar — poin 33/34
ACC/Tolak tidak memberi alasan yang jelas (bahkan crash) saat pengajuan/pengembalian yang terkait sudah dihapus:
- Beberapa endpoint accept/decline tidak punya pengecekan null pada pencarian datanya dan crash 500 kalau recordnya sudah dihapus.
- `acceptCashBesar()`/`declineCashBesar()` (endpoint Kas Besar yang sebenarnya — dikonfirmasi PM bahwa pengajuan/pengembalian admin/gudang memang selalu di-ACC dari Kas Besar, karena dipegang direksi) ternyata crash di **setiap ACC/Tolak yang berhasil**, bukan cuma saat data dihapus, karena ada import class `Session` yang hilang.
- Ditambahkan `pengajuanFailureMessage()`, dipakai bersama di semua endpoint ini, yang membedakan "sudah dihapus" dari "sudah diterima"/"sudah ditolak" — sebelumnya semua kegagalan dilempar ke satu kalimat generik yang sama.

### Kas Admin / Kas Gudang / Dompet Armada / Dompet Sales — poin 35/36/38
Pengembalian dengan nominal minus muncul di kolom Masuk/Keluar yang salah, karena presenter menentukan kolomnya murni dari flag aksi/tipe dan mengabaikan tanda nominalnya. Diperbaiki dengan pembalikan kolom yang scope-nya sempit, hanya untuk aksi saldo yang disebutkan di masing-masing poin — baris operasional/pengeluaran, Setoran, Pemasukan, dan Setor ke Bank tidak tersentuh.

### Dompet Armada — poin 37
Membuka "Tambah Aktivitas" untuk armada yang sudah dipilih dari filter halaman memakai ulang `customer_saldo` yang ter-cache di dropdown filter tersebut — jadi basi begitu ada aktivitas "Uang Masuk Customer" yang mengubah saldo sebenarnya. Sekarang mengambil ulang saldo terbaru lewat filter `customer_id` baru (opsional) di `/autocompleteCustomer`.

### Dompet Sales — poin 39
"Setor ke Bank" bisa diisi nominal minus (bawaan dari default `staff_saldo` yang bisa minus), padahal setoran ke bank tidak masuk akal kalau minus. Ditambahkan guard di JS maupun server yang menolaknya.

### Bug tambahan yang ditemukan saat verifikasi

**Tombol lihat/edit di Dompet Armada & Dompet Sales tidak merespons klik sama sekali** — `cr_img`/`cs_img` seharusnya berupa array nama file dalam format JSON, tapi sebagian baris (data lama, atau baris yang masuk lewat jalur lain seperti External API) menyimpannya sebagai string nama file polos, atau kosong/null. `JSON.parse()` melempar error untuk kasus-kasus itu, dan `img[0]` pada hasil `null` juga melempar error — keduanya tidak tertangkap, jadi seluruh handler klik berhenti diam-diam sebelum sempat menampilkan modalnya. Ditambahkan `parseCashPhotoList()`, helper kecil yang selalu mengembalikan array dan menangani semua kasus tersebut dengan aman.

**Tombol aksi (Terima/Tolak/Lihat/Edit/Hapus) di tabel Kas Operasional & Kas Besar tidak berwarna** — sesuai standar warna yang sudah ditetapkan di GitHub #117 (hijau/kuning/merah/biru), tapi ternyata dua presenter ini salah dikategorikan di rollout #117 sebagai "tombol modal, bukan ikon baris tabel" — padahal keduanya memang ikon baris tabel yang di-render di server (PHP), bukan di JS seperti tabel lain. Kelas `bg-success`/`bg-danger`/`text-light` yang dipakai kalah oleh aturan global `!important` di `header.blade.php`, jadi warnanya tidak pernah benar-benar tampil. Sudah dipindah ke kelas `.btn-action-approve`/`.btn-action-reject`/`.btn-action-view`/`.btn-action-edit`/`.btn-action-delete` yang sudah dipakai tabel lain.

## Testing
- `tests/Regression/CashAdminAccDeclineDeletedRecordCrashesTest.php` — dipastikan crash 500 di kode sebelum diperbaiki, lolos dengan pesan yang benar setelahnya (poin 33/34).
- `tests/Unit/CashOperasionalPresenterSignFlipTest.php` — 14 kasus pure-logic yang mencakup pembalikan kolom maupun kasus yang harus tetap tidak berubah (poin 35/36/38).
- `tests/Regression/AutocompleteCustomerFreshSaldoTest.php` — pencarian exact-id mengembalikan saldo terkini, pencarian keyword tetap berfungsi (poin 37).
- Test lama di `tests/Workflow/CashSalesFlowTest.php` yang mendokumentasikan perilaku minus-diizinkan (sebelum poin 39) diganti jadi memastikan penolakannya.
- Perbaikan tombol lihat/edit (foto) dan pewarnaan tombol aksi adalah perubahan JS/CSS murni, diverifikasi lewat penelusuran kode + skrip Node kecil untuk logika parsing foto.
- Seluruh suite `--filter=Cash` (85 test) + `tests/Unit` (50 test) hijau.

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)
