### PR TITLE
fix(hutang): kembalikan tombol Print Hutang ke normal setelah download

### DIFF
--- a/public/Custom_js/Backoffice/Reports/Pay_Receive.js
+++ b/public/Custom_js/Backoffice/Reports/Pay_Receive.js
@@ -444,6 +444,7 @@
                     return;
                 }
                 window.open('/generateHutang?' + $.param(params), '_self');
+                resetHutangActionBtn($btn, BTN_PRINT_HTML);
             },
             error: function(e){
                 resetHutangActionBtn($btn, BTN_PRINT_HTML);


### PR DESCRIPTION
## Ringkasan
Fix untuk #138 — di halaman Hutang (`/payReceive`), tombol **Print Hutang** menampilkan spinner loading saat proses download PDF berjalan, tapi tidak pernah dikembalikan ke tampilan tombol normal setelah download selesai (karena `window.open(..., '_self')` tidak diikuti reset state tombol).

## Perubahan
- `public/Custom_js/Backoffice/Reports/Pay_Receive.js`: setelah `window.open('/generateHutang?...')` dipanggil pada handler `.btn-print`, tombol direset kembali ke state normal via `resetHutangActionBtn($btn, BTN_PRINT_HTML)`.

## Cara test
1. Buka halaman Hutang (`/payReceive`).
2. Isi filter tanggal Dari/Sampai, klik **Print Hutang**.
3. PDF terdownload, dan tombol kembali ke tampilan normal (bukan spinner permanen).

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)