### PR TITLE
fix(changelog): deteksi tab ditutup supaya baris 'Sedang dibuka' tidak nyangkut selamanya

### DIFF
--- a/app/Http/Controllers/DashboardActivityController.php
+++ b/app/Http/Controllers/DashboardActivityController.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\DashboardChangeLog;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+
+class DashboardActivityController extends Controller
+{
+    /**
+     * Tutup baris 'open' terakhir milik staf yang sedang login, ditembak oleh
+     * navigator.sendBeacon() dari layout/mainlayout.blade.php saat tab/halaman
+     * benar-benar ditinggalkan (pagehide, atau visibilitychange -> hidden sebagai
+     * fallback mobile Safari yang tidak selalu memanggil pagehide).
+     *
+     * Ini sinyal AKTIF, beda dari estimasi pasif di LogDashboardActivity::logOpen()
+     * (yang baru menutup baris saat user membuka menu LAIN). Tanpa ini, tab yang
+     * ditutup tanpa navigasi lagi akan nyangkut "Sedang dibuka" selamanya di
+     * ReportController::dashboardChangeLogCounts()/laporan aktivitas.
+     *
+     * Tidak pakai $maxSeconds (null) -- beda dari estimasi pasif, sinyal ini nyata
+     * (browser benar-benar menutup halaman), jadi durasi berapa pun tetap valid,
+     * bukan tebakan yang perlu dibatasi.
+     *
+     * sendBeacon tidak menunggu response, jadi isi balasan tidak penting -- yang
+     * penting endpoint ini ringan & selalu 204 walau tidak ada sesi 'open' yang cocok
+     * (mis. beacon terkirim dua kali, atau baris sudah ditutup oleh navigasi lain).
+     */
+    public function closeSession(Request $request): Response
+    {
+        $staffId = (int) (session('user')->staff_id ?? 0);
+        if ($staffId > 0) {
+            // Token per-pageview (window.__dashboardActivityToken, ditanam oleh
+            // LogDashboardActivity::logOpen()) -- wajib dipakai kalau ada, supaya beacon
+            // menutup baris 'open' yang BENAR miliknya sendiri, bukan baris lain yang keburu
+            // dibuat navigasi berikutnya (race condition, lihat catatan di logOpen()).
+            // Fallback ke closeOpenSession() lama hanya untuk halaman yang sempat di-cache
+            // sebelum fix ini (token belum ada di HTML-nya).
+            $token = trim((string) $request->input('token', ''));
+            if ($token !== '') {
+                DashboardChangeLog::closeOpenSessionByToken($staffId, $token, now());
+            } else {
+                DashboardChangeLog::closeOpenSession($staffId, now(), null);
+            }
+        }
+
+        return response()->noContent();
+    }
+}

--- a/app/Http/Middleware/LogDashboardActivity.php
+++ b/app/Http/Middleware/LogDashboardActivity.php
@@ -23,7 +23,7 @@ class LogDashboardActivity
             // samping log mutasi di atas. Baris 'open' dicatat dengan activity_type terpisah
             // supaya ReportController::dashboardChangeLogCounts() (KPI "Changelog" = antrean
             // butuh ACC Direktur) tidak ikut menghitung page-view biasa sebagai item pending.
-            $this->logOpen($request);
+            $this->logOpen($request, $response);
         }
 
         return $response;
@@ -64,7 +64,7 @@ class LogDashboardActivity
      * Ini estimasi pasif (jarak waktu ke request berikutnya), bukan sinyal tab-ditutup yang
      * sesungguhnya — lihat catatan cap 4 jam di bawah.
      */
