### PR TITLE
fix(produksi): jangan auto-focus search Select2 di tablet, hindari salah pilih produk

### DIFF
--- a/resources/views/layout/partials/footer-scripts.blade.php
+++ b/resources/views/layout/partials/footer-scripts.blade.php
@@ -967,37 +967,9 @@ https://cdn.jsdelivr.net/npm/toastr@2.1.4/toastr.min.js
     return ('ontouchstart' in window) || (navigator.maxTouchPoints > 0);
   }
 
-  /**
-   * Select2 (`AttachBody._positionDropdown`) menghitung `left` dropdown dari
-   * offset field pemicu di dokumen, tapi gak pernah di-clamp ke lebar
-   * viewport — dan tetap dipakai ulang tiap `window.resize` (termasuk yang
-   * dipicu keyboard on-screen). Kalau hasil hitungannya kegeser ke kanan,
-   * gak ada yang narik balik dropdown itu ke dalam layar. Karena
-   * dropdown-nya nempel di `<body>` (dropdownParent: body, bukan modal),
-   * ini bikin lebar area scroll seluruh halaman ikut membesar -> halaman
-   * jadi bisa di-slide horizontal & tampilannya kacau (GitHub #142, tablet).
-   * Clamp manual di sini pakai getBoundingClientRect (relatif viewport, gak
-   * kepengaruh miscalc internal-nya) supaya dropdown selalu balik masuk
-   * layar berapa pun offset yang dihitung Select2.
-   */
-  function pgClampSelect2DropdownPosition() {
-    var $dropdown = $('.select2-container--open').last().find('.select2-dropdown');
-    if (!$dropdown.length) return;
-    var el = $dropdown[0];
-    var margin = 8;
-    var vw = document.documentElement.clientWidth || window.innerWidth;
-    var rect = el.getBoundingClientRect();
-    var currentLeft = parseFloat($dropdown.css('left')) || 0;
-    if (rect.right > vw - margin) {
-      $dropdown.css('left', (currentLeft - (rect.right - (vw - margin))) + 'px');
-    } else if (rect.left < margin) {
-      $dropdown.css('left', (currentLeft + (margin - rect.left)) + 'px');
-    }
-  }
-
   /** Fokus kolom search Select2 (modal + dropdownParent body / mobile). */
   function attachSelect2SearchOpenFix($el) {
-    $el.off('select2:open.pgSearchFix select2:close.pgSearchFix');
+    $el.off('select2:open.pgSearchFix');
     $el.on('select2:open.pgSearchFix', function() {
       setTimeout(function() {
         var $open = $('.select2-container--open').last();
@@ -1016,17 +988,7 @@ https://cdn.jsdelivr.net/npm/toastr@2.1.4/toastr.min.js
             $search.trigger('focus');
           }
         }
-        pgClampSelect2DropdownPosition();
       }, 0);
-      // Keyboard on-screen buka/tutup memicu window resize -> Select2 hitung
-      // ulang posisi (tanpa clamp) tiap kali. Clamp ulang di sini juga.
-      $(window).off('resize.pgSelect2Clamp orientationchange.pgSelect2Clamp')
-        .on('resize.pgSelect2Clamp orientationchange.pgSelect2Clamp', function() {
-          setTimeout(pgClampSelect2DropdownPosition, 50);
-        });
-    });
-    $el.on('select2:close.pgSearchFix', function() {
-      $(window).off('resize.pgSelect2Clamp orientationchange.pgSelect2Clamp');
     });
   }
 

--- a/resources/views/layout/partials/footer-scripts.blade.php
+++ b/resources/views/layout/partials/footer-scripts.blade.php
@@ -962,6 +962,11 @@ https://cdn.jsdelivr.net/npm/toastr@2.1.4/toastr.min.js
     });
   }
 
