### PR TITLE
feat(stock-transfer): bukti foto wajib saat Kirim (#140)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@
 /public/customer_product_returns/
 /public/customer_supply_returns/
 /public/customer_returns/
+/public/stock_transfers/
 /storage/*.key
 /storage/pail
 /vendor

--- a/app/Http/Controllers/StockTransferController.php
+++ b/app/Http/Controllers/StockTransferController.php
@@ -17,7 +17,9 @@ use App\Support\StockTransferApproval;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Session;
+use Illuminate\Support\Str;
 use Throwable;
 
 /**
@@ -554,6 +556,10 @@ class StockTransferController extends Controller
                 'source_id' => $row->source_id ? (int) $row->source_id : null,
                 'disposition' => $row->disposition,
                 'status' => $status,
+                // Bukti foto Kirim (GitHub #140): hanya relevan/ditampilkan saat status Kirim.
+                'ship_proof_url' => $status === 2 && $row->ship_proof_path
+                    ? asset($row->ship_proof_path)
+                    : null,
                 'selisih' => $status === 4 ? $selisihMeta['selisih'] : null,
                 'has_selisih' => $status === 4 ? $selisihMeta['has_selisih'] : false,
                 'selisih_lines' => $status === 4 ? $selisihMeta['lines'] : 0,
@@ -826,6 +832,10 @@ class StockTransferController extends Controller
             'source_id' => $header->source_id ? (int) $header->source_id : null,
             'disposition' => $header->disposition,
             'status' => $status,
+            // Bukti foto Kirim (GitHub #140): hanya relevan/ditampilkan saat status Kirim.
+            'ship_proof_url' => $status === 2 && $header->ship_proof_path
+                ? asset($header->ship_proof_path)
+                : null,
             'is_retail_request' => $isRetailRequest ? 1 : 0,
             'requires_approval' => $requiresApproval ? 1 : 0,
             'qc_required' => StockTransferApproval::qcRequiredAtWarehouse($fromWh) ? 1 : 0,
@@ -1525,10 +1535,29 @@ class StockTransferController extends Controller
             return response()->json(['status' => -1, 'message' => 'Kepala Operasional sudah approve']);
         }
 
+        // Approval terakhir (QC bila Ops tidak ada di gudang asal, atau Ops) langsung memotong
+        // stok & set status Kirim — bukti foto wajib diunggah di sini juga (GitHub #140).
+        $qcApprovedAfter = $type === 'qc' ? true : StockTransferApproval::isQcApproved($header);
+        $opsApprovedAfter = $type === 'ops' ? true : StockTransferApproval::isOpsApproved($header);
+        $willAutoShip = (! StockTransferApproval::qcRequiredAtWarehouse($fromWh) || $qcApprovedAfter)
+            && (! StockTransferApproval::opsRequiredAtWarehouse($fromWh) || $opsApprovedAfter);
+
+        $proofPath = null;
+        if ($willAutoShip) {
+            try {
+                $proofPath = $this->storeShipProof($req);
+            } catch (Throwable $e) {
+                return response()->json([
+                    'status' => -1,
+                    'message' => $e->getMessage() ?: 'Bukti foto wajib diunggah',
+                ]);
+            }
+        }
+
         $before = $this->snapshotTransfer($stId);
         $autoShipped = false;
         try {
-            DB::transaction(function () use ($stId, $type, $staffId, $fromWh, &$autoShipped) {
+            DB::transaction(function () use ($stId, $type, $staffId, $fromWh, $proofPath, &$autoShipped) {
                 $locked = StockTransfer::query()
                     ->where('st_id', $stId)
                     ->where('status', 1)
@@ -1594,15 +1623,22 @@ class StockTransferController extends Controller
                     $this->warehouseIsMain((int) $locked->to_warehouse_id)
                 );
                 if ($isRetail && StockTransferApproval::isFullyApproved($locked, $fromWh)) {
-                    $this->shipLockedTransfer($locked, $staffId);
+                    $this->shipLockedTransfer($locked, $staffId, $proofPath);
                     $autoShipped = true;
                 }
             });
         } catch (Throwable $e) {
+            $this->deleteShipProof($proofPath);
+
             return response()->json([
                 'status' => -1,
                 'message' => $e->getMessage() ?: 'Gagal approve stock transfer',
             ]);
+        }
+
+        // Prediksi auto-ship di atas tidak tercapai (mis. race lockForUpdate) → jangan simpan file yatim.
+        if ($proofPath && ! $autoShipped) {
+            $this->deleteShipProof($proofPath);
         }
 
         $after = $this->snapshotTransfer($stId);
@@ -1649,12 +1685,21 @@ class StockTransferController extends Controller
             return response()->json(['status' => -1, 'message' => $gate]);
         }
 
+        try {
+            $proofPath = $this->storeShipProof($req);
+        } catch (Throwable $e) {
+            return response()->json([
+                'status' => -1,
+                'message' => $e->getMessage() ?: 'Bukti foto wajib diunggah',
+            ]);
+        }
+
         $user = Session::get('user');
         $accBy = (int) ($user->staff_id ?? 0);
 
         $before = $this->snapshotTransfer((int) $header->st_id);
         try {
-            DB::transaction(function () use ($stId, $accBy) {
+            DB::transaction(function () use ($stId, $accBy, $proofPath) {
                 $lockedHeader = StockTransfer::query()
                     ->where('st_id', $stId)
                     ->where('status', 1)
@@ -1667,9 +1712,11 @@ class StockTransferController extends Controller
                 if ($gateLocked !== true) {
                     throw new \RuntimeException($gateLocked);
                 }
-                $this->shipLockedTransfer($lockedHeader, $accBy);
+                $this->shipLockedTransfer($lockedHeader, $accBy, $proofPath);
             });
         } catch (Throwable $e) {
+            $this->deleteShipProof($proofPath);
+
             return response()->json([
                 'status' => -1,
                 'message' => $e->getMessage() ?: 'Gagal kirim stock transfer',
@@ -1690,7 +1737,7 @@ class StockTransferController extends Controller
     /**
      * Potong stok + set status=2. Caller harus sudah lockForUpdate header status=1.
      */
-    protected function shipLockedTransfer(StockTransfer $lockedHeader, int $accBy): void
+    protected function shipLockedTransfer(StockTransfer $lockedHeader, int $accBy, ?string $shipProofPath = null): void
     {
         $stId = (int) $lockedHeader->st_id;
         $details = StockTransferDetail::query()
@@ -1751,7 +1798,69 @@ class StockTransferController extends Controller
         if ($accBy > 0) {
             $lockedHeader->acc_by = $accBy;
         }
+        if ($shipProofPath) {
+            $lockedHeader->ship_proof_path = $shipProofPath;
+        }
         $lockedHeader->save();
+    }
+
+    /**
+     * Simpan bukti foto pengiriman (GitHub #140) — wajib saat Pending → Kirim, baik lewat
+     * tombol Kirim manual maupun approval terakhir yang auto-Kirim (request eceran). Terima
+     * file multipart (`proof`) ATAU data URI base64 (`proof_base64`), sama seperti pola bukti
+     * foto pengembalian pelanggan (App\Support\CustomerReturnCreation::storeProofFromInput).
+     */
+    private function storeShipProof(Request $req): string
+    {
+        $file = $req->hasFile('proof') ? $req->file('proof') : null;
+        $base64 = $req->filled('proof_base64') ? (string) $req->input('proof_base64') : null;
+
+        $binary = null;
+        if ($file !== null) {
+            $binary = File::get($file->getRealPath());
+        } elseif ($base64) {
+            if (! preg_match('/^data:image\/(jpeg|jpg|png|webp);base64,([A-Za-z0-9+\/=\r\n]+)$/', $base64, $matches)) {
+                throw new \RuntimeException('Format bukti foto tidak valid');
+            }
+            $binary = base64_decode($matches[2], true);
+            if ($binary === false || strlen($binary) > 5 * 1024 * 1024) {
+                throw new \RuntimeException('Ukuran bukti foto maksimal 5 MB');
+            }
+        }
+        if ($binary === null) {
+            throw new \RuntimeException('Bukti foto wajib diunggah sebelum Kirim');
+        }
+
+        $imageInfo = @getimagesizefromstring($binary);
+        $mime = $imageInfo['mime'] ?? '';
+        $extensions = ['image/jpeg' => 'jpg', 'image/png' => 'png', 'image/webp' => 'webp'];
+        if (! isset($extensions[$mime])) {
+            throw new \RuntimeException('Isi file bukti bukan gambar JPEG, PNG, atau WebP yang valid');
+        }
+
+        $directory = public_path('stock_transfers');
+        File::ensureDirectoryExists($directory);
+        $filename = now()->format('YmdHis') . '_' . Str::random(24) . '.' . $extensions[$mime];
+        if (File::put($directory . DIRECTORY_SEPARATOR . $filename, $binary) === false) {
+            throw new \RuntimeException('Bukti foto gagal disimpan');
+        }
+
+        return 'stock_transfers/' . $filename;
+    }
+
+    /**
+     * Hapus berkas bukti foto pengiriman — dipanggil saat aksi Kirim/approve gagal setelah file
+     * tersimpan, supaya tidak ada berkas yatim. Hanya path folder fitur ini yang boleh dihapus.
+     */
+    private function deleteShipProof(?string $path): void
+    {
+        if (! $path || ! str_starts_with($path, 'stock_transfers/')) {
+            return;
+        }
+        $full = public_path($path);
+        if (File::exists($full)) {
+            File::delete($full);
+        }
     }
 
     public function accStockTransfer(Request $req)
@@ -2981,6 +3090,7 @@ class StockTransferController extends Controller
                 'disposition' => $header->disposition,
                 'status' => (int) $header->status,
                 'acc_by' => $header->acc_by ? (int) $header->acc_by : null,
+                'ship_proof_path' => $header->ship_proof_path,
                 'qc_approved_by' => $header->qc_approved_by ? (int) $header->qc_approved_by : null,
                 'qc_approved_at' => $header->qc_approved_at ? (string) $header->qc_approved_at : null,
                 'ops_approved_by' => $header->ops_approved_by ? (int) $header->ops_approved_by : null,

--- a/app/Models/StockTransfer.php
+++ b/app/Models/StockTransfer.php
@@ -30,6 +30,7 @@ class StockTransfer extends Model
         'status',
         'created_by',
         'acc_by',
+        'ship_proof_path',
         'qc_approved_by',
         'qc_approved_at',
         'ops_approved_by',

--- a/database/migrations/2026_09_04_003000_add_ship_proof_path_to_stock_transfers_table.php
+++ b/database/migrations/2026_09_04_003000_add_ship_proof_path_to_stock_transfers_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Bukti foto pengiriman (GitHub #140) — wajib diisi saat Kirim (status=2),
+     * disimpan di public/stock_transfers/.
+     */
+    public function up(): void
+    {
+        if (! Schema::hasColumn('stock_transfers', 'ship_proof_path')) {
+            Schema::table('stock_transfers', function (Blueprint $table) {
+                $table->string('ship_proof_path', 255)->nullable()->after('acc_by');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        if (Schema::hasColumn('stock_transfers', 'ship_proof_path')) {
+            Schema::table('stock_transfers', function (Blueprint $table) {
+                $table->dropColumn('ship_proof_path');
+            });
+        }
+    }
+};

--- a/public/Custom_js/Backoffice/Inventory/Stock_Transfer.js
+++ b/public/Custom_js/Backoffice/Inventory/Stock_Transfer.js
@@ -19,6 +19,10 @@ var transferQcRequired = false;
 var transferOpsRequired = false;
 var transferQcApproved = false;
 var transferOpsApproved = false;
+var transferPhotoProofRequired = false; // bukti foto wajib (GitHub #140) di #modalKonfirmasi saat ini
+var transferKeepPhotoProofOnClose = false; // true = #modalKonfirmasi ditutup sementara untuk buka kamera
+var transferThenShipProofBase64 = ""; // bukti foto utk kombo Simpan+Kirim (edit mode, tanpa #modalKonfirmasi)
+var transferPendingThenShip = false; // true = habis ambil foto, lanjutkan otomatis Simpan+Kirim
 var transferCreateRequestMode = false; // eceran create: label request / penerima = aktif
 var transferIsRetailRequest = false; // create ATAU edit retail_request
 var transferScanMode = false;
@@ -99,7 +103,7 @@ function restoreTransferOverlayIfNeeded() {
 }
 
 /** Konfirmasi di atas detail ST / accept: hide parent → show konfirmasi; cancel → buka lagi parent. */
-function showTransferModalKonfirmasi(text, buttonId, dataId, parentSelector, danger) {
+function showTransferModalKonfirmasi(text, buttonId, dataId, parentSelector, danger, requirePhoto) {
     transferOverlayState.done = false;
     var wasOpen = beginTransferOverlay(parentSelector || "#add_stock_transfer");
     function openConfirm() {
@@ -111,6 +115,11 @@ function showTransferModalKonfirmasi(text, buttonId, dataId, parentSelector, dan
             $("#modalKonfirmasi #" + buttonId).attr("data-id", dataId);
             $("#modalKonfirmasi").attr("data-transfer-id", dataId);
         }
+        if (requirePhoto) {
+            showKonfirmasiPhotoProof();
+        } else {
+            hideKonfirmasiPhotoProof();
+        }
     }
     if (wasOpen) {
         $(transferOverlayState.parent).one("hidden.bs.modal", openConfirm);
@@ -118,6 +127,71 @@ function showTransferModalKonfirmasi(text, buttonId, dataId, parentSelector, dan
         openConfirm();
     }
 }
+
+/**
+ * Bukti foto wajib saat Pending → Kirim (GitHub #140) — manual (tombol Kirim) maupun
+ * auto-Kirim (approval terakhir request eceran). Field disuntik ke #modalKonfirmasi
+ * yang dipakai bersama banyak halaman lain, jadi selalu di-reset & disembunyikan lagi
+ * setelah dipakai supaya tidak "nempel" ke konfirmasi lain yang tidak terkait.
+ */
+function resetKonfirmasiPhotoProof() {
+    $("#konfirmasi_photo_proof_base64").val("");
+    $("#konfirmasi-photo-preview").addClass("d-none").attr("src", "");
+    $("#konfirmasi-photo-proof-error").hide();
+}
+function showKonfirmasiPhotoProof() {
+    transferPhotoProofRequired = true;
+    resetKonfirmasiPhotoProof();
+    $("#konfirmasi-photo-proof").removeClass("d-none");
+}
+function hideKonfirmasiPhotoProof() {
+    transferPhotoProofRequired = false;
+    $("#konfirmasi-photo-proof").addClass("d-none");
+    resetKonfirmasiPhotoProof();
+}
+function getKonfirmasiPhotoProof() {
+    return $("#konfirmasi_photo_proof_base64").val() || "";
+}
+function assertKonfirmasiPhotoProof() {
+    if (!transferPhotoProofRequired) return true;
+    if (getKonfirmasiPhotoProof()) return true;
+    $("#konfirmasi-photo-proof-error").show();
+    if (typeof toastr !== "undefined") {
+        toastr.error("", "Bukti foto wajib diunggah sebelum Kirim");
+    }
+    return false;
+}
+
+/** Request eceran: apakah approval `type` ini yang melengkapi approval → auto-Kirim. */
+function willTransferAutoShip(type) {
+    var qcOk = !transferQcRequired || type === "qc" || transferQcApproved;
+    var opsOk = !transferOpsRequired || type === "ops" || transferOpsApproved;
+    return qcOk && opsOk;
+}
+
+$(document).on("click", "#btn-konfirmasi-photo-proof", function () {
+    modeCamera = 5;
+    rotationAngle = 0;
+    camRotation = 0;
+    photoData = "";
+    inputFile = "#konfirmasi_photo_proof_base64";
+    cameraReturnModal = "#modalKonfirmasi";
+    $("#video").removeClass("rot90 rot180 rot270");
+    $("#preview-box").hide();
+    $("#camera").show();
+    startCamera();
+    transferKeepPhotoProofOnClose = true;
+    $("#modalKonfirmasi").modal("hide");
+    $("#modalPhoto").modal("show");
+});
+
+$(document).on("shown.bs.modal", "#modalKonfirmasi", function () {
+    var val = getKonfirmasiPhotoProof();
+    if (val) {
+        $("#konfirmasi-photo-preview").attr("src", val).removeClass("d-none");
+        $("#konfirmasi-photo-proof-error").hide();
+    }
+});
 
 function showProductionRejectOverTransfer(id) {
     transferOverlayState.done = false;
@@ -137,6 +211,11 @@ function showProductionRejectOverTransfer(id) {
 $(document).on("hidden.bs.modal", "#modalKonfirmasi", function () {
     $("#modalKonfirmasi").removeAttr("data-transfer-id");
     $("#modalKonfirmasi .btn-konfirmasi").removeAttr("data-id");
+    if (transferKeepPhotoProofOnClose) {
+        transferKeepPhotoProofOnClose = false;
+    } else {
+        hideKonfirmasiPhotoProof();
+    }
     restoreTransferOverlayIfNeeded();
 });
 
@@ -535,7 +614,13 @@ function inisialisasi() {
                         return '<span class="badge" style="background-color: #fff7ed; color: #ea580c; border: 1px solid #ffedd5; padding: 6px 12px; border-radius: 20px; font-weight: 600; font-size: 12px; letter-spacing: 0.3px;"><i class="fe fe-clock me-1"></i> Pending</span>';
                     }
                     if (data == 2) {
-                        return '<span class="badge" style="background-color: #eff6ff; color: #1d4ed8; border: 1px solid #bfdbfe; padding: 6px 12px; border-radius: 20px; font-weight: 600; font-size: 12px; letter-spacing: 0.3px;"><i class="fe fe-truck me-1"></i> Kirim</span>';
+                        // Bukti foto pengiriman (GitHub #140) — hanya muncul saat status Kirim.
+                        var proofBtn = row && row.ship_proof_url
+                            ? ' <a href="javascript:void(0);" class="btnViewShipProof" data-url="' +
+                              row.ship_proof_url +
+                              '" title="Lihat bukti foto pengiriman"><i class="fe fe-camera" style="color:#1d4ed8;vertical-align:middle;"></i></a>'
+                            : "";
+                        return '<span class="badge" style="background-color: #eff6ff; color: #1d4ed8; border: 1px solid #bfdbfe; padding: 6px 12px; border-radius: 20px; font-weight: 600; font-size: 12px; letter-spacing: 0.3px;"><i class="fe fe-truck me-1"></i> Kirim</span>' + proofBtn;
                     }
                     if (data == 3) {
                         return '<span class="badge" style="background-color: #fee2e2; color: #991b1b; border: 1px solid #fecaca; padding: 6px 12px; border-radius: 20px; font-weight: 600; font-size: 12px; letter-spacing: 0.3px;"><i class="fe fe-x-circle me-1"></i> Cancel</span>';
@@ -2348,6 +2433,10 @@ function resetTransferForm() {
     transferCreateRequestMode = false;
     transferIsRetailRequest = false;
     transferScanMode = false;
+    transferThenShipProofBase64 = "";
+    transferPendingThenShip = false;
+    $("#st-ship-proof-slot").addClass("d-none");
+    $("#st-ship-proof-thumb").attr("src", "");
     clearTransferStockLoads();
     retailUnitValidationPending = 0;
     retailValidationRun++;
@@ -3373,10 +3462,13 @@ $(document).on("click", ".btn-save-transfer", function () {
             method: "post",
             data: {
                 id: stId,
+                proof_base64: transferThenShipProofBase64,
                 _token: token || $('meta[name="csrf-token"]').attr("content"),
             },
             success: function (shipRes) {
                 resetSaveBtn();
+                transferThenShipProofBase64 = "";
+                $("#transfer_then_ship_proof_base64").val("");
                 if (!shipRes || shipRes.status != 1) {
                     if (typeof toastr !== "undefined") {
                         toastr.error("", (shipRes && shipRes.message) || "Gagal ACC kirim");
@@ -3462,12 +3554,42 @@ $(document).on("click", ".btn-acc-transfer", function () {
         showTransferModalKonfirmasi(
             "Kirim transfer ini? Stok gudang asal akan dipotong dan status menjadi Kirim.",
             "btn-ship-stock-transfer",
-            id
+            id,
+            null,
+            false,
+            true
         );
+        return;
+    }
+    // Simpan + Kirim langsung (edit mode, tanpa konfirmasi teks) — bukti foto tetap wajib
+    // (GitHub #140): ambil dulu lewat kamera, baru lanjutkan Simpan+Kirim otomatis.
+    if (!transferThenShipProofBase64) {
+        modeCamera = 5;
+        rotationAngle = 0;
+        camRotation = 0;
+        photoData = "";
+        inputFile = "#transfer_then_ship_proof_base64";
+        cameraReturnModal = "#add_stock_transfer";
+        $("#video").removeClass("rot90 rot180 rot270");
+        $("#preview-box").hide();
+        $("#camera").show();
+        startCamera();
+        transferPendingThenShip = true;
+        $("#add_stock_transfer").modal("hide");
+        $("#modalPhoto").modal("show");
         return;
     }
     $("#add_stock_transfer").data("then-ship", true);
     $(".btn-save-transfer").trigger("click");
+});
+
+$(document).on("shown.bs.modal", "#add_stock_transfer", function () {
+    transferThenShipProofBase64 = $("#transfer_then_ship_proof_base64").val() || "";
+    if (transferPendingThenShip && transferThenShipProofBase64) {
+        transferPendingThenShip = false;
+        $("#add_stock_transfer").data("then-ship", true);
+        $(".btn-save-transfer").trigger("click");
+    }
 });
 
 function approveStockTransfer(type) {
@@ -3482,6 +3604,7 @@ function approveStockTransfer(type) {
     var label = type === "qc" ? "QC" : "Kepala Operasional";
     var $confirmBtn = $("#modalKonfirmasi #btn-approve-" + type + "-stock-transfer");
     if ($confirmBtn.data("busy")) return;
+    if (!assertKonfirmasiPhotoProof()) return;
 
     // UX pre-check stok (QC22); gate wajib tetap di BE approveStockTransfer + shipLockedTransfer.
     function runApprove() {
@@ -3493,6 +3616,7 @@ function approveStockTransfer(type) {
             data: {
                 id: id,
                 type: type,
+                proof_base64: getKonfirmasiPhotoProof(),
                 _token: token || $('meta[name="csrf-token"]').attr("content"),
             },
             success: function (res) {
@@ -3575,7 +3699,10 @@ $(document).on("click", ".btn-approve-qc-transfer", function () {
     showTransferModalKonfirmasi(
         "Setujui request ini (QC)? Setelah disetujui, menunggu approval Kepala Operasional.",
         "btn-approve-qc-stock-transfer",
-        id
+        id,
+        null,
+        false,
+        willTransferAutoShip("qc")
     );
 });
 $(document).on("click", ".btn-approve-ops-transfer", function () {
@@ -3587,7 +3714,10 @@ $(document).on("click", ".btn-approve-ops-transfer", function () {
     showTransferModalKonfirmasi(
         "Setujui request ini (Kepala Operasional)? Stok gudang asal akan dipotong dan status menjadi Kirim — gudang eceran dapat menerima.",
         "btn-approve-ops-stock-transfer",
-        id
+        id,
+        null,
+        false,
+        willTransferAutoShip("ops")
     );
 });
 
@@ -3712,6 +3842,16 @@ function loadTransferDetailForEdit(id) {
                 $("#transfer_date").data("DateTimePicker").date(res.transfer_date);
             }
             $("#transfer_note").val(res.note || "");
+            // Bukti foto pengiriman (GitHub #140) — hanya muncul saat status Kirim.
+            if (res.ship_proof_url) {
+                $("#st-ship-proof-thumb").attr("src", res.ship_proof_url);
+                $("#st-ship-proof-link").attr("href", res.ship_proof_url);
+                $("#st-ship-proof-slot").removeClass("d-none");
+            } else {
+                $("#st-ship-proof-slot").addClass("d-none");
+                $("#st-ship-proof-thumb").attr("src", "");
+                $("#st-ship-proof-link").attr("href", "javascript:void(0);");
+            }
             setDefaultSender();
             fillSelectOption($("#transfer_from_warehouse_id"), res.from_warehouse_id, res.from_warehouse_name);
             fillSelectOption($("#transfer_to_warehouse_id"), res.to_warehouse_id, res.to_warehouse_name);
@@ -4022,6 +4162,12 @@ $(document).on("click", "#btn-delete-stock-transfer", function () {
     });
 });
 
+$(document).on("click", ".btnViewShipProof", function (e) {
+    e.stopPropagation();
+    var url = $(this).attr("data-url");
+    if (url) window.open(url, "_blank");
+});
+
 $(document).on("click", ".btnShipTransfer", function () {
     var id = $(this).attr("data-id");
     if (!id) return;
@@ -4044,6 +4190,7 @@ $(document).on("click", ".btnShipTransfer", function () {
         "btn-ship-stock-transfer"
     );
     $("#modalKonfirmasi #btn-ship-stock-transfer").attr("data-id", id);
+    showKonfirmasiPhotoProof();
 });
 
 $(document).on("click", "#btn-ship-stock-transfer", function () {
@@ -4056,6 +4203,7 @@ $(document).on("click", "#btn-ship-stock-transfer", function () {
         }
         return;
     }
+    if (!assertKonfirmasiPhotoProof()) return;
     $confirmBtn.data("busy", true);
     LoadingButton($confirmBtn);
     $.ajax({
@@ -4063,6 +4211,7 @@ $(document).on("click", "#btn-ship-stock-transfer", function () {
         method: "post",
         data: {
             id: id,
+            proof_base64: getKonfirmasiPhotoProof(),
             _token: token || $('meta[name="csrf-token"]').attr("content"),
         },
         success: function (res) {
@@ -4304,6 +4453,8 @@ $(document).on("click", ".btnAccept", function () {
     $("#accept_stock_transfer input, #accept_stock_transfer textarea").val("");
     $("#accept_stock_transfer select").val(null).trigger("change");
     $("#lbl_accept_sender, #lbl_accept_from, #lbl_accept_date, #lbl_accept_to, #lbl_accept_ship_note").text("-");
+    $("#accept-ship-proof-slot").hide();
+    $("#accept-ship-proof-thumb").attr("src", "");
     renderAcceptItems([]);
     // Jangan init autocomplete — penerima dikunci ke user login
     var $recv = $("#accept_receiver_id");
@@ -4336,6 +4487,14 @@ $(document).on("click", ".btnAccept", function () {
             $("#lbl_accept_date").text(res.transfer_date || "-");
             $("#lbl_accept_to").text(res.to_warehouse_name || "-");
             $("#lbl_accept_ship_note").text(res.note || "-");
+            // Bukti foto pengiriman (GitHub #140) — muncul hanya saat status Kirim (jaminan di atas).
+            if (res.ship_proof_url) {
+                $("#accept-ship-proof-thumb").attr("src", res.ship_proof_url);
+                $("#accept-ship-proof-link").attr("href", res.ship_proof_url);
+                $("#accept-ship-proof-slot").show();
+            } else {
+                $("#accept-ship-proof-slot").hide();
+            }
             $("#accept_note").val(res.accept_note || "");
             // Penerima ACC = user login, dikunci (tidak bisa diganti)
             var $recv = $("#accept_receiver_id");

--- a/resources/views/components/modals/shared/modal-konfirmasi.blade.php
+++ b/resources/views/components/modals/shared/modal-konfirmasi.blade.php
@@ -10,6 +10,25 @@
       </div>
       <div class="modal-body p-4">
         <p id="text-konfirmasi" class="mb-0"></p>
+        {{-- Bukti foto (mis. wajib saat Kirim Stock Transfer, GitHub #140) — disembunyikan
+             default, ditampilkan lewat JS (showKonfirmasiPhotoProof) hanya untuk aksi yang butuh. --}}
+        <div id="konfirmasi-photo-proof" class="mt-3 d-none">
+          <label class="form-label fw-semibold text-muted mb-2"
+                 style="font-size:11px;text-transform:uppercase;letter-spacing:.4px;">
+            Bukti Foto<span class="text-danger ms-1">*</span>
+          </label>
+          <div class="d-flex align-items-center gap-2">
+            <img id="konfirmasi-photo-preview" src="" alt="Preview bukti foto" class="d-none"
+                 style="width:56px;height:56px;object-fit:cover;border-radius:8px;border:1px solid #e2e8f0;">
+            <button type="button" class="btn btn-outline-primary" id="btn-konfirmasi-photo-proof">
+              <i class="fe fe-camera me-1"></i>Ambil/Upload Foto
+            </button>
+          </div>
+          <div id="konfirmasi-photo-proof-error" class="text-danger mt-1" style="font-size:11px;display:none;">
+            Bukti foto wajib diunggah
+          </div>
+          <input type="hidden" id="konfirmasi_photo_proof_base64">
+        </div>
       </div>
       <div class="modal-footer pg-modal-footer">
         <button type="button" class="btn pg-btn-cancel btn-cancel">Batal</button>

--- a/resources/views/components/modals/stock-transfer/accept-stock-transfer.blade.php
+++ b/resources/views/components/modals/stock-transfer/accept-stock-transfer.blade.php
@@ -59,6 +59,16 @@
                         class="fe fe-file-text me-1 text-primary"></i>Catatan Pengiriman</div>
                     <div class="fw-bold text-dark mt-0.5" style="font-size:12.5px;" id="lbl_accept_ship_note">-</div>
                   </div>
+                  {{-- Bukti foto pengiriman (GitHub #140) --}}
+                  <div class="col-6" id="accept-ship-proof-slot" style="display:none;">
+                    <div class="text-muted"
+                      style="font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.3px;color:#475569;"><i
+                        class="fe fe-camera me-1 text-primary"></i>Bukti Foto</div>
+                    <a href="javascript:void(0);" id="accept-ship-proof-link" target="_blank" rel="noopener">
+                      <img id="accept-ship-proof-thumb" src="" alt="Bukti foto pengiriman"
+                        style="width:48px;height:48px;object-fit:cover;border-radius:8px;border:1px solid #cbd5e1;margin-top:2px;">
+                    </a>
+                  </div>
                 </div>
               </div>
             </div>

--- a/resources/views/components/modals/stock-transfer/add-stock-transfer.blade.php
+++ b/resources/views/components/modals/stock-transfer/add-stock-transfer.blade.php
@@ -115,6 +115,18 @@
                         </select>
                       </div>
                       <div class="col-12 d-none" id="st-date-slot-tujuan"></div>
+                      {{-- Bukti foto pengiriman (GitHub #140) — muncul hanya saat status Kirim --}}
+                      <div class="col-12 d-none" id="st-ship-proof-slot">
+                        <label class="text-muted mb-0.5"
+                          style="font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.3px;color:#475569;"><i
+                            class="fe fe-camera me-1 text-primary"></i>Bukti Foto Kirim</label>
+                        <div>
+                          <a href="javascript:void(0);" id="st-ship-proof-link" target="_blank" rel="noopener">
+                            <img id="st-ship-proof-thumb" src="" alt="Bukti foto pengiriman"
+                              style="width:64px;height:64px;object-fit:cover;border-radius:8px;border:1px solid #cbd5e1;">
+                          </a>
+                        </div>
+                      </div>
                       <div class="col-12" id="st-note-slot-tujuan">
                         <div id="st-note-block" class="d-flex flex-column">
                           <label class="text-muted mb-0.5"
@@ -263,6 +275,8 @@
           <button type="button" class="btn pg-btn-accept btn-approve-ops-transfer d-none"><i class="fe fe-check-circle me-1"></i>Setujui Ops</button>
           <button type="button" class="btn pg-btn-accept btn-acc-transfer d-none"><i class="fe fe-truck me-1"></i>Kirim</button>
           <button type="button" class="btn pg-btn-save btn-save-transfer"><i class="fe fe-save me-1"></i>Simpan</button>
+          {{-- Bukti foto Kirim (GitHub #140) untuk kombo Simpan+Kirim (edit mode, tanpa #modalKonfirmasi) --}}
+          <input type="hidden" id="transfer_then_ship_proof_base64">
         </div>
       </form>
     </div>

--- a/tests/Regression/StockTransferApprovalPermissionTest.php
+++ b/tests/Regression/StockTransferApprovalPermissionTest.php
@@ -26,6 +26,9 @@ class StockTransferApprovalPermissionTest extends TestCase
 {
     use ActingAsStaff;
 
+    /** Bukti foto wajib saat approval yang auto-Kirim (GitHub #140). */
+    private const PROOF_BASE64 = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=';
+
 
     /** @var int */
     private int $pieceUnitId = 0;
@@ -196,7 +199,11 @@ class StockTransferApprovalPermissionTest extends TestCase
             ->assertJsonPath('can_approve_qc', false)
             ->assertJsonPath('can_approve_ops', true);
 
-        $this->post('/approveStockTransfer', ['id' => $header->st_id, 'type' => 'ops'])
+        $this->post('/approveStockTransfer', [
+            'id' => $header->st_id,
+            'type' => 'ops',
+            'proof_base64' => self::PROOF_BASE64,
+        ])
             ->assertOk()
             ->assertJson(['status' => 1]);
 

--- a/tests/Workflow/StockTransferWorkflowTest.php
+++ b/tests/Workflow/StockTransferWorkflowTest.php
@@ -33,6 +33,8 @@ class StockTransferWorkflowTest extends TestCase
     private const RETAIL_WAREHOUSE_ID = 2;
     private const PIECE_UNIT_ID = 9;
     private const DOS_UNIT_ID = 7;
+    /** Bukti foto wajib saat Kirim (GitHub #140). */
+    private const PROOF_BASE64 = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=';
 
     /** Second main warehouse — needed for item #4's "utama -> utama" scenario. */
     private function createSecondMainWarehouse(): Warehouse
@@ -223,7 +225,7 @@ class StockTransferWorkflowTest extends TestCase
 
         $this->withActiveWarehouse(self::MAIN_WAREHOUSE_ID);
 
-        $this->post('/shipStockTransfer', ['id' => $header->st_id])
+        $this->post('/shipStockTransfer', ['id' => $header->st_id, 'proof_base64' => self::PROOF_BASE64])
             ->assertStatus(200)
             ->assertJson(['status' => 1]);
 
@@ -275,7 +277,7 @@ class StockTransferWorkflowTest extends TestCase
 
         $this->withActiveWarehouse(self::MAIN_WAREHOUSE_ID);
 
-        $this->post('/shipStockTransfer', ['id' => $header->st_id])
+        $this->post('/shipStockTransfer', ['id' => $header->st_id, 'proof_base64' => self::PROOF_BASE64])
             ->assertStatus(200)
             ->assertJson(['status' => 1]);
 
@@ -338,7 +340,7 @@ class StockTransferWorkflowTest extends TestCase
 
         $this->withActiveWarehouse(self::MAIN_WAREHOUSE_ID);
 
-        $this->post('/shipStockTransfer', ['id' => $header->st_id])
+        $this->post('/shipStockTransfer', ['id' => $header->st_id, 'proof_base64' => self::PROOF_BASE64])
             ->assertStatus(200)
             ->assertJson(['status' => -1]);
 
@@ -377,7 +379,7 @@ class StockTransferWorkflowTest extends TestCase
         );
 
         $this->withActiveWarehouse(self::MAIN_WAREHOUSE_ID);
-        $this->post('/shipStockTransfer', ['id' => $header->st_id])->assertJson(['status' => 1]);
+        $this->post('/shipStockTransfer', ['id' => $header->st_id, 'proof_base64' => self::PROOF_BASE64])->assertJson(['status' => 1]);
 
         $this->withActiveWarehouse($retailWarehouseId);
         $this->post('/accStockTransfer', ['id' => $header->st_id])
@@ -437,7 +439,7 @@ class StockTransferWorkflowTest extends TestCase
         );
 
         $this->withActiveWarehouse(self::MAIN_WAREHOUSE_ID);
-        $this->post('/shipStockTransfer', ['id' => $header->st_id])->assertJson(['status' => 1]);
+        $this->post('/shipStockTransfer', ['id' => $header->st_id, 'proof_base64' => self::PROOF_BASE64])->assertJson(['status' => 1]);
 
         $sourcePieceStock->refresh();
         $this->assertSame(0.0, (float) $sourcePieceStock->ps_stock, 'all 50 Piece left the source warehouse');


### PR DESCRIPTION
## Ringkasan
Implementasi GitHub #140: bukti foto wajib diunggah saat Stock Transfer dikirim (status **Kirim**), baik lewat tombol Kirim manual maupun approval terakhir yang auto-Kirim (request eceran → Kepala Operasional/QC approve terakhir).

## Perubahan
- **Migration**: kolom baru `stock_transfers.ship_proof_path`.
- **Backend** (`StockTransferController`):
  - `shipStockTransfer` & `approveStockTransfer` (saat approval ini akan melengkapi approval dan memicu auto-Kirim) sekarang wajib menerima bukti foto — file multipart `proof` atau data URI `proof_base64`, disimpan ke `public/stock_transfers/` mengikuti pola yang sudah ada di `CustomerReturnCreation::storeProofFromInput` (Retur Pelanggan).
  - File dihapus lagi kalau transaksi ship/approve gagal setelah tersimpan (tidak ada berkas yatim).
  - `getStockTransfer` / `getStockTransferDetail` mengembalikan `ship_proof_url` **hanya saat status Kirim** (sesuai teks issue).
- **Frontend**:
  - `#modalKonfirmasi` (shared, dipakai banyak halaman) mendapat blok bukti-foto opsional yang disuntik lewat JS hanya untuk konfirmasi Kirim/approve yang relevan — pakai kamera modal (`#modalPhoto`) yang sudah ada di seluruh app, tidak menambah komponen baru.
  - Kombo "Simpan + Kirim" langsung di mode edit (tanpa `#modalKonfirmasi`) diarahkan ke kamera dulu sebelum submit.
  - Badge status "Kirim" di tabel list, detail modal, dan modal Terima menampilkan ikon/thumbnail bukti foto (klik untuk buka ukuran penuh).

## Testing
- `StockTransferWorkflowTest` & `StockTransferApprovalPermissionTest` diperbarui menyertakan `proof_base64` pada setiap panggilan ship/approve yang diharapkan sukses.
- Full `Workflow` + `Regression` + `Health` suites dijalankan — hanya kegagalan pra-existing yang tidak terkait (dikonfirmasi identik di baseline `fase2/main` sebelum perubahan ini).

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)