-    private function logOpen(Request $request): void
+    private function logOpen(Request $request, Response $response): void
     {
         $staffId = (int) (session('user')->staff_id ?? 0);
         if ($staffId <= 0) {
@@ -87,23 +87,22 @@ class LogDashboardActivity
         // Tutup baris 'open' terakhir milik staf ini (modul manapun) yang belum punya durasi —
         // durasinya = jarak ke pembukaan menu berikutnya ini. Kalau jaraknya lebih dari 4 jam,
         // anggap tab lama itu cuma ditinggal (idle/browser ditutup tanpa navigasi lagi) dan
-        // jangan diisi durasi yang menyesatkan.
-        $previous = DashboardChangeLog::where('created_by', $staffId)
-            ->where('activity_type', 'open')
-            ->whereNull('duration_seconds')
-            ->orderByDesc('created_at')
-            ->first();
-        if ($previous) {
-            // Explicit $absolute=true + cast to int: Carbon 3's diffInSeconds() defaults to a
-            // signed, sub-second-precision float (negative here since $previous is in the past).
-            $seconds = (int) $now->diffInSeconds($previous->created_at, true);
-            if ($seconds <= 4 * 3600) {
-                $previous->duration_seconds = $seconds;
-                $previous->save();
-            }
-        }
+        // jangan diisi durasi yang menyesatkan. Lihat juga DashboardActivityController::closeSession()
+        // -- sinyal AKTIF (tab ditutup) yang ditembak lewat navigator.sendBeacon() saat unload,
+        // supaya baris 'open' tidak nyangkut "Sedang dibuka" selamanya kalau user tidak pernah
+        // buka menu lain lagi.
+        DashboardChangeLog::closeOpenSession($staffId, $now);
 
         $staffName = session('user')->staff_name ?? '-';
+
+        // Token unik per-pageview, ditanam ke HTML di bawah supaya close-beacon (lihat
+        // mainlayout.blade.php) menutup baris 'open' INI secara spesifik lewat
+        // whereJson('meta->client_token', ...), bukan cuma "baris open terakhir milik staf
+        // ini yang durasinya masih kosong". Tanpa token itu ada race: beacon pagehide milik
+        // halaman A bisa sampai ke server SETELAH request GET halaman B (navigasi berikutnya)
+        // sudah lebih dulu bikin baris 'open' baru untuk B -- akibatnya beacon A malah menutup
+        // baris B yang baru berumur 0 detik (durasi jadi 0, bukan durasi A yang sebenarnya).
+        $clientToken = (string) Str::uuid();
 
         DashboardChangeLog::create([
             'module_key' => $moduleKey,
@@ -121,9 +120,31 @@ class LogDashboardActivity
             'meta' => [
                 'method' => $request->method(),
                 'path' => $request->path(),
+                'client_token' => $clientToken,
             ],
             'duration_seconds' => null,
         ]);
+
+        $this->injectClientToken($response, $clientToken);
+    }
+
+    /**
+     * Suntik token pageview ke HTML yang SUDAH di-render ($next($request) di handle() sudah
+     * jalan) -- tidak bisa lewat View::share() karena blade-nya sudah selesai dieksekusi.
+     * str_replace ke penutup </body> yang terakhir supaya window.__dashboardActivityToken
+     * selalu ada saat beacon di mainlayout.blade.php butuh dikirim.
+     */
+    private function injectClientToken(Response $response, string $token): void
+    {
+        $content = $response->getContent();
+        if ($content === false || !str_contains($content, '</body>')) {
+            return;
+        }
+
+        $script = '<script>window.__dashboardActivityToken='.json_encode($token).';</script></body>';
+        $pos = strrpos($content, '</body>');
+        $content = substr_replace($content, $script, $pos, strlen('</body>'));
+        $response->setContent($content);
     }
 
     private function shouldLogChange(Request $request, Response $response): bool
@@ -142,7 +163,7 @@ class LogDashboardActivity
         if ($path === '' || str_starts_with($path, 'get')) {
             return false;
         }
-        if (in_array($path, ['dismissdashboardqueueitem', 'updatedashboardwidgets', 'updatepermission'], true)) {
+        if (in_array($path, ['dismissdashboardqueueitem', 'updatedashboardwidgets', 'updatepermission', 'closedashboardsession'], true)) {
             return false;
         }
 

--- a/app/Models/DashboardChangeLog.php
+++ b/app/Models/DashboardChangeLog.php
@@ -25,4 +25,70 @@ class DashboardChangeLog extends Model
     protected $casts = [
         'meta' => 'array',
     ];
+
+    /**
+     * Tutup baris 'open' terakhir milik staf ini (modul manapun) yang belum punya durasi,
+     * dengan durasi = jarak waktu ke $endedAt. Dipakai dari dua tempat: LogDashboardActivity
+     * (estimasi pasif -- ditutup oleh pembukaan menu BERIKUTNYA) dan tab-close beacon
+     * (sinyal aktif -- ditutup oleh browser saat tab/halaman benar-benar ditinggalkan).
+     *
+     * $maxSeconds membatasi durasi yang menyesatkan (tab lama ditinggal idle tanpa navigasi
+     * lagi); default 4 jam sama seperti estimasi pasif. Beacon boleh melewati batas ini
+     * (null) karena sinyalnya nyata, bukan estimasi.
+     *
+     * Idempotent lewat whereNull('duration_seconds') di query pemanggil -- baris yang sudah
+     * ditutup (oleh salah satu jalur) tidak akan tertimpa oleh jalur lainnya.
+     */
+    public static function closeOpenSession(int $staffId, $endedAt, ?int $maxSeconds = 4 * 3600): ?self
+    {
+        $previous = self::where('created_by', $staffId)
+            ->where('activity_type', 'open')
+            ->whereNull('duration_seconds')
+            ->orderByDesc('created_at')
+            ->first();
+
+        if (!$previous) {
+            return null;
+        }
+
+        // Explicit $absolute=true + cast to int: Carbon 3's diffInSeconds() defaults to a
+        // signed, sub-second-precision float (negative here since $previous is in the past).
+        $seconds = (int) $endedAt->diffInSeconds($previous->created_at, true);
+        if ($maxSeconds !== null && $seconds > $maxSeconds) {
+            return null;
+        }
+
+        $previous->duration_seconds = $seconds;
+        $previous->save();
+
+        return $previous;
+    }
+
+    /**
+     * Sama seperti closeOpenSession(), tapi menutup baris 'open' yang SPESIFIK lewat
+     * client_token (tertanam di meta saat baris dibuat -- lihat
+     * LogDashboardActivity::logOpen()), bukan "baris open terakhir milik staf ini".
+     *
+     * Dipakai oleh DashboardActivityController::closeSession() (beacon tab-close) supaya
+     * tidak salah tutup baris LAIN yang keburu dibuat oleh navigasi berikutnya sebelum beacon
+     * sampai ke server -- lihat catatan race condition di logOpen().
+     */
+    public static function closeOpenSessionByToken(int $staffId, string $token, $endedAt): ?self
+    {
+        $row = self::where('created_by', $staffId)
+            ->where('activity_type', 'open')
+            ->whereNull('duration_seconds')
+            ->where('meta->client_token', $token)
+            ->first();
+
+        if (!$row) {
+            return null;
+        }
+
+        $seconds = (int) $endedAt->diffInSeconds($row->created_at, true);
+        $row->duration_seconds = $seconds;
+        $row->save();
+
+        return $row;
+    }
 }

--- a/resources/views/layout/mainlayout.blade.php
+++ b/resources/views/layout/mainlayout.blade.php
@@ -251,6 +251,40 @@
       '><i class="fe fe-trash-2"></i></a>'
     );
   }
