### PR TITLE
fix(produksi): 4 bugs from GitHub #134

### DIFF
--- a/app/Http/Controllers/ProductionController.php
+++ b/app/Http/Controllers/ProductionController.php
@@ -163,6 +163,18 @@ class ProductionController extends Controller
         }
         $item = json_decode($req->detail, true);
         $bahan = json_decode($req->list_bahan, true);
+        // GitHub #134: harus ada minimal 1 produk. Validasi array kosong lolos begitu saja lewat
+        // validateProductionItems() di bawah (loop kosong = tidak ada yang gagal), jadi tanpa
+        // guard ini submit yang detail-nya kosong (mis. klik "Tambah Produksi" race dengan
+        // checkProductionStock yang belum selesai mendorong baris ke `items`) tetap membuat
+        // baris Production tanpa satu pun ProductionDetails — transaksi "kosongan" di tabel.
+        if (! is_array($item) || count($item) === 0) {
+            return response()->json([
+                'status' => 0,
+                'header' => 'Gagal Insert',
+                'message' => 'Harus ada 1 produk dipilih',
+            ]);
+        }
         $destinationValidation = $this->normalizeProductionDestinations($item);
         if (! $destinationValidation['ok']) {
             return response()->json([
@@ -1546,7 +1558,13 @@ class ProductionController extends Controller
                 $output['unit_id'],
                 $output['qty'],
                 $p->production_code,
-                'Pembatalan produksi ' . $p->production_code
+                'Pembatalan produksi ' . $p->production_code,
+                false,
+                true,
+                // GitHub #134: reversal produksi mode stok gudang bukan alur Stock Transfer —
+                // kalau butuh bongkar satuan, Log Stock harus menyebut ini pembatalan produksi,
+                // bukan ikut default "Stock Transfer - bongkar satuan".
+                'Pembatalan produksi'
             );
             if (! $cut['ok']) {
                 DB::rollBack();

--- a/app/Models/Bom.php
+++ b/app/Models/Bom.php
@@ -390,8 +390,12 @@ class Bom extends Model
             $row->unit_name = $bomUnit
                 ? ($bomUnit->unit_name ?? $bomUnit->unit_short_name ?? '-')
                 : '-';
-            // product_unit bisa kosong/inkonsisten — selalu sertakan default + satuan BOM
-            // supaya FE modal produksi punya opsi + nilai terpilih.
+            // product_unit = satuan yang benar-benar dikonfigurasi di Daftar Produk — itu yang
+            // wajib jadi sumber pilihan satuan di modal produksi (GitHub #134: UNICAL cuma
+            // punya Pail di Daftar Produk, tapi dulu bisa pilih pcs juga karena baris di bawah
+            // ini selalu menambahkan satuan resep BOM (boms.unit_id) apa pun isi product_unit-nya
+            // -- BOM boleh dihitung dalam satuan lain buat kebutuhan bahan, tapi itu bukan berarti
+            // produk boleh DIPRODUKSI dalam satuan itu).
             $unitIds = [];
             foreach ((array) (json_decode($row->product_unit, true) ?: []) as $unitId) {
                 $uid = is_array($unitId)
@@ -401,7 +405,18 @@ class Bom extends Model
                     $unitIds[$uid] = true;
                 }
             }
-            foreach ([$row->default_unit, $row->unit_id, $row->retail_unit] as $extraId) {
+            if ($unitIds === []) {
+                // product_unit kosong/rusak — fallback ke satuan default produk, lalu satuan
+                // resep BOM, supaya dropdown FE tetap punya minimal 1 opsi yang valid.
+                $fallbackId = (int) ($row->default_unit ?? 0);
+                if ($fallbackId <= 0) {
+                    $fallbackId = (int) ($row->unit_id ?? 0);
+                }
+                if ($fallbackId > 0) {
+                    $unitIds[$fallbackId] = true;
+                }
+            }
+            foreach ([$row->default_unit, $row->retail_unit] as $extraId) {
                 $uid = (int) ($extraId ?? 0);
                 if ($uid > 0) {
                     $unitIds[$uid] = true;

--- a/app/Support/ProductUnitStock.php
+++ b/app/Support/ProductUnitStock.php
@@ -531,7 +531,8 @@ class ProductUnitStock
         string $logCode,
         string $logNotes = 'Stock Transfer - keluar',
         bool $allowPacking = false,
-        bool $allowUnpack = true
+        bool $allowUnpack = true,
+        ?string $unpackNotePrefix = null
     ): array {
         if ($qty <= 0) {
             return ['ok' => true];
@@ -585,13 +586,19 @@ class ProductUnitStock
         $relations = self::relations($productVariantId);
         /** @var list<array{unit_id:int, qty:float, category:int, note:string}> $logs */
         $logs = [];
+        // Prefix "Stock Transfer" cuma benar kalau deduct ini memang lewat alur Stock Transfer.
+        // Caller lain yang juga bisa memicu bongkar satuan (mis. pembatalan produksi mode stok
+        // gudang, GitHub #134) wajib kirim $unpackNotePrefix miliknya sendiri, supaya Log Stock
+        // tidak salah menyebut transaksi gudang sebagai Stock Transfer.
+        $unpackPrefix = $unpackNotePrefix ?? 'Stock Transfer';
 
         $ensure = function (int $targetUnitId, float $need) use (
             &$ensure,
             &$virtual,
             &$logs,
             $relations,
-            $byUnit
+            $byUnit,
+            $unpackPrefix
         ): bool {
             if (($virtual[$targetUnitId] ?? 0) + 1e-9 >= $need) {
                 return true;
@@ -635,14 +642,14 @@ class ProductUnitStock
                 'unit_id' => $parentId,
                 'qty' => (float) $takeParent,
                 'category' => 2,
-                'note' => 'Stock Transfer - bongkar satuan',
+                'note' => $unpackPrefix . ' - bongkar satuan',
                 'saldo' => round((float) ($virtual[$parentId] ?? 0), 4),
             ];
             $logs[] = [
                 'unit_id' => $targetUnitId,
                 'qty' => (float) $got,
                 'category' => 1,
-                'note' => 'Stock Transfer - hasil bongkar',
+                'note' => $unpackPrefix . ' - hasil bongkar',
                 'saldo' => round((float) ($virtual[$targetUnitId] ?? 0), 4),
             ];
 

--- a/public/Custom_js/Backoffice/Production/Production.js
+++ b/public/Custom_js/Backoffice/Production/Production.js
@@ -137,6 +137,18 @@ var fixRecipeProductMeta = { relasi: [], pr_unit: [] };
 /** Stash when + Tambah gagal karena satuan resep; di-retry setelah Update Resep sukses. */
 var pendingProductionAdd = null;
 
+/**
+ * GitHub #134: "+Tambah" (checkProductionStock, async) dan "Tambah Produksi"
+ * (insertProduction) bisa saling balapan — user klik "Tambah Produksi" cepat-cepat
+ * sebelum checkProductionStock selesai mendorong baris produk yang baru diisi ke
+ * `items`. Kuncian silang: selama salah satu masih diproses, tombol yang lain
+ * dinonaktifkan (bukan LoadingButton — biar label/spinner milik tombol itu sendiri
+ * tidak ikut berubah).
+ */
+function setProductionOtherButtonBusy(otherSelector, busy) {
+    $(otherSelector).prop("disabled", busy);
+}
+
 function productionMainWarehouseName() {
     if (typeof getMainWarehouseName === "function") {
         var main = getMainWarehouseName();
@@ -1341,6 +1353,7 @@ function continueAddProduct(tempBom) {
     // daftar - dulu cek ini cuma jalan pas klik "Tambah Produksi" di akhir, jadi
     // user baru tahu stok kurang setelah menyusun seluruh daftar. GitHub #101.
     LoadingButton(".btn-add-product");
+    setProductionOtherButtonBusy(".btn-save", true);
     $.ajax({
         url: "/checkProductionStock",
         method: "post",
@@ -1353,6 +1366,7 @@ function continueAddProduct(tempBom) {
         },
         success: function (e) {
             resetAddProductButton();
+            setProductionOtherButtonBusy(".btn-save", false);
             if (!e || e.status != 1) {
                 handleProductionValidationError(e, temp.bom_id);
                 return;
@@ -1387,6 +1401,7 @@ function continueAddProduct(tempBom) {
         },
         error: function (a) {
             resetAddProductButton();
+            setProductionOtherButtonBusy(".btn-save", false);
             if (handlePermissionError(a)) return;
             console.log(a);
             notifikasi(
@@ -1406,6 +1421,10 @@ $(document).ready(function () {
 
 $(document).on("click", ".btnAdd", function () {
     resetProductionApprovalActions();
+    // Jaga-jaga: kalau modal sebelumnya ditutup di tengah salah satu ajax (add-product /
+    // save) sehingga kuncian silang setProductionOtherButtonBusy() sempat nyantol disabled.
+    setProductionOtherButtonBusy(".btn-save", false);
+    setProductionOtherButtonBusy(".btn-add-product", false);
     setProductionModalMode("form");
     mode = 1;
     modeBahan = 1;
@@ -2024,6 +2043,7 @@ $(document).on("click", ".btn-save", function () {
         param.revision_source_production_id = revisionSourceId;
     }
     LoadingButton($(this));
+    setProductionOtherButtonBusy(".btn-add-product", true);
     $.ajax({
         url: url,
         data: param,
@@ -2036,6 +2056,7 @@ $(document).on("click", ".btn-save", function () {
                 ".btn-save",
                 mode == 1 ? "Tambah Produksi" : "Update Produksi",
             );
+            setProductionOtherButtonBusy(".btn-add-product", false);
             if (!e || e.status != 1) {
                 handleProductionValidationError(
                     e,
@@ -2050,6 +2071,7 @@ $(document).on("click", ".btn-save", function () {
                 ".btn-save",
                 mode == 1 ? "Tambah Produksi" : "Update Produksi",
             );
+            setProductionOtherButtonBusy(".btn-add-product", false);
             if (handlePermissionError(a)) return;
             console.log(a);
         },
@@ -2828,6 +2850,11 @@ $(document).on("click", "#btn-delete-production", function () {
         },
         method: "post",
         success: function (e) {
+            // GitHub #134: modal harus ditutup dulu sebelum body-nya dikosongkan, baik sukses
+            // maupun gagal — dulu cuma ditutup di jalur sukses, jadi kalau gagal (mis. ST sudah
+            // dikirim) modal nyantol kebuka dengan body kosong walau notifikasi errornya sudah
+            // muncul dengan benar.
+            $(".modal").modal("hide");
             $("#modalDelete .modal-body").html(
                 `<p id="text-delete" style="font-size:10pt"></p>`,
             );
@@ -2841,7 +2868,6 @@ $(document).on("click", "#btn-delete-production", function () {
                 refreshProduction();
                 return false;
             }
-            $(".modal").modal("hide");
             afterInsert();
             notifikasi(
                 "success",

--- a/tests/Regression/ProductionModuleIssue134Test.php
+++ b/tests/Regression/ProductionModuleIssue134Test.php
@@ -1,0 +1,223 @@
+<?php
+
+namespace Tests\Regression;
+
+use App\Http\Controllers\ProductionController;
+use App\Models\Bom;
+use App\Models\Category;
+use App\Models\LogStock;
+use App\Models\Product;
+use App\Models\ProductRelation;
+use App\Models\ProductStock;
+use App\Models\ProductVariant;
+use App\Support\ProductUnitStock;
+use Illuminate\Http\Request;
+use Tests\Support\ActingAsStaff;
+use Tests\TestCase;
+
+/**
+ * GitHub #134 — "[Bug] [Fase 2] Produksi module", 4 separate bugs bundled in one issue. See
+ * cdocs/testing/KNOWN_ISSUES.md for the write-up of each. Bug #1 (cancel-production modal left
+ * open/empty on a rejected batal request) is a pure front-end fix in
+ * public/Custom_js/Backoffice/Production/Production.js — not covered here, nothing server-side
+ * to assert against.
+ */
+class ProductionModuleIssue134Test extends TestCase
+{
+    use ActingAsStaff;
+
+    private const WAREHOUSE_ID = 1;
+    private const DOS_UNIT_ID = 7;   // DOS
+    private const PCS_UNIT_ID = 9;   // Piece
+
+    /**
+     * Bug #2: reversing a production output that needs to "bongkar" (unpack) a bigger unit to
+     * satisfy the smaller unit being deducted used to hardcode "Stock Transfer - ..." log notes
+     * regardless of caller — even when the deduction has nothing to do with a Stock Transfer
+     * (e.g. cancelling a plain warehouse-mode production). ProductUnitStock::deductQty() now
+     * accepts an explicit $unpackNotePrefix so callers outside the ST flow can say what they
+     * actually are.
+     */
+    public function test_deduct_qty_unpack_notes_use_the_callers_own_context_not_stock_transfer(): void
+    {
+        $variant = $this->createLadderVariant();
+
+        // Stock exists at both levels, but Piece is at 0 — deducting Piece must bongkar 1 DOS.
+        $this->createProductStock($variant->product_variant_id, self::DOS_UNIT_ID, 5);
+        $this->createProductStock($variant->product_variant_id, self::PCS_UNIT_ID, 0);
+
+        $result = ProductUnitStock::deductQty(
+            self::WAREHOUSE_ID,
+            $variant->product_variant_id,
+            self::PCS_UNIT_ID,
+            10, // < 1 DOS (12 pcs) worth, forces an unpack
+            'PR-TEST-134',
+            'Pembatalan produksi PR-TEST-134',
+            false,
+            true,
+            'Pembatalan produksi'
+        );
+
+        $this->assertTrue($result['ok'], $result['message'] ?? 'expected ok');
+
+        $notes = LogStock::where('log_kode', 'PR-TEST-134')->pluck('log_notes')->all();
+        $this->assertNotEmpty($notes);
+        foreach ($notes as $note) {
+            $this->assertStringNotContainsString('Stock Transfer', $note);
+            $this->assertStringContainsString('Pembatalan produksi', $note);
+        }
+    }
+
+    /** Default behaviour (no $unpackNotePrefix passed) is unchanged for existing ST callers. */
+    public function test_deduct_qty_unpack_notes_default_to_stock_transfer_when_no_prefix_given(): void
+    {
+        $variant = $this->createLadderVariant();
+        $this->createProductStock($variant->product_variant_id, self::DOS_UNIT_ID, 5);
+        $this->createProductStock($variant->product_variant_id, self::PCS_UNIT_ID, 0);
+
+        $result = ProductUnitStock::deductQty(
+            self::WAREHOUSE_ID,
+            $variant->product_variant_id,
+            self::PCS_UNIT_ID,
+            10,
+            'ST-TEST-134',
+            'Stock Transfer ST-TEST-134 - keluar gudang asal'
+        );
+
+        $this->assertTrue($result['ok'], $result['message'] ?? 'expected ok');
+
+        $notes = LogStock::where('log_kode', 'ST-TEST-134')
+            ->where('log_notes', 'like', '%bongkar%')
+            ->pluck('log_notes')->all();
+        $this->assertNotEmpty($notes);
+        foreach ($notes as $note) {
+            $this->assertStringContainsString('Stock Transfer', $note);
+        }
+    }
+
+    /**
+     * Bug #3: Bom::searchForAutocomplete() used to always inject the BOM's own recipe unit
+     * (boms.unit_id) into the produksi unit dropdown even when Daftar Produk's configured
+     * product_unit list didn't include it (real-world case: UNICAL LITHIUM configured with only
+     * Pail in Daftar Produk, but its BOM recipe was set up in Piece — could then pick Piece in
+     * Produksi even though Daftar Produk only offers Pail).
+     */
+    public function test_bom_autocomplete_unit_choices_do_not_leak_the_recipe_unit_when_not_configured(): void
+    {
+        $category = new Category();
+        $category->category_name = 'Issue134 Bom Unit Category';
+        $category->status = 1;
+        $category->save();
+
+        $product = new Product();
+        $product->product_name = 'Issue134 Pail Only Product';
+        $product->category_id = $category->category_id;
+        $product->product_unit = json_encode([self::DOS_UNIT_ID]); // only "DOS" configured
+        $product->unit_id = self::DOS_UNIT_ID;
+        $product->status = 1;
+        $product->save();
+
+        $variant = new ProductVariant();
+        $variant->product_id = $product->product_id;
+        $variant->product_variant_name = 'Default';
+        $variant->product_variant_sku = 'ISSUE134-'.uniqid();
+        $variant->product_variant_price = 0;
+        $variant->status = 1;
+        $variant->save();
+
+        $bom = new Bom();
+        $bom->product_id = $variant->product_variant_id; // boms.product_id is actually a variant id
+        $bom->bom_qty = 1;
+        $bom->unit_id = self::PCS_UNIT_ID; // recipe written in Piece, NOT in product_unit
+        $bom->status = 1;
+        $bom->save();
+
+        $result = (new Bom())->searchForAutocomplete(['search' => 'Issue134 Pail Only Product'], 30);
+        $this->assertNotEmpty($result['data']);
+        $row = collect($result['data'])->first();
+
+        $unitIds = collect($row->pr_unit)->pluck('unit_id')->all();
+        $this->assertContains(self::DOS_UNIT_ID, $unitIds, 'the configured product_unit must stay selectable');
+        $this->assertNotContains(
+            self::PCS_UNIT_ID,
+            $unitIds,
+            'a BOM recipe unit that is not part of product_unit must not leak into the dropdown'
+        );
+    }
+
+    /**
+     * Bug #4: a race between "+Tambah" (checkProductionStock) and "Tambah Produksi"
+     * (insertProduction) could let an empty `detail` payload reach insertProduction()
+     * unblocked — validateProductionItems() finds nothing wrong in an empty array, so it used to
+     * create a Production header row with zero ProductionDetails ("transaksi kosongan" in the
+     * list). insertProduction() now rejects an empty/missing detail up front.
+     */
+    public function test_insert_production_rejects_empty_detail_instead_of_creating_an_empty_row(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $countBefore = \App\Models\Production::count();
+
+        $req = Request::create('/insertProduction', 'POST', [
+            'production_date' => now()->toDateString(),
+            'production_desc' => 'Issue134 empty detail race',
+            'detail' => json_encode([]),
+            'list_bahan' => json_encode([]),
+        ]);
+
+        $response = (new ProductionController())->insertProduction($req);
+        $payload = json_decode($response->getContent(), true);
+
+        $this->assertSame(0, $payload['status']);
+        $this->assertSame(\App\Models\Production::count(), $countBefore, 'no Production row should be created');
+    }
+
+    private function createLadderVariant(): ProductVariant
+    {
+        $category = new Category();
+        $category->category_name = 'Issue134 Ladder Category';
+        $category->status = 1;
+        $category->save();
+
+        $product = new Product();
+        $product->product_name = 'Issue134 Ladder Product';
+        $product->category_id = $category->category_id;
+        $product->product_unit = json_encode([self::DOS_UNIT_ID, self::PCS_UNIT_ID]);
+        $product->unit_id = self::DOS_UNIT_ID;
+        $product->status = 1;
+        $product->save();
+
+        $variant = new ProductVariant();
+        $variant->product_id = $product->product_id;
+        $variant->product_variant_name = 'Default';
+        $variant->product_variant_sku = 'ISSUE134-LADDER-'.uniqid();
+        $variant->product_variant_price = 0;
+        $variant->status = 1;
+        $variant->save();
+
+        $relation = new ProductRelation();
+        $relation->product_variant_id = $variant->product_variant_id;
+        $relation->pr_unit_id_1 = self::DOS_UNIT_ID;
+        $relation->pr_unit_value_1 = 1;
+        $relation->pr_unit_id_2 = self::PCS_UNIT_ID;
+        $relation->pr_unit_value_2 = 12; // 1 DOS = 12 Piece
+        $relation->status = 1;
+        $relation->save();
+
+        return $variant;
+    }
+
+    private function createProductStock(int $productVariantId, int $unitId, float $qty): ProductStock
+    {
+        $stock = new ProductStock();
+        $stock->product_id = ProductVariant::find($productVariantId)->product_id;
+        $stock->product_variant_id = $productVariantId;
+        $stock->unit_id = $unitId;
+        $stock->warehouse_id = self::WAREHOUSE_ID;
+        $stock->ps_stock = $qty;
+        $stock->status = 1;
+        $stock->save();
+
+        return $stock;
+    }
+}


### PR DESCRIPTION
## Ringkasan
Memperbaiki 4 bug yang digabung dalam #134:

1. **Modal batalkan produksi nyantol kosong** — handler sukses untuk request batal cuma menutup modal di jalur berhasil; kalau ditolak (mis. Stock Transfer hasilnya sudah kirim) errornya sudah benar muncul, tapi modal tetap kebuka dengan body kosong. Sekarang modal ditutup lebih dulu sebelum body-nya ditulis ulang, apa pun hasilnya.
2. **Pembatalan produksi mode stok gudang tercatat di Log Stock sebagai "Stock Transfer"** — `ProductUnitStock::deductQty()` selalu menulis catatan `"Stock Transfer - ..."` untuk setiap bongkar satuan, tidak peduli siapa pemanggilnya. Ditambahkan parameter opsional `$unpackNotePrefix` (default tidak berubah, jadi alur Stock Transfer asli tidak terpengaruh); pembatalan produksi sekarang mengirim `"Pembatalan produksi"`.
3. **Dropdown satuan di Produksi menawarkan satuan yang tidak dikonfigurasi di Daftar Produk** (contoh nyata: UNICAL LITHIUM cuma punya Pail di Daftar Produk, tapi Piece juga bisa dipilih) — `Bom::searchForAutocomplete()` selalu menyisipkan satuan resep BOM itu sendiri terlepas dari isi `product_unit`. Sekarang cuma dipakai sebagai fallback terakhir kalau `product_unit` kosong/rusak.
4. **Klik cepat "+Tambah" lalu "Tambah Produksi" bisa membuat transaksi produksi kosong ganda** — `checkProductionStock` berjalan async dan baru mendorong baris baru ke `items` di callback-nya, tapi tombol submit tidak dinonaktifkan selama itu. Kedua tombol sekarang saling mengunci (nonaktif) selama salah satu request masih berjalan, dan `insertProduction()` sekarang menolak `detail` yang kosong/hilang sejak awal (sebelumnya `validateProductionItems()` diam-diam meloloskan array kosong sehingga membuat baris header tanpa detail sama sekali).

## Pengujian
- `php vendor/bin/phpunit tests/Regression/ProductionModuleIssue134Test.php` — tes regresi baru untuk bug #2-#4 (bug #1 murni perbaikan front-end, tidak ada yang bisa diuji di sisi server).
- `php vendor/bin/phpunit --filter="Production|Bom"` — 60 tes lolos.
- Dikonfirmasi 1 kegagalan `StockTransferWorkflowTest` (403 permission check) yang sudah ada sebelumnya dan tidak berkaitan, tereproduksi identik di `fase2/main` sebelum perubahan branch ini.

Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)