### PR TITLE
fix(stock-opname): gulung satuan sekali saat terbit + Pengembalian ikut menggulung (GH #132)

### DIFF
--- a/.claude/skills/pegasus-conventions/SKILL.md
+++ b/.claude/skills/pegasus-conventions/SKILL.md
@@ -24,6 +24,57 @@ out which variant is dominant and which is legacy-only.
   plain `<script src>` tag, no `import`/`export`, no npm packages beyond axios (present but not the AJAX
   pattern actually used — see below).
 
+## ⚠️ Touching any stock-mutating logic — check unit roll-up FIRST, before writing code
+If the change you're about to write reads or writes `product_stocks.ps_stock` /
+`supplies_stocks.ss_stock` — directly, via a model's `insertX`/`updateX`, or via a helper —
+**stop and reason about unit roll-up before writing the mutation, and say so to the user.** Don't
+silently pick flat-vs-rolled-up on your own judgment when the flow could plausibly want either.
+
+Why this matters: a product/bahan can have a unit ladder (`product_relations`/`supplies_relations`,
+e.g. 1 DOS = 12 pcs) and the SAME physical stock is represented completely differently depending on
+which unit a flow happens to credit/debit in. Two real, shipped bugs came from exactly this
+(GitHub #19, #132): a flow that flat-credits `+= qty` at whatever unit it was handed, instead of
+rolling a full multiple up the ladder, leaves the bigger unit's row missing/stale — and that stale
+row then corrupts whatever reads it next (Stock Opname finding no DOS row to opname; another
+flow's `allowedProductUnitIds()` gate silently refusing to roll into a unit that "doesn't exist").
+
+**Before writing the mutation, work out and state to the user:**
+1. Does this product/bahan actually have a unit ladder here (`ProductRelation`/`SuppliesRelation`),
+   or is this always a single-unit item? If always single-unit, roll-up is moot — say so and move on.
+2. Is this warehouse a **retail warehouse**? Retail warehouses are only ever supposed to hold their
+   `retail_unit` row (`ProductVariant::retail_unit`) — never roll up there, never provision a
+   bigger-unit row there. See `App\Support\StockOpname\OpnameLifecycle::isRetailWarehouse()` for the
+   canonical check.
+3. Is this flow a **credit** (stock coming IN — production output, PO receipt, return, restore) or a
+   **full snapshot/replace** (Stock Opname setting the counted value directly)? These need different
+   tools:
+   - Credit → `App\Support\ProductUnitStock::addQty(..., rollUp: true, ...)` (products) — the
+     established helper (GH #19/PR #75), used by `ProductionController::accProduction()` and
+     `CustomerProductReturnController::accept()`. Pass `rollUp: false` explicitly (or omit it) only
+     when you've confirmed with the user that this specific flow should stay flat.
+   - Snapshot/replace → `App\Support\UnitRollUp::collapseProduct()`/`collapseSupplies()`, the pattern
+     `App\Support\StockOpname\OpnameLifecycle`/`BahanOpnameLifecycle::rollUpUnits()` use.
+   - There is currently **no** Supplies/Bahan equivalent of `ProductUnitStock::addQty()` — a
+     Bahan-side credit flow needing roll-up has no helper to reuse yet (flagged, not built, in
+     `cdocs/testing/KNOWN_ISSUES.md`'s GitHub #132 entry). Say so rather than silently leaving it
+     flat or building a one-off inline version.
+4. Does rolling up risk **silently creating a stock row nobody asked for**? Default to only crediting
+   units that already have an active `ProductStock`/`SuppliesStock` row at that warehouse
+   (`UnitRollUp::allowedProductUnitIds()`/`allowedSuppliesUnitIds()`, both take `$warehouseId` —
+   always pass the flow's OWN warehouse, never rely on the ambient "active session warehouse"
+   scope). Only pass the permissive `ladderUnitIds()` (which allows provisioning new rows) if the
+   flow already has an explicit user-confirmation step before writing, matching
+   `ProductionController::accProduction()`'s `confirm_create_stock` round-trip.
+5. **When does the roll-up actually happen** — every save, or only once at a specific transition?
+   Get this wrong and a flow that lets a user save progress repeatedly (a draft, a multi-step form)
+   will re-collapse and blank out raw in-progress input on every intermediate save — this is exactly
+   what GitHub #132 was. If the flow has any "save progress without finalizing" step, roll-up must
+   happen only once, at the point of finalizing, never on an interim save.
+
+Read `app/Support/UnitRollUp.php`'s class docblock and `app/Support/ProductUnitStock.php`'s
+`addQty()` docblock in full before implementing — they carry the reasoning for points 3-4 above in
+much more detail than fits here.
+
 ## Adding a new CRUD feature — end-to-end recipe
 This is the most common task shape in this repo. Do these steps together, in this order:
 

--- a/app/Http/Controllers/CustomerProductReturnController.php
+++ b/app/Http/Controllers/CustomerProductReturnController.php
@@ -4,8 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Models\CustomerProductReturn;
 use App\Models\CustomerProductReturnDetail;
-use App\Models\LogStock;
-use App\Models\ProductStock;
+use App\Support\ProductUnitStock;
 use App\Support\RoleAccess;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -272,6 +271,24 @@ class CustomerProductReturnController extends Controller
                 ])->all();
             $this->validateDetails($details);
 
+            // GitHub #132 (2026-09-03, "Bug report yang perlu diperhatikan"): dulu di sini cuma
+            // `$stock->ps_stock += qty` polos di SATUAN YANG DIKEMBALIKAN saja -- pengembalian
+            // 100 pcs (1 DOS = 12 pcs) di gudang besar tersimpan sebagai 100 Piece, bukan ikut naik
+            // jadi 8 DOS + 4 Piece. Bukan cuma representasi yang beda dari barang fisik yang sama,
+            // stok yang tidak pernah dikonversi ini jugalah yang belakangan membuat Stock Opname di
+            // gudang itu "rusak" (baris DOS-nya tidak pernah ada / tidak pernah ikut naik). Sekarang
+            // pakai ProductUnitStock::addQty() (helper yang sama dipakai ProductionController sejak
+            // GH #19/PR #75) dengan $rollUp cuma untuk gudang UTAMA -- gudang eceran tetap kredit
+            // flat di satuan aslinya, konsisten dengan OpnameLifecycle::isRetailWarehouse() (gudang
+            // eceran memang sengaja hanya pernah punya baris retail_unit).
+            $mainWarehouseIds = DB::table('warehouses as w')
+                ->join('warehouse_types as wt', 'wt.id', '=', 'w.warehouse_type_id')
+                ->whereIn('w.id', collect($details)->pluck('warehouse_id')->unique()->all())
+                ->where('wt.is_main_warehouse', 1)
+                ->pluck('w.id')
+                ->map(fn ($id) => (int) $id)
+                ->all();
+
             foreach ($details as $detail) {
                 $variant = DB::table('product_variants')
                     ->where('product_variant_id', $detail['product_variant_id'])
@@ -283,39 +300,16 @@ class CustomerProductReturnController extends Controller
                     ]);
                 }
 
-                $stock = ProductStock::withoutGlobalScope('active_warehouse')
-                    ->where('product_variant_id', $detail['product_variant_id'])
-                    ->where('unit_id', $detail['unit_id'])
-                    ->where('warehouse_id', $detail['warehouse_id'])
-                    ->lockForUpdate()
-                    ->first();
-                if (! $stock) {
-                    $stock = new ProductStock([
-                        'product_id' => (int) $variant->product_id,
-                        'product_variant_id' => $detail['product_variant_id'],
-                        'unit_id' => $detail['unit_id'],
-                        'warehouse_id' => $detail['warehouse_id'],
-                        'ps_stock' => 0,
-                        'status' => 1,
-                        'created_by' => $this->userId(),
-                    ]);
-                }
-                $stock->status = 1;
-                $stock->ps_stock = (float) $stock->ps_stock + $detail['qty'];
-                $stock->created_by = $this->userId();
-                $stock->save();
-
-                (new LogStock())->insertLog([
-                    'log_date' => now(),
-                    'log_kode' => $record->return_number,
-                    'log_type' => 1,
-                    'log_category' => 1,
-                    'log_item_id' => $detail['product_variant_id'],
-                    'log_notes' => 'Pengembalian produk jadi dari armada ' . $customerName,
-                    'log_jumlah' => $detail['qty'],
-                    'unit_id' => $detail['unit_id'],
-                    'warehouse_id' => $detail['warehouse_id'],
-                ]);
+                ProductUnitStock::addQty(
+                    $detail['warehouse_id'],
+                    (int) $variant->product_id,
+                    $detail['product_variant_id'],
+                    $detail['unit_id'],
+                    (float) $detail['qty'],
+                    $record->return_number,
+                    'Pengembalian produk jadi dari armada ' . $customerName,
+                    rollUp: in_array($detail['warehouse_id'], $mainWarehouseIds, true)
+                );
             }
 
             $record->status = 2;