+  /** Deteksi device touch (tablet/HP) — dipakai buat skip autofocus search Select2. */
+  function pgIsTouchDevice() {
+    return ('ontouchstart' in window) || (navigator.maxTouchPoints > 0);
+  }
+
   /** Fokus kolom search Select2 (modal + dropdownParent body / mobile). */
   function attachSelect2SearchOpenFix($el) {
     $el.off('select2:open.pgSearchFix');
@@ -971,7 +976,17 @@ https://cdn.jsdelivr.net/npm/toastr@2.1.4/toastr.min.js
         $open.find('.select2-search--dropdown').removeClass('select2-search--hide').show();
         var $search = $open.find('.select2-search__field');
         if ($search.length) {
-          $search.prop('readonly', false).attr('inputmode', 'search').trigger('focus');
+          $search.prop('readonly', false).attr('inputmode', 'search');
+          // Di tablet/touch, auto-focus di sini memicu keyboard on-screen yang
+          // langsung menggeser posisi list opsi (browser scroll-into-view buat
+          // input yang fokus). Kalau user udah mulai tap ke arah item pas layout
+          // bergeser, tap-nya mendarat di opsi lain -> item yang ke-pilih beda
+          // dari yang dimaksud user ("auto pilih" salah produk, GitHub #142).
+          // Search field tetap kelihatan & bisa di-tap manual buat ketik cari;
+          // cuma auto-focus-nya yang di-skip khusus touch device.
+          if (!pgIsTouchDevice()) {
+            $search.trigger('focus');
+          }
         }
       }, 0);
     });

--- a/resources/views/layout/partials/footer-scripts.blade.php
+++ b/resources/views/layout/partials/footer-scripts.blade.php
@@ -967,9 +967,37 @@ https://cdn.jsdelivr.net/npm/toastr@2.1.4/toastr.min.js
     return ('ontouchstart' in window) || (navigator.maxTouchPoints > 0);
   }
 
+  /**
+   * Select2 (`AttachBody._positionDropdown`) menghitung `left` dropdown dari
+   * offset field pemicu di dokumen, tapi gak pernah di-clamp ke lebar
+   * viewport — dan tetap dipakai ulang tiap `window.resize` (termasuk yang
+   * dipicu keyboard on-screen). Kalau hasil hitungannya kegeser ke kanan,
+   * gak ada yang narik balik dropdown itu ke dalam layar. Karena
+   * dropdown-nya nempel di `<body>` (dropdownParent: body, bukan modal),
+   * ini bikin lebar area scroll seluruh halaman ikut membesar -> halaman
+   * jadi bisa di-slide horizontal & tampilannya kacau (GitHub #142, tablet).
+   * Clamp manual di sini pakai getBoundingClientRect (relatif viewport, gak
+   * kepengaruh miscalc internal-nya) supaya dropdown selalu balik masuk
+   * layar berapa pun offset yang dihitung Select2.
+   */
+  function pgClampSelect2DropdownPosition() {
+    var $dropdown = $('.select2-container--open').last().find('.select2-dropdown');
+    if (!$dropdown.length) return;
+    var el = $dropdown[0];
+    var margin = 8;
+    var vw = document.documentElement.clientWidth || window.innerWidth;
+    var rect = el.getBoundingClientRect();
+    var currentLeft = parseFloat($dropdown.css('left')) || 0;
+    if (rect.right > vw - margin) {
+      $dropdown.css('left', (currentLeft - (rect.right - (vw - margin))) + 'px');
+    } else if (rect.left < margin) {
+      $dropdown.css('left', (currentLeft + (margin - rect.left)) + 'px');
+    }
+  }
+
   /** Fokus kolom search Select2 (modal + dropdownParent body / mobile). */
   function attachSelect2SearchOpenFix($el) {
-    $el.off('select2:open.pgSearchFix');
+    $el.off('select2:open.pgSearchFix select2:close.pgSearchFix');
     $el.on('select2:open.pgSearchFix', function() {
       setTimeout(function() {
         var $open = $('.select2-container--open').last();
@@ -988,7 +1016,17 @@ https://cdn.jsdelivr.net/npm/toastr@2.1.4/toastr.min.js
             $search.trigger('focus');
           }
         }
+        pgClampSelect2DropdownPosition();
       }, 0);
+      // Keyboard on-screen buka/tutup memicu window resize -> Select2 hitung
+      // ulang posisi (tanpa clamp) tiap kali. Clamp ulang di sini juga.
+      $(window).off('resize.pgSelect2Clamp orientationchange.pgSelect2Clamp')
+        .on('resize.pgSelect2Clamp orientationchange.pgSelect2Clamp', function() {
+          setTimeout(pgClampSelect2DropdownPosition, 50);
+        });
+    });
+    $el.on('select2:close.pgSearchFix', function() {
+      $(window).off('resize.pgSelect2Clamp orientationchange.pgSelect2Clamp');
     });
   }
 