+
+  // GitHub #53 follow-up: baris 'open' di dashboard_change_logs sebelumnya HANYA ditutup
+  // secara pasif -- saat staf membuka menu lain (LogDashboardActivity::logOpen()). Kalau tab
+  // ditutup (atau browser ditutup) tanpa navigasi lagi, baris itu nyangkut "Sedang dibuka"
+  // selamanya. navigator.sendBeacon() dipilih karena request biasa (fetch/XHR) BOLEH dibatalkan
+  // browser saat unload, sedangkan sendBeacon dijamin terkirim di background walau tab sudah
+  // ditutup.
+  //
+  // 'pagehide' dipakai, bukan 'beforeunload'/'unload' -- keduanya legacy, mematikan bfcache
+  // (halaman tidak bisa di-cache untuk tombol back/forward), dan sebagian browser mobile tidak
+  // konsisten memanggilnya. 'visibilitychange' -> hidden ditambah sebagai fallback: di Safari
+  // iOS, menutup tab/app-switch kadang hanya memicu ini, bukan pagehide.
+  (function () {
+    var csrfToken = document.querySelector('meta[name="csrf-token"]')?.content || "";
+    var sent = false;
+    function closeDashboardSession() {
+      if (sent || !navigator.sendBeacon) return;
+      sent = true;
+      var data = new FormData();
+      data.append("_token", csrfToken);
+      // window.__dashboardActivityToken diisi oleh LogDashboardActivity::injectClientToken()
+      // -- mengidentifikasi baris 'open' HALAMAN INI secara spesifik, supaya beacon tidak
+      // salah tutup baris lain yang keburu dibuat navigasi berikutnya (race condition kalau
+      // cuma mengandalkan "baris open terakhir").
+      if (window.__dashboardActivityToken) {
+        data.append("token", window.__dashboardActivityToken);
+      }
+      navigator.sendBeacon("{{ url('closeDashboardSession') }}", data);
+    }
+    window.addEventListener("pagehide", closeDashboardSession);
+    document.addEventListener("visibilitychange", function () {
+      if (document.visibilityState === "hidden") closeDashboardSession();
+    });
+  })();
 </script>
 @yield('custom_js')
 </body>

--- a/routes/web.php
+++ b/routes/web.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\CustomerController;
 use App\Http\Controllers\CustomerProductReturnController;
 use App\Http\Controllers\CustomerReturnController;
 use App\Http\Controllers\CustomerSupplyReturnController;