--- a/app/Http/Controllers/CustomerReturnController.php
+++ b/app/Http/Controllers/CustomerReturnController.php
@@ -7,12 +7,12 @@ use App\Models\CustomerProductReturnDetail;
 use App\Models\CustomerSupplyReturn;
 use App\Models\CustomerSupplyReturnDetail;
 use App\Models\LogStock;
-use App\Models\ProductStock;
 use App\Models\Staff;
 use App\Models\StockTransfer;
 use App\Models\StockTransferDetail;
 use App\Models\SuppliesStock;
 use App\Support\CustomerReturnCreation;
+use App\Support\ProductUnitStock;
 use App\Support\RoleAccess;
 use Barryvdh\DomPDF\Facade\Pdf;
 use Carbon\Carbon;
@@ -466,6 +466,17 @@ class CustomerReturnController extends Controller
             })->all();
         $this->validateProductDetails($details);
 
+        // GitHub #132 (2026-09-03): kembaran persis CustomerProductReturnController::accept() --
+        // lihat komentarnya untuk alasan lengkap kenapa ini sekarang lewat ProductUnitStock::
+        // addQty() dengan roll-up khusus gudang utama.
+        $mainWarehouseIds = DB::table('warehouses as w')
+            ->join('warehouse_types as wt', 'wt.id', '=', 'w.warehouse_type_id')
+            ->whereIn('w.id', collect($details)->pluck('warehouse_id')->unique()->all())
+            ->where('wt.is_main_warehouse', 1)
+            ->pluck('w.id')
+            ->map(fn ($id) => (int) $id)
+            ->all();
+
         foreach ($details as $detail) {
             $variant = DB::table('product_variants')
                 ->where('product_variant_id', $detail['product_variant_id'])
@@ -477,39 +488,16 @@ class CustomerReturnController extends Controller
                 ]);
             }
 
-            $stock = ProductStock::withoutGlobalScope('active_warehouse')
-                ->where('product_variant_id', $detail['product_variant_id'])
-                ->where('unit_id', $detail['unit_id'])
-                ->where('warehouse_id', $detail['warehouse_id'])
-                ->lockForUpdate()
-                ->first();
-            if (! $stock) {
-                $stock = new ProductStock([
-                    'product_id' => (int) $variant->product_id,
-                    'product_variant_id' => $detail['product_variant_id'],
-                    'unit_id' => $detail['unit_id'],
-                    'warehouse_id' => $detail['warehouse_id'],
-                    'ps_stock' => 0,
-                    'status' => 1,
-                    'created_by' => $this->userId(),
-                ]);
-            }
-            $stock->status = 1;
-            $stock->ps_stock = (float) $stock->ps_stock + $detail['qty'];
-            $stock->created_by = $this->userId();
-            $stock->save();
-
-            (new LogStock())->insertLog([
-                'log_date' => now(),
-                'log_kode' => $record->return_group ?: $record->return_number,
-                'log_type' => 1,
-                'log_category' => 1,
-                'log_item_id' => $detail['product_variant_id'],
-                'log_notes' => 'Pengembalian produk jadi dari armada ' . $customerName,
-                'log_jumlah' => $detail['qty'],
-                'unit_id' => $detail['unit_id'],
-                'warehouse_id' => $detail['warehouse_id'],
-            ]);
+            ProductUnitStock::addQty(
+                $detail['warehouse_id'],
+                (int) $variant->product_id,
+                $detail['product_variant_id'],
+                $detail['unit_id'],
+                (float) $detail['qty'],
+                $record->return_group ?: $record->return_number,
+                'Pengembalian produk jadi dari armada ' . $customerName,
+                rollUp: in_array($detail['warehouse_id'], $mainWarehouseIds, true)
+            );
         }
 
         $createdTransferIds = $this->createRetailStockTransfers($record, $details, $customerName);