--- a/resources/views/layout/partials/head.blade.php
+++ b/resources/views/layout/partials/head.blade.php
@@ -94,6 +94,19 @@
             box-sizing: border-box !important;
         }
 
+        /*
+         * Kolom search Select2 ikut font-size body (14px) lewat rule
+         * `font-size: 100%` bawaan select2.css. Safari di tablet/HP
+         * otomatis nge-zoom in halaman begitu sebuah <input> dengan
+         * font-size di bawah 16px kefokus — hasilnya kelihatan kayak
+         * layout "kegeser"/halaman jadi bisa di-slide horizontal begitu
+         * autocomplete dibuka atau diketik (GitHub #142, tablet).
+         * 16px = ambang aman biar Safari gak nge-zoom.
+         */
+        .select2-search__field {
+            font-size: 16px !important;
+        }
+
         /* Global Table Styling (Aesthetic) */
         .table-responsive {
             border: 1px solid #e2e8f0;


### PR DESCRIPTION
## Ringkasan
Fixes #142

Bug: di tablet, saat mau memilih produk lewat autocomplete di Produksi (dan field lain yang pakai Select2 ajax), malah "auto pilih" item yang salah, dan membuka/mengetik di kolom search membuat seluruh halaman kelihatan kegeser dan jadi bisa di-slide horizontal.

Dua penyebab terpisah, ditemukan lewat dua screenshot terpisah dari tablet asli:

## 1. Auto-focus search Select2 memicu keyboard on-screen di saat yang salah
Commit 93e495e4 menambahkan `attachSelect2SearchOpenFix()`, yang otomatis `.trigger('focus')` ke kolom search Select2 begitu dropdown dibuka (dipakai `autocompleteBom`, field produk di Produksi). Di tablet, auto-focus ke input teks memicu keyboard on-screen + browser auto-scroll-into-view, menggeser posisi daftar opsi tepat saat user lagi tap ke arah item yang dia mau — tap-nya mendarat di opsi lain, kelihatan seperti "auto pilih" produk yang salah.

**Fix:** `attachSelect2SearchOpenFix()` sekarang skip `.trigger('focus')` khusus di touch device (deteksi via `ontouchstart`/`navigator.maxTouchPoints`). Kolom search tetap tampil & bisa di-tap manual buat ketik cari, perilaku desktop tidak berubah.

## 2. Safari auto-zoom saat search field (font-size 14px) difokus
Screenshot kedua dari reporter nunjukin bug lain: tiap kolom search Select2 difokus (manual, pas user mau ngetik cari), seluruh halaman kegeser & jadi bisa di-slide. Ini classic iOS Safari behavior: browser otomatis zoom-in halaman begitu `<input>` dengan font-size di bawah 16px difokus. `.select2-search__field` warisan `font-size: 100%` dari select2.css, ke-resolve jadi 14px (font-size body) — di bawah ambang aman.

(Sempat dicoba fix lain di commit ini — clamp posisi dropdown lewat `getBoundingClientRect` tiap `window.resize` — tapi itu nembak gejala yang salah dan sudah di-revert.)

**Fix:** paksa `.select2-search__field { font-size: 16px !important; }` secara global, ambang aman biar Safari gak nge-zoom otomatis.

## Test
Perubahan murni JS/CSS behavior di sisi client (tidak ada logic backend yang berubah) — tidak ada test PHPUnit yang relevan. Sudah divalidasi lewat 2 ronde screenshot dari tablet asli reporter; menunggu 1 ronde verifikasi terakhir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)