+use App\Http\Controllers\DashboardActivityController;
 use App\Http\Controllers\DeployController;
 use App\Http\Controllers\DeploymentCheckController;
 use App\Http\Controllers\ExternalApiController;
@@ -62,6 +63,11 @@ Route::middleware(checkLogin::class)->group(function () {
     // staff account). Only devs who know the URL (from reading this file) reach them.
     Route::get('/system/changelog', [ChangelogController::class, 'index'])->name('system.changelog');
     Route::get('/system/deployment-check', [DeploymentCheckController::class, 'index'])->name('system.deployment-check');
+
+    // Ditembak oleh navigator.sendBeacon() saat tab/halaman ditutup -- lihat
+    // DashboardActivityController::closeSession(). Sengaja tidak pakai check.access,
+    // sama seperti rute internal lain di grup ini -- cukup checkLogin.
+    Route::post('/closeDashboardSession', [DashboardActivityController::class, 'closeSession'])->name('closeDashboardSession');
 
     Route::get('/', function () {
         return view('Backoffice.Dashboard.Dashboard-Admin');


### PR DESCRIPTION
## Masalah

Di Change Log dashboard admin, baris `activity_type='open'` (catatan "staf X membuka menu Y") hanya ditutup **secara pasif**: durasinya baru diisi kalau staf tersebut membuka menu lain lagi (`LogDashboardActivity::logOpen()`). Kalau tab/browser ditutup begitu saja tanpa navigasi lanjutan, baris itu **nyangkut "Sedang dibuka" selamanya** sampai staf itu login & buka halaman lagi — jadi catatan waktunya tidak valid.

## Perbaikan

- Tambah `navigator.sendBeacon()` di `mainlayout.blade.php`, dipicu saat event `pagehide` (dengan fallback `visibilitychange` → hidden untuk Safari iOS yang kadang tidak memanggil `pagehide`). Beacon ini menembak endpoint baru `POST /closeDashboardSession` saat tab benar-benar ditinggalkan/ditutup — sinyal **aktif**, beda dari estimasi pasif yang sudah ada.
- Setiap baris `open` sekarang dapat `client_token` unik per-pageview yang ditanam ke HTML halaman (lewat `LogDashboardActivity::injectClientToken()`), supaya beacon menutup **baris miliknya sendiri secara spesifik** — bukan cuma "baris open terakhir milik staf ini".
  - Tanpa token ini sempat ketahuan ada race condition saat pengujian manual: beacon `pagehide` halaman A bisa sampai ke server **setelah** request GET halaman B (navigasi berikutnya) sudah lebih dulu membuat baris `open` baru untuk B. Akibatnya beacon A salah menutup baris B yang baru berumur ~0 detik (durasi tercatat 0, bukan durasi A yang sebenarnya). Fix token ini menghilangkan race tersebut.
- Logika "tutup baris open terakhir" diekstrak ke `DashboardChangeLog::closeOpenSession()` / `closeOpenSessionByToken()` supaya dipakai bersama oleh jalur estimasi pasif (`logOpen`) dan jalur sinyal aktif (beacon), idempotent lewat `whereNull('duration_seconds')`.

## File yang berubah

- `app/Http/Middleware/LogDashboardActivity.php` — generate & tanam `client_token`, refactor pemanggilan close.
- `app/Models/DashboardChangeLog.php` — `closeOpenSession()` (diekstrak) + `closeOpenSessionByToken()` (baru).
- `app/Http/Controllers/DashboardActivityController.php` — endpoint baru `closeSession()` untuk beacon.
- `routes/web.php` — route `POST /closeDashboardSession` (di grup `checkLogin`), dikecualikan dari pencatatan "change" biasa.
- `resources/views/layout/mainlayout.blade.php` — script beacon.

## Catatan / trade-off

Beacon juga terpicu saat tab sekadar **dipindah ke background** (bukan ditutup) lewat fallback `visibilitychange`, khususnya untuk jalur iOS Safari yang tidak selalu memanggil `pagehide`. Jadi kalau staf pindah app lalu balik lagi, durasi halaman itu bisa tercatat sedikit lebih pendek dari waktu sebenarnya. Ini tetap jauh lebih baik daripada sebelumnya (nyangkut tak terbatas), tapi ditandai di sini kalau ke depannya mau dibuat lebih ketat.

## Testing

- `php -l` pada semua file PHP yang diubah — tidak ada syntax error.
- Belum ada test otomatis baru untuk jalur ini (butuh simulasi request/beacon terpisah); functional testing manual disarankan sebelum merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)