--- a/app/Http/Controllers/StockController.php
+++ b/app/Http/Controllers/StockController.php
@@ -106,15 +106,19 @@ class StockController extends Controller
             StockOpnameLine::writeFromPayload($id, $items);
 
             $lifecycle = new OpnameLifecycle();
-            // Keputusan PM 2026-08-27: gulung satuan (mis. 1 DOS = 12 pcs, isi 30 pcs -> tersimpan
-            // 2 DOS + 6 pcs) di SETIAP simpan -- draft ATAUPUN langsung menunggu, bukan cuma saat
-            // diajukan/diputuskan. Dipanggil SEBELUM publish() supaya identitas satuan yang baru
-            // ikut tercipta dari gulungan (kalaupun ada) turut dibekukan pada publish yang sama.
+            // GitHub #132 (2026-09-03, GANTI keputusan PM 2026-08-27): gulung satuan (mis. 1 DOS =
+            // 12 pcs, isi 30 pcs -> tersimpan 2 DOS + 6 pcs) HANYA di titik dokumen benar-benar
+            // terbit. .btn-save (dokumen dibuat LANGSUNG non-draft, is_draft = 0) membuat insert
+            // INI-lah momen "terbit"-nya. .btn-save-draft (is_draft = 1) membuat rollUpUnits()
+            // sendiri yang no-op di sini (lihat guard is_draft di dalamnya) -- gulungnya baru
+            // terjadi nanti, satu kali, di submitStockOpname() saat draft itu diajukan. Dipanggil
+            // SEBELUM publish() supaya identitas satuan yang baru ikut tercipta dari gulungan
+            // (kalaupun ada) turut dibekukan pada publish yang sama.
             $lifecycle->rollUpUnits(StockOpname::find($id));
 
-            // UI sekarang membuat dokumen LANGSUNG non-draft (.btn-save mengirim is_draft = 0 dan
-            // tidak pernah lewat /submitStockOpname), jadi publish-nya terjadi di sini. Aman juga
-            // untuk draft: publish() sendiri yang menolak selama is_draft masih true.
+            // publish() sendiri yang menolak selama is_draft masih true -- aman dipanggil di sini
+            // tanpa syarat baik untuk .btn-save (langsung publish) maupun .btn-save-draft (no-op,
+            // publish sesungguhnya terjadi nanti di submitStockOpname()).
             $lifecycle->publish(StockOpname::find($id));
 
             return response()->json(['status' => 1, 'sto_id' => $id]);
@@ -178,9 +182,12 @@ class StockController extends Controller
             // menggandakan baris seperti alur lama.
             StockOpnameLine::writeFromPayload($id, $items);
 
-            $lifecycle = new OpnameLifecycle();
-            $lifecycle->rollUpUnits($sto->refresh());
-            $lifecycle->publish($sto->refresh());
+            // GitHub #132 (2026-09-03): rollUpUnits() SENGAJA TIDAK dipanggil di sini lagi --
+            // dokumen yang masih bisa diedit (draft ATAUPUN koreksi sebelum ACC/tolak) harus
+            // menyimpan angka mentah persis seperti yang diketik staf. Gulung cuma terjadi SATU
+            // KALI, pas dokumen terbit (insertStockOpname() saat langsung non-draft, atau
+            // submitStockOpname() saat draft diajukan) -- lihat OpnameLifecycle::rollUpUnits().
+            (new OpnameLifecycle())->publish($sto->refresh());
         });
 
         return 1;
@@ -211,7 +218,15 @@ class StockController extends Controller
         // dokumen keluar dari draft di sini -- inilah saat snapshot identitas dibekukan untuk
         // alur draft (tombol .btn-ajukan). Idempoten, jadi tidak masalah kalau dokumen ini
         // ternyata sudah pernah publish lewat insert.
-        (new OpnameLifecycle())->publish($sto->refresh());
+        $lifecycle = new OpnameLifecycle();
+        // GitHub #132 (2026-09-03): inilah SATU-SATUNYA titik "diajukan" yang sebenarnya untuk
+        // dokumen yang lahir sebagai draft -- gulung satuannya di sini, bukan di update, supaya
+        // angka mentah yang diketik staf selama masih draft tidak diam-diam berubah tiap simpan.
+        // Dipanggil SEBELUM publish() supaya identitas satuan yang baru tercipta dari gulungan
+        // (kalau ada) ikut terbekukan pada publish yang sama -- lihat urutan yang sama persis di
+        // insertStockOpname().
+        $lifecycle->rollUpUnits($sto->refresh());
+        $lifecycle->publish($sto->refresh());
 
         return 1;
     }
@@ -957,8 +972,9 @@ class StockController extends Controller
             StockOpnameBahanLine::writeFromPayload($id, $items);
 
             $lifecycle = new BahanOpnameLifecycle();
-            // Kembaran keputusan PM di insertStockOpname() Produk -- gulung di SETIAP simpan,
-            // draft ataupun langsung menunggu, sebelum publish() membekukan identitasnya.
+            // GitHub #132 (2026-09-03): kembaran persis insertStockOpname() Produk -- lihat
+            // komentarnya untuk alasan lengkap kenapa ini satu-satunya titik gulung untuk dokumen
+            // yang lahir langsung non-draft.
             $lifecycle->rollUpUnits(StockOpnameBahan::find($id));
             $lifecycle->publish(StockOpnameBahan::find($id));
 
@@ -1012,9 +1028,9 @@ class StockController extends Controller
 
             StockOpnameBahanLine::writeFromPayload($id, $items);
 
-            $lifecycle = new BahanOpnameLifecycle();
-            $lifecycle->rollUpUnits($stob->refresh());
-            $lifecycle->publish($stob->refresh());
+            // GitHub #132 (2026-09-03): kembaran persis updateStockOpname() Produk -- lihat
+            // komentarnya. rollUpUnits() tidak lagi dipanggil dari update.
+            (new BahanOpnameLifecycle())->publish($stob->refresh());
         });
 
         return 1;
@@ -1041,7 +1057,11 @@ class StockController extends Controller
         // NB (merged from main's efef95e, 2026-08-28): main called
         // (new StockOpnameBahan())->submitStockOpnameBahan($data), a model method that doesn't
         // exist in this tree -- see submitStockOpname()'s (Produk) matching note.
-        (new BahanOpnameLifecycle())->publish($stob->refresh());
+        $lifecycle = new BahanOpnameLifecycle();
+        // GitHub #132 (2026-09-03): kembaran persis submitStockOpname() Produk -- lihat
+        // komentarnya untuk alasan lengkap kenapa gulung pindah ke sini.
+        $lifecycle->rollUpUnits($stob->refresh());
+        $lifecycle->publish($stob->refresh());
 
         return 1;
     }

--- a/app/Support/StockOpname/BahanOpnameLifecycle.php
+++ b/app/Support/StockOpname/BahanOpnameLifecycle.php
@@ -89,11 +89,13 @@ class BahanOpnameLifecycle
 
     /**
      * Kembaran persis OpnameLifecycle::rollUpUnits() (Produk), untuk Supplies. Lihat kelas itu
-     * untuk alasan lengkap.
+     * untuk alasan lengkap -- termasuk GANTI KEPUTUSAN 2026-09-03 (GitHub #132): tidak lagi
+     * dipanggil dari update, hanya sekali saat dokumen benar-benar terbit (insert langsung
+     * non-draft, atau submitStockOpnameBahan() saat draft diajukan). Guard is_draft di bawah.
      */
     public function rollUpUnits($stob): void
     {
-        if (! $stob || $stob->is_old_version) {
+        if (! $stob || $stob->is_old_version || $stob->is_draft) {
             return;
         }
 

--- a/app/Support/StockOpname/OpnameLifecycle.php
+++ b/app/Support/StockOpname/OpnameLifecycle.php
@@ -23,16 +23,19 @@ use App\Support\UnitRollUp;
  *   menunggu           -> tidak menulis apa pun; stok sistem dibaca live saat ditampilkan.
  *   disetujui/ditolak  -> snapshot STOK SISTEM (sol_system_qty_final) + nama pemutus + waktu.
  *
- * >>> PERHATIAN alur UI SEKARANG <<<
- * CreateStockOpname.blade.php cuma memasang tombol .btn-save, yang memanggil insertData() TANPA
- * isDraft -- artinya dokumen dibuat LANGSUNG non-draft (is_draft = 0), tidak pernah lewat
- * /submitStockOpname. Handler .btn-save-draft / .btn-ajukan sudah ada di CreateStockOpname.js
- * tapi markup-nya belum dipasang, jadi jalur draft masih tidur.
+ * >>> PERBARUI 2026-09-03: jalur draft SUDAH hidup, bukan lagi "tidur" <<<
+ * CreateStockOpname.blade.php sekarang memasang KETIGA tombol -- .btn-save-draft, .btn-ajukan,
+ * DAN .btn-save -- jadi staf yang menghitung dokumen besar (banyak produk) bisa betul-betul
+ * menyimpan sebagai draft berkali-kali sambil terus menghitung, baru menekan .btn-ajukan kalau
+ * sudah selesai. Catatan lama di sini bilang draft "masih tidur" dan itulah yang membuat
+ * rollUpUnits() dulu dipanggil dari SETIAP simpan (insert+update) tanpa peduli is_draft -- begitu
+ * jalur draft hidup, itu jadi bug nyata (GitHub #132, kasus SP0110): tiap simpan-antara draft
+ * langsung menggulung angka mentah yang belum selesai diketik staf. Sekarang rollUpUnits() cuma
+ * jalan SATU KALI, pas dokumen benar-benar terbit -- lihat docblock method itu sendiri.
  *
- * Karena itu publish() dipicu oleh KEADAAN ("dokumen ini sudah bukan draft dan identitasnya
+ * publish() sendiri TETAP dipicu oleh KEADAAN ("dokumen ini sudah bukan draft dan identitasnya
  * belum dibekukan"), bukan oleh peristiwa tombol tertentu, dan aman dipanggil berkali-kali.
- * Panggil dari SEMUA pintu: insert, update, dan submit. Saat tombol draft nanti dipasang, tidak
- * ada satu baris pun di kelas ini yang perlu berubah.
+ * Panggil dari SEMUA pintu: insert, update, dan submit.
  */
 class OpnameLifecycle
 {
@@ -127,12 +130,26 @@ class OpnameLifecycle
 
     /**
      * Gulung REKURSIF hasil hitung tiap produk ke tangga satuannya (App\Support\UnitRollUp::
-     * collapseProduct()) -- keputusan PM 2026-08-27: isi satuan kecil, satuan besar yang belum
-     * disentuh ikut naik otomatis (mis. 1 DOS = 12 pcs, isi 30 pcs -> tersimpan 2 DOS + 6 pcs).
+     * collapseProduct()) -- isi satuan kecil, satuan besar yang belum disentuh ikut naik otomatis
+     * (mis. 1 DOS = 12 pcs, isi 30 pcs -> tersimpan 2 DOS + 6 pcs).
      *
-     * Dipanggil dari SETIAP simpan (insert MAUPUN update) -- draft ataupun langsung menunggu,
-     * bukan cuma saat diajukan/diputuskan. Aman dipanggil berkali-kali: collapse() idempoten,
-     * menjalankan ulang pada dokumen yang sudah tergulung tidak mengubah apa pun lagi.
+     * >>> GANTI KEPUTUSAN 2026-09-03 (GitHub #132) <<<
+     * Keputusan PM 2026-08-27 tadinya "gulung di SETIAP simpan" (insert MAUPUN update, draft
+     * ataupun langsung menunggu). Itu ternyata SALAH pada dokumen banyak-baris: tiap simpan
+     * antara (staf menghitung produk lain lalu simpan lagi, atau sekadar menyimpan draft)
+     * langsung menggulung angka mentah yang baru saja diketik dan MENGOSONGKAN kembali kolom
+     * satuan kecilnya -- staf yang belum selesai menghitung melihat isiannya "hilang"/berubah
+     * jadi satuan lain di tengah jalan (kasus nyata: SP0110, RCHK5LH 4 pcs berulang kali tergulung
+     * jadi angka DOS yang jauh berbeda karena banyak simpan-antara sebelum diajukan).
+     *
+     * Sekarang: TIDAK PERNAH dipanggil dari update (StockController::updateStockOpname()) --
+     * angka yang diketik staf dibiarkan APA ADANYA selama dokumen masih bisa diedit (draft
+     * maupun koreksi sebelum ACC/tolak). Hanya dipanggil SATU KALI, pas dokumen baru benar-benar
+     * "terbit" (bukan draft lagi): StockController::insertStockOpname() saat dibuat LANGSUNG
+     * non-draft (satu-satunya jalur UI hari ini), dan StockController::submitStockOpname() saat
+     * draft diajukan (.btn-ajukan, jalur yang belum dipasang di UI tapi sudah disiapkan).
+     * Guard is_draft di bawah membuat panggilan dari insert saat draft (kalau UI draft-nya nanti
+     * dipasang) jadi no-op dengan aman, konsisten dengan aturan ini.
      *
      * TIDAK PERNAH mengisi satuan yang lebih kecil dari satuan terkecil yang benar-benar diisi --
      * lihat UnitRollUp::collapse() untuk alasan lengkap (setara GitHub #78: jangan mengarang data
@@ -140,7 +157,7 @@ class OpnameLifecycle
      */
     public function rollUpUnits($sto): void
     {
-        if (! $sto || $sto->is_old_version) {
+        if (! $sto || $sto->is_old_version || $sto->is_draft) {
             return;
         }
 

--- a/tests/Workflow/CustomerProductReturnRollUpTest.php
+++ b/tests/Workflow/CustomerProductReturnRollUpTest.php
@@ -1,0 +1,206 @@
+<?php
+
+namespace Tests\Workflow;
+
+use App\Models\Category;
+use App\Models\Customer;
+use App\Models\CustomerProductReturn;
+use App\Models\CustomerProductReturnDetail;
+use App\Models\Product;
+use App\Models\ProductRelation;
+use App\Models\ProductStock;
+use App\Models\ProductVariant;
+use App\Models\Unit;
+use App\Models\Warehouse;
+use Tests\Support\ActingAsStaff;
+use Tests\TestCase;
+
+/**
+ * GitHub #132 ("Bug report yang perlu diperhatikan"): Pengembalian produk jadi pcs di gudang
+ * besar dulu ditulis flat (`ps_stock += qty` di satuan yang dikembalikan saja) tanpa pernah
+ * menggulung ke satuan atas -- 100 pcs (1 DOS = 12 pcs) tersimpan sebagai 100 Piece, bukan 8 DOS +
+ * 4 Piece, dan data yang tidak pernah dikonversi ini yang belakangan membuat Stock Opname gudang
+ * itu "rusak" (baris DOS tidak pernah ada/ikut naik). Sekarang lewat App\Support\ProductUnitStock::
+ * addQty() dengan roll-up khusus gudang UTAMA -- lihat CustomerProductReturnController::accept().
+ */
+class CustomerProductReturnRollUpTest extends TestCase
+{
+    use ActingAsStaff;
+
+    private array $units = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $rows = Unit::where('status', 1)->limit(2)->get();
+        $this->assertGreaterThanOrEqual(2, $rows->count(), 'fixture butuh minimal 2 satuan aktif');
+        $this->units = ['dos' => $rows[0], 'pcs' => $rows[1]];
+    }
+
+    private function mainWarehouseId(): int
+    {
+        return (int) Warehouse::query()
+            ->where('warehouses.status', 1)
+            ->whereHas('type', fn ($q) => $q->where('status', 1)->where('is_main_warehouse', 1))
+            ->orderBy('warehouses.id')
+            ->value('id');
+    }
+
+    private function retailWarehouseId(): int
+    {
+        return (int) Warehouse::query()
+            ->where('warehouses.status', 1)
+            ->whereHas('type', fn ($q) => $q->where('status', 1)->where('is_main_warehouse', 0))
+            ->orderBy('warehouses.id')
+            ->value('id');
+    }
+
+    /** 1 DOS = 12 pcs, kedua satuan sudah punya baris ProductStock aktif di $warehouseId. */
+    private function makeLadderedVariant(int $warehouseId, int $dosStock, int $pcsStock, int $ratio = 12): ProductVariant
+    {
+        $category = new Category();
+        $category->category_name = 'Return RollUp Test Category';
+        $category->status = 1;
+        $category->save();
+
+        $product = new Product();
+        $product->product_name = 'Return RollUp Test Product';
+        $product->category_id = $category->category_id;
+        $product->product_unit = json_encode([$this->units['dos']->unit_id, $this->units['pcs']->unit_id]);
+        $product->unit_id = $this->units['dos']->unit_id;
+        $product->status = 1;
+        $product->save();
+
+        $variant = new ProductVariant();
+        $variant->product_id = $product->product_id;
+        $variant->product_variant_name = 'Return RollUp Test Variant';
+        $variant->product_variant_sku = 'RTNRU-'.uniqid();
+        $variant->product_variant_price = 0;
+        $variant->status = 1;
+        $variant->save();
+
+        $relation = new ProductRelation();
+        $relation->product_variant_id = $variant->product_variant_id;
+        $relation->pr_unit_id_1 = $this->units['dos']->unit_id; // besar
+        $relation->pr_unit_value_1 = 1;
+        $relation->pr_unit_id_2 = $this->units['pcs']->unit_id; // kecil
+        $relation->pr_unit_value_2 = $ratio;
+        $relation->status = 1;
+        $relation->save();
+
+        foreach ([['dos', $dosStock], ['pcs', $pcsStock]] as [$key, $qty]) {
+            $s = new ProductStock();
+            $s->product_id = $product->product_id;
+            $s->product_variant_id = $variant->product_variant_id;
+            $s->unit_id = $this->units[$key]->unit_id;
+            $s->warehouse_id = $warehouseId;
+            $s->ps_stock = $qty;
+            $s->status = 1;
+            $s->save();
+        }
+
+        return $variant;
+    }
+
+    private function createArmada(): Customer
+    {
+        $customer = new Customer();
+        $customer->customer_name = 'Return RollUp Test Armada';
+        $customer->customer_code = 'RRU'.random_int(1000, 9999);
+        $customer->status = 1;
+        $customer->save();
+
+        return $customer;
+    }
+
+    private function currentStock(ProductVariant $v, string $unitKey, int $warehouseId): int
+    {
+        return (int) ProductStock::withoutGlobalScope('active_warehouse')
+            ->where('product_variant_id', $v->product_variant_id)
+            ->where('unit_id', $this->units[$unitKey]->unit_id)
+            ->where('warehouse_id', $warehouseId)
+            ->value('ps_stock');
+    }
+
+    private function makeReturn(Customer $customer, ProductVariant $v, int $warehouseId, string $unitKey, int $qty): CustomerProductReturn
+    {
+        $record = new CustomerProductReturn();
+        $record->return_number = 'PBJ-TEST-'.uniqid();
+        $record->customer_id = $customer->customer_id;
+        $record->return_date = now()->toDateString();
+        $record->proof_path = 'return-rollup-test.png';
+        $record->status = 1;
+        $record->created_by = $this->staffId();
+        $record->save();
+
+        $detail = new CustomerProductReturnDetail();
+        $detail->return_id = $record->return_id;
+        $detail->product_variant_id = $v->product_variant_id;
+        $detail->unit_id = $this->units[$unitKey]->unit_id;
+        $detail->warehouse_id = $warehouseId;
+        $detail->qty = $qty;
+        $detail->status = 1;
+        $detail->save();
+
+        return $record;
+    }
+
+    private function staffId(): int
+    {
+        return (int) \Illuminate\Support\Facades\DB::table('staffs')->where('status', 1)->value('staff_id');
+    }
+
+    public function test_returning_pcs_at_main_warehouse_rolls_up_into_the_bigger_unit(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $warehouseId = $this->mainWarehouseId();
+        $v = $this->makeLadderedVariant($warehouseId, dosStock: 0, pcsStock: 0, ratio: 12);
+        $customer = $this->createArmada();
+
+        // Dikembalikan 100 pcs (1 DOS = 12 pcs) -> harus tergulung jadi 8 DOS + 4 Piece, bukan
+        // menumpuk sebagai 100 Piece polos.
+        $record = $this->makeReturn($customer, $v, $warehouseId, 'pcs', 100);
+
+        $response = $this->post("/customerProductReturns/{$record->return_id}/accept");
+        $response->assertOk();
+
+        $this->assertSame(8, $this->currentStock($v, 'dos', $warehouseId), 'pengembalian di gudang utama harus ikut menggulung ke DOS');
+        $this->assertSame(4, $this->currentStock($v, 'pcs', $warehouseId), 'sisa yang tidak genap satu DOS harus tetap di Piece');
+    }
+
+    public function test_returning_pcs_at_retail_warehouse_stays_flat_no_roll_up(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $retailId = $this->retailWarehouseId();
+        if ($retailId <= 0) {
+            $this->markTestSkipped('Tidak ada gudang eceran aktif di seed data.');
+        }
+
+        // Gudang eceran hanya boleh punya baris retail_unit (pcs) -- DOS sengaja tidak dibuat di
+        // sini, meniru OpnameLifecycle::isRetailWarehouse()'s aturan yang sama.
+        $v = $this->makeLadderedVariant($retailId, dosStock: 0, pcsStock: 0, ratio: 12);
+        $v->retail_unit = $this->units['pcs']->unit_id;
+        $v->save();
+        ProductStock::withoutGlobalScope('active_warehouse')
+            ->where('product_variant_id', $v->product_variant_id)
+            ->where('warehouse_id', $retailId)
+            ->where('unit_id', $this->units['dos']->unit_id)
+            ->delete();
+
+        $customer = $this->createArmada();
+        $record = $this->makeReturn($customer, $v, $retailId, 'pcs', 100);
+
+        $response = $this->post("/customerProductReturns/{$record->return_id}/accept");
+        $response->assertOk();
+
+        $this->assertSame(100, $this->currentStock($v, 'pcs', $retailId), 'gudang eceran tidak boleh menggulung sama sekali');
+        $this->assertDatabaseMissing('product_stocks', [
+            'product_variant_id' => $v->product_variant_id,
+            'warehouse_id' => $retailId,
+            'unit_id' => $this->units['dos']->unit_id,
+            'status' => 1,
+        ]);
+    }
+}

--- a/tests/Workflow/StockOpnameBahanV2LifecycleTest.php
+++ b/tests/Workflow/StockOpnameBahanV2LifecycleTest.php
@@ -407,20 +407,32 @@ class StockOpnameBahanV2LifecycleTest extends TestCase
         $this->assertSame(2, (int) $lines[$dos->unit_id]->sobl_counted_qty);
     }
 
-    /** "Baik draft maupun langsung menunggu" -- keputusan PM eksplisit, keduanya harus tergulung. */
-    public function test_roll_up_applies_equally_to_draft_and_pending_documents(): void
+    /**
+     * GANTI keputusan (GitHub #132, 2026-09-03): kembaran persis
+     * StockOpnameV2LifecycleTest::test_roll_up_only_applies_to_a_published_document_never_a_draft()
+     * -- lihat komentarnya untuk alasan lengkap.
+     */
+    public function test_roll_up_only_applies_to_a_published_document_never_a_draft(): void
     {
-        foreach ([true, false] as $isDraft) {
-            [$supplies, $dos, $pcs] = $this->makeFixtureWithLadder(dosStock: 0);
-            $stob = $this->makeDocument(isDraft: $isDraft);
-            $this->addLines($stob, $supplies, [$pcs->unit_id => 30, $dos->unit_id => null]);
+        [$supplies, $dos, $pcs] = $this->makeFixtureWithLadder(dosStock: 0);
+        $draft = $this->makeDocument(isDraft: true);
+        $this->addLines($draft, $supplies, [$pcs->unit_id => 30, $dos->unit_id => null]);
 
-            (new BahanOpnameLifecycle())->rollUpUnits($stob);
+        (new BahanOpnameLifecycle())->rollUpUnits($draft);
 
-            $lines = StockOpnameBahanLine::getLines($stob->stob_id)->keyBy('unit_id');
-            $this->assertSame(2, (int) $lines[$dos->unit_id]->sobl_counted_qty, 'is_draft='.($isDraft ? '1' : '0'));
-            $this->assertSame(6, (int) $lines[$pcs->unit_id]->sobl_counted_qty, 'is_draft='.($isDraft ? '1' : '0'));
-        }
+        $lines = StockOpnameBahanLine::getLines($draft->stob_id)->keyBy('unit_id');
+        $this->assertSame(30, (int) $lines[$pcs->unit_id]->sobl_counted_qty, 'draft tidak boleh tergulung sama sekali');
+        $this->assertNull($lines[$dos->unit_id]->sobl_counted_qty, 'draft tidak boleh tergulung sama sekali');
+
+        [$supplies2, $dos2, $pcs2] = $this->makeFixtureWithLadder(dosStock: 0);
+        $pending = $this->makeDocument(isDraft: false);
+        $this->addLines($pending, $supplies2, [$pcs2->unit_id => 30, $dos2->unit_id => null]);
+
+        (new BahanOpnameLifecycle())->rollUpUnits($pending);
+
+        $lines2 = StockOpnameBahanLine::getLines($pending->stob_id)->keyBy('unit_id');
+        $this->assertSame(2, (int) $lines2[$dos2->unit_id]->sobl_counted_qty, 'dokumen yang sudah terbit tetap tergulung');
+        $this->assertSame(6, (int) $lines2[$pcs2->unit_id]->sobl_counted_qty, 'dokumen yang sudah terbit tetap tergulung');
     }
 
     /** Setara GitHub #78: satuan besar diisi 0 tidak boleh membuat satuan kecil ikut disimpulkan. */

--- a/tests/Workflow/StockOpnameV2EndToEndTest.php
+++ b/tests/Workflow/StockOpnameV2EndToEndTest.php
@@ -736,8 +736,12 @@ class StockOpnameV2EndToEndTest extends TestCase
         $this->assertStringContainsString('2 '.$this->units['dos']->unit_short_name, $row);
     }
 
-    /** "Baik draft maupun langsung menunggu" (keputusan PM) -- draft lewat /insertStockOpname juga harus tergulung. */
-    public function test_insert_endpoint_rolls_up_on_a_draft_document_too(): void
+    /**
+     * GANTI keputusan (GitHub #132, 2026-09-03): draft lewat /insertStockOpname TIDAK BOLEH
+     * tergulung -- angka mentah dibiarkan apa adanya sampai benar-benar diajukan/terbit. Lihat
+     * OpnameLifecycle::rollUpUnits() untuk alasan lengkap (kasus nyata SP0110).
+     */
+    public function test_insert_endpoint_leaves_a_draft_document_unrolled(): void
     {
         $this->actingAsSuperAdminStaff();
 
@@ -751,12 +755,17 @@ class StockOpnameV2EndToEndTest extends TestCase
         $this->assertTrue((bool) $sto->is_draft);
 
         $lines = StockOpnameLine::getLines($stoId)->keyBy('unit_id');
-        $this->assertSame(6, (int) $lines[$this->units['pcs']->unit_id]->sol_counted_qty);
-        $this->assertSame(2, (int) $lines[$this->units['dos']->unit_id]->sol_counted_qty, 'draft pun harus tergulung, bukan cuma dokumen yang langsung menunggu');
+        $this->assertSame(30, (int) $lines[$this->units['pcs']->unit_id]->sol_counted_qty, 'draft tidak boleh tergulung sama sekali');
+        $this->assertNull($lines[$this->units['dos']->unit_id]->sol_counted_qty, 'draft tidak boleh tergulung sama sekali');
     }
 
-    /** Mengedit dokumen yang sudah ada (menunggu) lewat /updateStockOpname juga harus menggulung ulang. */
-    public function test_update_endpoint_rolls_up_after_editing_the_count(): void
+    /**
+     * GANTI keputusan (GitHub #132, 2026-09-03): /updateStockOpname TIDAK BOLEH lagi menggulung
+     * ulang -- koreksi sebelum ACC/tolak harus tersimpan persis seperti yang diketik staf. Gulung
+     * cuma terjadi sekali, saat dokumen terbit (insert langsung non-draft, atau /submitStockOpname
+     * saat draft diajukan) -- lihat StockController::submitStockOpname().
+     */
+    public function test_update_endpoint_no_longer_rolls_up(): void
     {
         $this->actingAsSuperAdminStaff();
 
@@ -783,7 +792,7 @@ class StockOpnameV2EndToEndTest extends TestCase
         $updateResponse->assertStatus(200);
 
         $lines = StockOpnameLine::getLines($stoId)->keyBy('unit_id');
-        $this->assertSame(6, (int) $lines[$this->units['pcs']->unit_id]->sol_counted_qty);
-        $this->assertSame(2, (int) $lines[$this->units['dos']->unit_id]->sol_counted_qty, 'edit yang menaikkan hitungan harus ikut menggulung ulang');
+        $this->assertSame(30, (int) $lines[$this->units['pcs']->unit_id]->sol_counted_qty, 'update tidak boleh menggulung, angka mentah harus tersimpan apa adanya');
+        $this->assertNull($lines[$this->units['dos']->unit_id]->sol_counted_qty, 'update tidak boleh menggulung, angka mentah harus tersimpan apa adanya');
     }
 }

--- a/tests/Workflow/StockOpnameV2LifecycleTest.php
+++ b/tests/Workflow/StockOpnameV2LifecycleTest.php
@@ -406,20 +406,34 @@ class StockOpnameV2LifecycleTest extends TestCase
         $this->assertSame(2, (int) $lines[$dos->unit_id]->sol_counted_qty, 'DOS harus ikut terisi otomatis dari kelebihan pcs');
     }
 
-    /** "Baik draft maupun langsung menunggu" -- keputusan PM eksplisit, keduanya harus tergulung. */
-    public function test_roll_up_applies_equally_to_draft_and_pending_documents(): void
+    /**
+     * GANTI keputusan (GitHub #132, 2026-09-03): dokumen draft TIDAK BOLEH tergulung -- angka
+     * mentah yang diketik staf harus dibiarkan apa adanya selama masih bisa diedit. Hanya dokumen
+     * yang sudah terbit (bukan draft) yang tergulung di sini. Dulu tesnya menuntut sebaliknya
+     * ("baik draft maupun menunggu") -- itulah persis akar bug SP0110/GitHub #132 (simpan-antara
+     * di dokumen draft diam-diam menggulung isian staf yang belum selesai menghitung).
+     */
+    public function test_roll_up_only_applies_to_a_published_document_never_a_draft(): void
     {
-        foreach ([true, false] as $isDraft) {
-            [$variant, $dos, $pcs] = $this->makeFixtureWithLadder(dosStock: 0);
-            $sto = $this->makeDocument(isDraft: $isDraft);
-            $this->addLines($sto, $variant, [$pcs->unit_id => 30, $dos->unit_id => null]);
+        [$variant, $dos, $pcs] = $this->makeFixtureWithLadder(dosStock: 0);
+        $draft = $this->makeDocument(isDraft: true);
+        $this->addLines($draft, $variant, [$pcs->unit_id => 30, $dos->unit_id => null]);
 
-            (new OpnameLifecycle())->rollUpUnits($sto);
+        (new OpnameLifecycle())->rollUpUnits($draft);
 
-            $lines = StockOpnameLine::getLines($sto->sto_id)->keyBy('unit_id');
-            $this->assertSame(2, (int) $lines[$dos->unit_id]->sol_counted_qty, 'is_draft='.($isDraft ? '1' : '0'));
-            $this->assertSame(6, (int) $lines[$pcs->unit_id]->sol_counted_qty, 'is_draft='.($isDraft ? '1' : '0'));
-        }
+        $lines = StockOpnameLine::getLines($draft->sto_id)->keyBy('unit_id');
+        $this->assertSame(30, (int) $lines[$pcs->unit_id]->sol_counted_qty, 'draft tidak boleh tergulung sama sekali');
+        $this->assertNull($lines[$dos->unit_id]->sol_counted_qty, 'draft tidak boleh tergulung sama sekali');
+
+        [$variant2, $dos2, $pcs2] = $this->makeFixtureWithLadder(dosStock: 0);
+        $pending = $this->makeDocument(isDraft: false);
+        $this->addLines($pending, $variant2, [$pcs2->unit_id => 30, $dos2->unit_id => null]);
+
+        (new OpnameLifecycle())->rollUpUnits($pending);
+
+        $lines2 = StockOpnameLine::getLines($pending->sto_id)->keyBy('unit_id');
+        $this->assertSame(2, (int) $lines2[$dos2->unit_id]->sol_counted_qty, 'dokumen yang sudah terbit tetap tergulung');
+        $this->assertSame(6, (int) $lines2[$pcs2->unit_id]->sol_counted_qty, 'dokumen yang sudah terbit tetap tergulung');
     }
 
     /**


### PR DESCRIPTION
## Ringkasan

Memperbaiki [#132](https://github.com/denny011299/pegasus/issues/132) — laporan awal "RCHK5LH 4pcs tidak rollup jadi DOS" ternyata dua bug berbeda setelah ditelusuri sampai data nyata di `pegasus_prod_3` (SP0110):

### 1. Waktu gulung satuan (Stock Opname Produk & Bahan) salah
`OpnameLifecycle`/`BahanOpnameLifecycle::rollUpUnits()` dulu dipanggil di **setiap simpan** (insert maupun update, draft ataupun menunggu) — keputusan PM 2026-08-27. Begitu tombol draft (`.btn-save-draft`/`.btn-ajukan`) benar-benar terpasang di UI, ini jadi bug nyata: staf yang menyimpan progres dokumen besar berkali-kali (atau mengoreksi sebelum ACC) melihat isian mentahnya diam-diam tergulung dan hilang lagi di tengah jalan — persis pola data SP0110 (pcs jadi `null`, DOS jadi `533` alih-alih `4` yang benar-benar dihitung staf).

**Perbaikan:** gulung sekarang cuma terjadi **satu kali**, pas dokumen benar-benar terbit:
- `rollUpUnits()` no-op selama `is_draft` masih true.
- `updateStockOpname()`/`updateStockOpnameBahan()` tidak lagi memanggilnya sama sekali — koreksi sebelum ACC/tolak tersimpan apa adanya.
- `submitStockOpname()`/`submitStockOpnameBahan()` (momen "ajukan" draft yang sesungguhnya) memanggilnya sekali, sebelum `publish()`.
- `insertStockOpname()`/`insertStockOpnameBahan()` tetap memanggilnya tanpa syarat — no-op untuk draft, gulung sekali yang benar untuk `.btn-save` langsung non-draft (satu-satunya jalur UI hari ini).

### 2. Pengembalian produk tidak pernah menggulung sama sekali
`CustomerProductReturnController::accept()` dan kembarannya yang lama `CustomerReturnController::acceptProduct()` mengkredit stok pengembalian dengan `ps_stock += qty` polos di satuan yang dikembalikan saja — pengembalian 100 pcs (1 DOS = 12 pcs) di gudang besar tersimpan sebagai 100 Piece selamanya, bukan 8 DOS + 4 Piece. Stok yang tidak pernah dikonversi inilah kemungkinan besar akar penyebab gudang-gudang yang cuma punya baris pcs tanpa baris DOS, yang belakangan membuat Stock Opname di gudang itu "rusak".

**Perbaikan:** kedua `accept()` sekarang lewat `App\Support\ProductUnitStock::addQty(..., rollUp: true)` — helper yang sama dipakai `ProductionController::accProduction()` sejak GH #19/PR #75 — dengan roll-up cuma untuk gudang **utama**; gudang eceran tetap kredit flat, konsisten dengan `OpnameLifecycle::isRetailWarehouse()`.

**Belum diperbaiki (sengaja, ditandai):** sisi Bahan/Supplies Pengembalian (`CustomerSupplyReturnController`, `CustomerReturnController::acceptSupply()`) punya celah yang sama persis, tapi belum ada padanan `ProductUnitStock::addQty()` untuk Supplies — di luar cakupan PR ini karena laporan awal cuma soal produk (pcs/DOS). Dicatat sebagai tindak lanjut.

### 3. Aturan baru untuk agen AI ke depan
Menambahkan bagian "⚠️ Touching any stock-mutating logic" di skill `pegasus-conventions` (auto-load sebelum edit backend apa pun di repo ini) — setiap perubahan yang memutasi `product_stocks`/`supplies_stocks` sekarang wajib dicek dulu implikasi roll-up-nya (ada tangga satuan? gudang eceran? kredit vs snapshot? beresiko bikin baris stok baru diam-diam? sekali vs tiap simpan?) sebelum kode ditulis.

## Pengujian

`php vendor/bin/phpunit` untuk seluruh berkas yang tersentuh — 97/100 hijau; 3 kegagalan sisanya terbukti sudah ada sebelum PR ini (diverifikasi ulang di kode tanpa perubahan), tidak terkait perubahan ini:
- `tests/Workflow/StockOpnameV2LifecycleTest.php`, `StockOpnameBahanV2LifecycleTest.php`
- `tests/Workflow/StockOpnameV2EndToEndTest.php`
- `tests/Workflow/CustomerProductReturnRollUpTest.php` (baru — gudang utama menggulung, gudang eceran tetap flat)

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)
