### PR TITLE
fix(stock-opname): tawarkan konfirmasi gulung satuan saat dokumen terbit

### DIFF
--- a/app/Http/Controllers/StockController.php
+++ b/app/Http/Controllers/StockController.php
@@ -127,9 +127,18 @@ class StockController extends Controller
         // Keputusan gulung SUDAH diambil di frontend lewat /previewStockOpnameRollup (baca-saja,
         // tidak menulis apa pun) SEBELUM endpoint ini pernah dipanggil -- lihat docblock method
         // itu. Jadi endpoint ini SELALU single-shot lagi seperti sebelum fitur konfirmasi gulung
-        // ada: tidak ada lagi jalur "tulis dulu, tanya nanti, tulis lagi kalau confirm". Default
-        // 'skip' (gulung PARSIAL yang aman) untuk pemanggil yang tidak lewat preview sama sekali
-        // (mis. panggilan API langsung) -- tidak pernah diam-diam menggulung penuh tanpa diminta.
+        // ada: tidak ada lagi jalur "tulis dulu, tanya nanti, tulis lagi kalau confirm".
+        //
+        // >>> GANTI 2026-09-06 (keputusan user: "setiap kali ada roll up yang terdeteksi,
+        // munculkan popup konfirmasinya") <<< rollup_decision !== 'full' TIDAK LAGI memicu
+        // rollUpUnits() (gulung parsial otomatis) sebagai fallback "aman" -- lihat docblock
+        // OpnameLifecycle::computeFullProjectionChanges() untuk bug yang ini tutup: mengisi
+        // satuan TERKECIL sendirian (mis. 1000 pcs, Dos kosong) dulu digulung otomatis lewat
+        // rollUpUnits() TANPA pernah lewat popup, karena hasilnya kebetulan identik dengan
+        // rollUpUnitsFull(). Sekarang SETIAP gulung nyata (apa pun bentuknya) wajib terdeteksi di
+        // /previewStockOpnameRollup dulu dan staf klik "Lanjut" -- rollup_decision yang bukan
+        // 'full' (default kalau pemanggil tidak lewat preview sama sekali, mis. panggilan API
+        // langsung) berarti TIDAK ADA gulung apa pun, angka tersimpan PERSIS seperti yang dikirim.
         $decision = $req->input('rollup_decision', 'skip');
 
         return DB::transaction(function () use ($data, $items, $decision) {
@@ -141,15 +150,11 @@ class StockController extends Controller
             // GitHub #132 (2026-09-03, GANTI keputusan PM 2026-08-27): gulung satuan (mis. 1 DOS =
             // 12 pcs, isi 30 pcs -> tersimpan 2 DOS + 6 pcs) HANYA di titik dokumen benar-benar
             // terbit. .btn-save (dokumen dibuat LANGSUNG non-draft, is_draft = 0) membuat insert
-            // INI-lah momen "terbit"-nya. .btn-save-draft (is_draft = 1) membuat rollUpUnits()
+            // INI-lah momen "terbit"-nya. .btn-save-draft (is_draft = 1) membuat rollUpUnitsFull()
             // sendiri yang no-op di sini (lihat guard is_draft di dalamnya) -- gulungnya baru
             // terjadi nanti, satu kali, di submitStockOpname() saat draft itu diajukan.
-            if (! $sto->is_draft) {
-                if ($decision === 'full') {
-                    $lifecycle->rollUpUnitsFull(StockOpname::find($id));
-                } else {
-                    $lifecycle->rollUpUnits(StockOpname::find($id));
-                }
+            if (! $sto->is_draft && $decision === 'full') {
+                $lifecycle->rollUpUnitsFull(StockOpname::find($id));
             }
 
             // publish() sendiri yang menolak selama is_draft masih true -- aman dipanggil di sini
@@ -277,11 +282,11 @@ class StockController extends Controller
         // angka mentah yang diketik staf selama masih draft tidak diam-diam berubah tiap simpan.
         // Dipanggil SEBELUM publish() supaya identitas satuan yang baru tercipta dari gulungan
         // (kalau ada) ikut terbekukan pada publish yang sama -- lihat urutan yang sama persis di
-        // insertStockOpname().
+        // insertStockOpname(). rollup_decision !== 'full' berarti TIDAK ADA gulung sama sekali
+        // (keputusan user 2026-09-06, lihat OpnameLifecycle::computeFullProjectionChanges()) --
+        // rollUpUnits() tidak lagi dipanggil sebagai fallback di sini.
         if ($decision === 'full') {
             $lifecycle->rollUpUnitsFull($sto->refresh());
-        } else {
-            $lifecycle->rollUpUnits($sto->refresh());
         }
         $lifecycle->publish($sto->refresh());
 

--- a/app/Http/Controllers/StockController.php
+++ b/app/Http/Controllers/StockController.php
@@ -96,29 +96,46 @@ class StockController extends Controller
      * Tidak butuh perubahan frontend: units[] dengan real_qty null-able sudah dikirim
      * CreateStockOpname.js sejak dulu, cuma dulu dibuang begitu saja di sini.
      */
+    /**
+     * Cek peluang gulung PENUH TANPA menulis apa pun ke DB -- keputusan user 2026-09-05: dulu
+     * insertStockOpname() menulis dokumen (header + baris) DULU cuma untuk bisa mengecek ini
+     * ("data bayangan" versi lama, ternyata tetap membuat dokumen sungguhan walau staf akhirnya
+     * klik Batal). Endpoint ini murni baca -- item dikirim mentah dari form (bentuk sama persis
+     * dengan yang dikirim insertStockOpname()/updateStockOpname()), tidak ada
+     * StockOpname/StockOpnameLine yang tersentuh sama sekali. Dipanggil dari CreateStockOpname.js
+     * SEBELUM insertData()/submitStockOpname() beneran jalan -- lihat previewStockOpnameRollup()
+     * di sana.
+     */
+    function previewStockOpnameRollup(Request $req)
+    {
+        $items = json_decode($req->item, true) ?: [];
+
+        $warehouseId = (int) ($req->input('warehouse_id') ?: (Session::get('active_warehouse_id') ?? 0));
+        if ($warehouseId <= 0) {
+            $warehouseId = (int) ProductStock::resolveWarehouseId();
+        }
+
+        $candidates = (new OpnameLifecycle())->detectRollupOpportunitiesFromPayload($items, $warehouseId ?: null);
+
+        return response()->json(['rollup_candidates' => $candidates]);
+    }
+
     function insertStockOpname(Request $req)
     {
         $data = $req->all();
         $items = json_decode($req->item, true) ?: [];
-        // null = belum ada keputusan dari staf; 'full'/'skip' datang dari panggilan KEDUA setelah
-        // staf menjawab popup konfirmasi gulung (lihat blok is_draft di bawah). $existingId dikirim
-        // HANYA pada panggilan kedua itu (bersama sto_id dokumen yang BARU SAJA dibuat panggilan
-        // pertama) supaya dokumennya tidak dibuat dua kali.
-        $decision = $req->input('rollup_decision');
-        $existingId = $req->input('sto_id');
+        // Keputusan gulung SUDAH diambil di frontend lewat /previewStockOpnameRollup (baca-saja,
+        // tidak menulis apa pun) SEBELUM endpoint ini pernah dipanggil -- lihat docblock method
+        // itu. Jadi endpoint ini SELALU single-shot lagi seperti sebelum fitur konfirmasi gulung
+        // ada: tidak ada lagi jalur "tulis dulu, tanya nanti, tulis lagi kalau confirm". Default
+        // 'skip' (gulung PARSIAL yang aman) untuk pemanggil yang tidak lewat preview sama sekali
+        // (mis. panggilan API langsung) -- tidak pernah diam-diam menggulung penuh tanpa diminta.
+        $decision = $req->input('rollup_decision', 'skip');
 
-        return DB::transaction(function () use ($data, $items, $decision, $existingId) {
-            if ($existingId) {
-                $sto = StockOpname::find($existingId);
-                if (! $sto) {
-                    return response()->json(['status' => -1, 'message' => 'Dokumen ini tidak bisa diubah']);
-                }
-                $id = $sto->sto_id;
-            } else {
-                $id = (new StockOpname())->insertStockOpname($data);
-                StockOpnameLine::writeFromPayload($id, $items);
-                $sto = StockOpname::find($id);
-            }
+        return DB::transaction(function () use ($data, $items, $decision) {
+            $id = (new StockOpname())->insertStockOpname($data);
+            StockOpnameLine::writeFromPayload($id, $items);
+            $sto = StockOpname::find($id);
 
             $lifecycle = new OpnameLifecycle();
             // GitHub #132 (2026-09-03, GANTI keputusan PM 2026-08-27): gulung satuan (mis. 1 DOS =
@@ -128,23 +145,6 @@ class StockController extends Controller
             // sendiri yang no-op di sini (lihat guard is_draft di dalamnya) -- gulungnya baru
             // terjadi nanti, satu kali, di submitStockOpname() saat draft itu diajukan.
             if (! $sto->is_draft) {
-                // Keputusan user 2026-09-04 (bug report "93 Dos, 104 Piece"): sebelum gulung PARSIAL
-                // otomatis ditulis, tawarkan dulu gulung PENUH (termasuk satuan yang tidak disentuh
-                // staf) kalau ada peluangnya -- staf yang memutuskan lewat popup di frontend, bukan
-                // otomatis. Baris sudah tersimpan (writeFromPayload di atas), jadi aman dijawab lewat
-                // panggilan kedua ke endpoint yang sama tanpa membuat dokumen ganda.
-                if ($decision === null) {
-                    $opportunities = $lifecycle->detectRollupOpportunities($sto);
-                    if ($opportunities !== []) {
-                        return response()->json([
-                            'status' => 2,
-                            'sto_id' => $id,
-                            'rollup_candidates' => $opportunities,
-                        ]);
-                    }
-                    $decision = 'skip';
-                }
-
                 if ($decision === 'full') {
                     $lifecycle->rollUpUnitsFull(StockOpname::find($id));
                 } else {

--- a/app/Http/Controllers/StockController.php
+++ b/app/Http/Controllers/StockController.php
@@ -117,7 +117,15 @@ class StockController extends Controller
 
         $candidates = (new OpnameLifecycle())->detectRollupOpportunitiesFromPayload($items, $warehouseId ?: null);
 
-        return response()->json(['rollup_candidates' => $candidates]);
+        // show_popup: OpnameLifecycle::ROLLUP_PROJECTION_ENABLED CUMA mengatur tampilan popup,
+        // bukan deteksi/gulungnya sendiri (keputusan user 2026-09-06, diperbaiki setelah salah
+        // paham pertama hari yang sama -- lihat docblock const itu). false berarti
+        // CreateStockOpname.js harus langsung lanjut dengan rollup_decision=full TANPA
+        // menampilkan modal, kalau ada kandidat.
+        return response()->json([
+            'rollup_candidates' => $candidates,
+            'show_popup' => OpnameLifecycle::ROLLUP_PROJECTION_ENABLED,
+        ]);
     }
 
     function insertStockOpname(Request $req)
@@ -136,10 +144,16 @@ class StockController extends Controller
         // satuan TERKECIL sendirian (mis. 1000 pcs, Dos kosong) dulu digulung otomatis lewat
         // rollUpUnits() TANPA pernah lewat popup, karena hasilnya kebetulan identik dengan
         // rollUpUnitsFull(). Sekarang SETIAP gulung nyata (apa pun bentuknya) wajib terdeteksi di
-        // /previewStockOpnameRollup dulu dan staf klik "Lanjut" -- rollup_decision yang bukan
-        // 'full' (default kalau pemanggil tidak lewat preview sama sekali, mis. panggilan API
-        // langsung) berarti TIDAK ADA gulung apa pun, angka tersimpan PERSIS seperti yang dikirim.
-        $decision = $req->input('rollup_decision', 'skip');
+        // /previewStockOpnameRollup dulu dan staf klik "Lanjut".
+        //
+        // Default kalau pemanggil tidak membawa rollup_decision eksplisit sama sekali (mis.
+        // panggilan API langsung yang tidak lewat preview): ikuti OpnameLifecycle::
+        // ROLLUP_PROJECTION_ENABLED -- flag itu CUMA mengatur tampilan popup, bukan gulungnya
+        // (koreksi 2026-09-06 yang sama), jadi kalau flag-nya false berarti "selalu langsung
+        // Lanjut" -- defaultnya 'full', bukan 'skip'. Gulung tetap hanya diterapkan untuk produk
+        // yang benar-benar punya perubahan nyata (lihat computeFullProjectionChanges()), jadi
+        // aman dijadikan default tanpa konfirmasi eksplisit.
+        $decision = $req->input('rollup_decision') ?? (OpnameLifecycle::ROLLUP_PROJECTION_ENABLED ? 'skip' : 'full');
 
         return DB::transaction(function () use ($data, $items, $decision) {
             $id = (new StockOpname())->insertStockOpname($data);
@@ -254,17 +268,26 @@ class StockController extends Controller
         // tawarkan dulu gulung PENUH kalau ada peluangnya -- staf memutuskan lewat popup di
         // frontend. is_draft masih true sampai staf menjawab, jadi memanggil endpoint ini dua kali
         // (sekali untuk melihat popup, sekali lagi membawa rollup_decision) aman/idempoten.
+        //
+        // OpnameLifecycle::ROLLUP_PROJECTION_ENABLED CUMA mengatur tampilan popup, bukan
+        // deteksi/gulungnya (koreksi 2026-09-06) -- kalau flag-nya false, jangan balas status=2
+        // (yang cuma berguna untuk menampilkan popup) sama sekali; langsung anggap staf sudah
+        // klik "Lanjut" dan gulung penuh kalau memang ada peluangnya.
         $decision = $req->input('rollup_decision');
         if ($decision === null) {
-            $opportunities = $lifecycle->detectRollupOpportunities($sto);
-            if ($opportunities !== []) {
-                return response()->json([
-                    'status' => 2,
-                    'sto_id' => $sto->sto_id,
-                    'rollup_candidates' => $opportunities,
-                ]);
+            if (! OpnameLifecycle::ROLLUP_PROJECTION_ENABLED) {
+                $decision = 'full';
+            } else {
+                $opportunities = $lifecycle->detectRollupOpportunities($sto);
+                if ($opportunities !== []) {
+                    return response()->json([
+                        'status' => 2,
+                        'sto_id' => $sto->sto_id,
+                        'rollup_candidates' => $opportunities,
+                    ]);
+                }
+                $decision = 'skip';
             }
-            $decision = 'skip';
         }
 
         $sto->is_draft = false;

--- a/app/Http/Controllers/StockController.php
+++ b/app/Http/Controllers/StockController.php
@@ -945,6 +945,17 @@ class StockController extends Controller
         if ($sto->is_draft && !$this->canManageStockOpnameDraft($sto)) {
             abort(404);
         }
+        // Draft belum punya snapshot apa pun (GitHub #115: identitas/stok sistem sengaja tidak
+        // dibekukan sampai dokumen terbit) -- PDF-nya tidak berarti dan tombolnya sendiri sudah
+        // disembunyikan di Stock_Opname.js (item.is_draft). Blokir juga di sini supaya menembak
+        // URL-nya langsung tidak bisa memaksa keluar dokumen setengah jadi, baik ini dokumen milik
+        // sendiri maupun bukan. Cuma dokumen versi BARU -- dokumen lama tidak pernah benar-benar
+        // punya draft lewat UI aslinya (tests/Workflow/StockOpnamePdfLiveSystemStockTest.php
+        // memaksanya cuma untuk menguji refreshLiveSystemQty() lama, cabang else di bawah tidak
+        // pernah menyembunyikan stok sistem seperti OpnameLineReader melakukannya untuk draft baru).
+        if ($sto->is_draft && ! $sto->is_old_version) {
+            abort(404, 'Dokumen masih draft, belum bisa dicetak.');
+        }
 
         if ($sto && ! $sto->is_old_version) {
             // Dokumen versi baru: satu pembaca untuk semuanya. Selisih diturunkan saat dibaca,
@@ -1494,6 +1505,10 @@ class StockController extends Controller
         }
         if ($stob->is_draft && !$this->canManageStockOpnameBahanDraft($stob)) {
             abort(404);
+        }
+        // Kembaran guard generateStockOpname() Produk di atas -- lihat komentarnya untuk alasan.
+        if ($stob->is_draft && ! $stob->is_old_version) {
+            abort(404, 'Dokumen masih draft, belum bisa dicetak.');
         }
 
         if ($stob && ! $stob->is_old_version) {

--- a/app/Http/Controllers/StockController.php
+++ b/app/Http/Controllers/StockController.php
@@ -100,10 +100,25 @@ class StockController extends Controller
     {
         $data = $req->all();
         $items = json_decode($req->item, true) ?: [];
+        // null = belum ada keputusan dari staf; 'full'/'skip' datang dari panggilan KEDUA setelah
+        // staf menjawab popup konfirmasi gulung (lihat blok is_draft di bawah). $existingId dikirim
+        // HANYA pada panggilan kedua itu (bersama sto_id dokumen yang BARU SAJA dibuat panggilan
+        // pertama) supaya dokumennya tidak dibuat dua kali.
+        $decision = $req->input('rollup_decision');
+        $existingId = $req->input('sto_id');
 
-        return DB::transaction(function () use ($data, $items) {
-            $id = (new StockOpname())->insertStockOpname($data);
-            StockOpnameLine::writeFromPayload($id, $items);
+        return DB::transaction(function () use ($data, $items, $decision, $existingId) {
+            if ($existingId) {
+                $sto = StockOpname::find($existingId);
+                if (! $sto) {
+                    return response()->json(['status' => -1, 'message' => 'Dokumen ini tidak bisa diubah']);
+                }
+                $id = $sto->sto_id;
+            } else {
+                $id = (new StockOpname())->insertStockOpname($data);
+                StockOpnameLine::writeFromPayload($id, $items);
+                $sto = StockOpname::find($id);
+            }
 
             $lifecycle = new OpnameLifecycle();
             // GitHub #132 (2026-09-03, GANTI keputusan PM 2026-08-27): gulung satuan (mis. 1 DOS =
@@ -111,10 +126,31 @@ class StockController extends Controller
             // terbit. .btn-save (dokumen dibuat LANGSUNG non-draft, is_draft = 0) membuat insert
             // INI-lah momen "terbit"-nya. .btn-save-draft (is_draft = 1) membuat rollUpUnits()
             // sendiri yang no-op di sini (lihat guard is_draft di dalamnya) -- gulungnya baru
-            // terjadi nanti, satu kali, di submitStockOpname() saat draft itu diajukan. Dipanggil
-            // SEBELUM publish() supaya identitas satuan yang baru ikut tercipta dari gulungan
-            // (kalaupun ada) turut dibekukan pada publish yang sama.
-            $lifecycle->rollUpUnits(StockOpname::find($id));
+            // terjadi nanti, satu kali, di submitStockOpname() saat draft itu diajukan.
+            if (! $sto->is_draft) {
+                // Keputusan user 2026-09-04 (bug report "93 Dos, 104 Piece"): sebelum gulung PARSIAL
+                // otomatis ditulis, tawarkan dulu gulung PENUH (termasuk satuan yang tidak disentuh
+                // staf) kalau ada peluangnya -- staf yang memutuskan lewat popup di frontend, bukan
+                // otomatis. Baris sudah tersimpan (writeFromPayload di atas), jadi aman dijawab lewat
+                // panggilan kedua ke endpoint yang sama tanpa membuat dokumen ganda.
+                if ($decision === null) {
+                    $opportunities = $lifecycle->detectRollupOpportunities($sto);
+                    if ($opportunities !== []) {
+                        return response()->json([
+                            'status' => 2,
+                            'sto_id' => $id,
+                            'rollup_candidates' => $opportunities,
+                        ]);
+                    }
+                    $decision = 'skip';
+                }
+
+                if ($decision === 'full') {
+                    $lifecycle->rollUpUnitsFull(StockOpname::find($id));
+                } else {
+                    $lifecycle->rollUpUnits(StockOpname::find($id));
+                }
+            }
 
             // publish() sendiri yang menolak selama is_draft masih true -- aman dipanggil di sini
             // tanpa syarat baik untuk .btn-save (langsung publish) maupun .btn-save-draft (no-op,
@@ -208,6 +244,24 @@ class StockController extends Controller
             return ["status" => -1, "message" => "Tidak diizinkan mengajukan draft milik staff lain"];
         }
 
+        $lifecycle = new OpnameLifecycle();
+        // Keputusan user 2026-09-04 (bug report "93 Dos, 104 Piece"): sebelum is_draft dimatikan,
+        // tawarkan dulu gulung PENUH kalau ada peluangnya -- staf memutuskan lewat popup di
+        // frontend. is_draft masih true sampai staf menjawab, jadi memanggil endpoint ini dua kali
+        // (sekali untuk melihat popup, sekali lagi membawa rollup_decision) aman/idempoten.
+        $decision = $req->input('rollup_decision');
+        if ($decision === null) {
+            $opportunities = $lifecycle->detectRollupOpportunities($sto);
+            if ($opportunities !== []) {
+                return response()->json([
+                    'status' => 2,
+                    'sto_id' => $sto->sto_id,
+                    'rollup_candidates' => $opportunities,
+                ]);
+            }
+            $decision = 'skip';
+        }
+
         $sto->is_draft = false;
         $sto->save();
 
@@ -218,14 +272,17 @@ class StockController extends Controller
         // dokumen keluar dari draft di sini -- inilah saat snapshot identitas dibekukan untuk
         // alur draft (tombol .btn-ajukan). Idempoten, jadi tidak masalah kalau dokumen ini
         // ternyata sudah pernah publish lewat insert.
-        $lifecycle = new OpnameLifecycle();
         // GitHub #132 (2026-09-03): inilah SATU-SATUNYA titik "diajukan" yang sebenarnya untuk
         // dokumen yang lahir sebagai draft -- gulung satuannya di sini, bukan di update, supaya
         // angka mentah yang diketik staf selama masih draft tidak diam-diam berubah tiap simpan.
         // Dipanggil SEBELUM publish() supaya identitas satuan yang baru tercipta dari gulungan
         // (kalau ada) ikut terbekukan pada publish yang sama -- lihat urutan yang sama persis di
         // insertStockOpname().
-        $lifecycle->rollUpUnits($sto->refresh());
+        if ($decision === 'full') {
+            $lifecycle->rollUpUnitsFull($sto->refresh());
+        } else {
+            $lifecycle->rollUpUnits($sto->refresh());
+        }
         $lifecycle->publish($sto->refresh());
 
         return 1;

--- a/app/Support/StockOpname/OpnameLifecycle.php
+++ b/app/Support/StockOpname/OpnameLifecycle.php
@@ -328,6 +328,21 @@ class OpnameLifecycle
      * keduanya untuk konteks. Kalau keduanya beda di satuan manapun, kembalikan array peluang
      * (null kalau tidak ada apa-apa yang berubah).
      *
+     * >>> GANTI 2026-09-05 (bug report user, hari yang sama): produk yang SAMA SEKALI tidak
+     * disentuh staf (semua satuannya null) TIDAK PERNAH dianggap peluang gulung, walau stok
+     * sistemnya sendiri kebetulan tidak kanonik (mis. Piece > 1 ratio Dos dari data lama) --
+     * UnitRollUp::collapseProductFull() tidak tahu bedanya "produk ini tidak disentuh" dari
+     * "produk ini disentuh tapi satuan ini kosong", dia cuma melihat $qtyByUnit per satuan.
+     * Tanpa guard ini, .btn-save mengirim SELURUH katalog yang sedang tampil di tabel (bukan
+     * cuma yang diisi -- itu memang disengaja untuk dokumen non-draft, lihat komentar keepSparse
+     * di CreateStockOpname.js), jadi produk APA PUN di layar yang kebetulan punya stok tidak
+     * kanonik ikut nongol di popup meski staf tidak pernah mengetiknya -- dan daftarnya berubah-
+     * ubah tergantung produk mana yang kebetulan sedang ter-render (katalog penuh saat create
+     * langsung, vs cuma baris yang pernah disimpan saat draft dibuka lagi), bukan berdasarkan apa
+     * yang staf ketik. "Disentuh" di sini = SETIDAKNYA satu satuan produk ini terisi -- baru untuk
+     * produk itu, satuan lain yang kosong DI DALAMNYA tetap boleh diisi dari stok sistem (itulah
+     * fungsi collapseProductFull()'s $existingByUnitId, dipertahankan apa adanya).
+     *
      * $changes[] diurutkan BESAR -> KECIL (keputusan user 2026-09-05: DOS di kiri, pcs di kanan
      * pada popup) lewat UnitRollUp::multipliersFromBottom() -- bukan urutan alami hasil collapse()
      * yang kebalikannya (kecil ke besar, dari cara carry naik dibangun).
@@ -340,6 +355,10 @@ class OpnameLifecycle
      */
     private function buildRollupOpportunity(int $productVariantId, array $qtyByUnit, ?int $warehouseId, $variants, $products, $unitNames): ?array
     {
+        if (array_filter($qtyByUnit, fn ($q) => $q !== null) === []) {
+            return null;
+        }
+
         $existing = UnitRollUp::existingProductStockByUnit($productVariantId, $warehouseId);
 
         $baselineByUnit = collect(UnitRollUp::collapseProduct($productVariantId, $qtyByUnit, $warehouseId))

--- a/app/Support/StockOpname/OpnameLifecycle.php
+++ b/app/Support/StockOpname/OpnameLifecycle.php
@@ -353,31 +353,15 @@ class OpnameLifecycle
      */
     private function buildRollupOpportunity(int $productVariantId, array $qtyByUnit, ?int $warehouseId, $variants, $products, $unitNames): ?array
     {
-        $existing = UnitRollUp::existingProductStockByUnit($productVariantId, $warehouseId);
-
-        $baselineByUnit = collect(UnitRollUp::collapseProduct($productVariantId, $qtyByUnit, $warehouseId))
-            ->pluck('qty', 'unit_id')->all();
-        $fullByUnit = collect(UnitRollUp::collapseProductFull($productVariantId, $qtyByUnit, $warehouseId))
-            ->pluck('qty', 'unit_id')->all();
-
-        $unitIds = array_unique(array_merge(array_keys($baselineByUnit), array_keys($fullByUnit)));
-        $changes = [];
-        foreach ($unitIds as $unitId) {
-            $before = $baselineByUnit[$unitId] ?? $qtyByUnit[$unitId] ?? $existing[$unitId] ?? 0;
-            $after = $fullByUnit[$unitId] ?? $before;
-            if ((int) $before !== (int) $after) {
-                $changes[] = [
-                    'unit_id' => (int) $unitId,
-                    'unit_short_name' => $unitNames->get($unitId) ?? ('unit#'.$unitId),
-                    'before' => (int) $before,
-                    'after' => (int) $after,
-                ];
-            }
-        }
-
+        $changes = self::computeFullProjectionChanges($productVariantId, $qtyByUnit, $warehouseId);
         if ($changes === []) {
             return null;
         }
+
+        foreach ($changes as &$change) {
+            $change['unit_short_name'] = $unitNames->get($change['unit_id']) ?? ('unit#'.$change['unit_id']);
+        }
+        unset($change);
 
         $multipliers = UnitRollUp::multipliersFromBottom(UnitRollUp::productChain($productVariantId));
         usort($changes, fn ($a, $b) => ($multipliers[$b['unit_id']] ?? 0) <=> ($multipliers[$a['unit_id']] ?? 0));
@@ -394,6 +378,45 @@ class OpnameLifecycle
     }
 
     /**
+     * Inti perbandingan "apakah produk ini punya perubahan NYATA antara gulung parsial (aman) dan
+     * gulung penuh" -- diekstrak dari buildRollupOpportunity() (2026-09-05) supaya rollUpUnitsFull()
+     * bisa memakai perbandingan yang SAMA PERSIS sebagai gerbang tulis, bukan cuma "apakah
+     * collapseProductFull() mengembalikan sesuatu" (lihat docblock rollUpUnitsFull() untuk bug yang
+     * ini tutup: collapseProductFull() SELALU mengembalikan kredit -- termasuk {qty: 0} untuk
+     * produk yang stoknya sendiri sudah 0 di semua satuan dan tidak ada yang perlu digulung sama
+     * sekali -- jadi "collapsed !== []" saja bukan sinyal yang aman untuk menulis).
+     *
+     * @param  array<int, int|null>  $qtyByUnit
+     * @return array<int, array{unit_id: int, before: int, after: int}>  kosong = tidak ada
+     *         perubahan sama sekali untuk produk ini, aman dilewati apa adanya
+     */
+    private static function computeFullProjectionChanges(int $productVariantId, array $qtyByUnit, ?int $warehouseId): array
+    {
+        $existing = UnitRollUp::existingProductStockByUnit($productVariantId, $warehouseId);
+
+        $baselineByUnit = collect(UnitRollUp::collapseProduct($productVariantId, $qtyByUnit, $warehouseId))
+            ->pluck('qty', 'unit_id')->all();
+        $fullByUnit = collect(UnitRollUp::collapseProductFull($productVariantId, $qtyByUnit, $warehouseId))
+            ->pluck('qty', 'unit_id')->all();
+
+        $unitIds = array_unique(array_merge(array_keys($baselineByUnit), array_keys($fullByUnit)));
+        $changes = [];
+        foreach ($unitIds as $unitId) {
+            $before = $baselineByUnit[$unitId] ?? $qtyByUnit[$unitId] ?? $existing[$unitId] ?? 0;
+            $after = $fullByUnit[$unitId] ?? $before;
+            if ((int) $before !== (int) $after) {
+                $changes[] = [
+                    'unit_id' => (int) $unitId,
+                    'before' => (int) $before,
+                    'after' => (int) $after,
+                ];
+            }
+        }
+
+        return $changes;
+    }
+
+    /**
      * Gulung PENUH: sama seperti rollUpUnits(), tapi lewat UnitRollUp::collapseProductFull() --
      * satuan yang TIDAK disentuh staf ikut dilipat ke satuan yang disentuh, bukan dibiarkan NULL.
      *
@@ -402,6 +425,19 @@ class OpnameLifecycle
      * submitStockOpname() untuk gerbangnya. TIDAK PERNAH otomatis, TIDAK PERNAH dari draft.
      * Jangan panggil ini dari update/simpan-antara mana pun -- alasannya sama persis dengan
      * rollUpUnits() (GitHub #132).
+     *
+     * >>> BUG DITEMUKAN USER 2026-09-05 (hari yang sama .btn-ajukan diganti ke katalog penuh):
+     * versi lama menulis untuk SETIAP produk yang "collapseProductFull() mengembalikan sesuatu",
+     * tapi collapseProductFull() SELALU mengembalikan sesuatu begitu chain-nya tidak kosong --
+     * termasuk kredit {qty: 0} untuk produk yang stoknya sendiri sudah 0 di semua satuan dan
+     * TIDAK ADA yang perlu digulung sama sekali. Efeknya: PDF dipenuhi baris "0 DOS, 0 pcs"
+     * ter-highlight HIJAU (seakan "dihitung dan cocok") padahal staf tidak pernah menghitungnya --
+     * baris yang seharusnya tetap NULL ("tidak dihitung", highlight kosong) malah tertimpa
+     * sol_counted_qty=0. Fix: gerbang tulisnya sekarang computeFullProjectionChanges() -- PERSIS
+     * perbandingan yang sama dipakai buildRollupOpportunity() untuk menentukan apa yang tampil di
+     * popup -- jadi "Lanjut" menulis TEPAT apa yang ditampilkan popup, tidak lebih tidak kurang.
+     * Produk yang tidak punya perubahan nyata (before === after untuk semua satuan) dilewati apa
+     * adanya, baris NULL-nya tetap NULL.
      */
     public function rollUpUnitsFull($sto): void
     {
@@ -422,20 +458,20 @@ class OpnameLifecycle
             }
 
             $qtyByUnit = $group->mapWithKeys(fn ($l) => [(int) $l->unit_id => $l->sol_counted_qty])->all();
-            $collapsed = UnitRollUp::collapseProductFull((int) $productVariantId, $qtyByUnit, $warehouseId);
-            if ($collapsed === []) {
+            $changes = self::computeFullProjectionChanges((int) $productVariantId, $qtyByUnit, $warehouseId);
+            if ($changes === []) {
                 continue;
             }
 
             $first = $group->first();
 
-            foreach ($collapsed as $credit) {
+            foreach ($changes as $change) {
                 StockOpnameLine::upsertLine([
                     'sto_id' => $sto->sto_id,
                     'product_id' => $first->product_id,
                     'product_variant_id' => $productVariantId,
-                    'unit_id' => $credit['unit_id'],
-                    'sol_counted_qty' => $credit['qty'],
+                    'unit_id' => $change['unit_id'],
+                    'sol_counted_qty' => $change['after'],
                     'sol_notes' => $first->sol_notes,
                 ]);
             }

--- a/app/Support/StockOpname/OpnameLifecycle.php
+++ b/app/Support/StockOpname/OpnameLifecycle.php
@@ -328,20 +328,18 @@ class OpnameLifecycle
      * keduanya untuk konteks. Kalau keduanya beda di satuan manapun, kembalikan array peluang
      * (null kalau tidak ada apa-apa yang berubah).
      *
-     * >>> GANTI 2026-09-05 (bug report user, hari yang sama): produk yang SAMA SEKALI tidak
-     * disentuh staf (semua satuannya null) TIDAK PERNAH dianggap peluang gulung, walau stok
-     * sistemnya sendiri kebetulan tidak kanonik (mis. Piece > 1 ratio Dos dari data lama) --
-     * UnitRollUp::collapseProductFull() tidak tahu bedanya "produk ini tidak disentuh" dari
-     * "produk ini disentuh tapi satuan ini kosong", dia cuma melihat $qtyByUnit per satuan.
-     * Tanpa guard ini, .btn-save mengirim SELURUH katalog yang sedang tampil di tabel (bukan
-     * cuma yang diisi -- itu memang disengaja untuk dokumen non-draft, lihat komentar keepSparse
-     * di CreateStockOpname.js), jadi produk APA PUN di layar yang kebetulan punya stok tidak
-     * kanonik ikut nongol di popup meski staf tidak pernah mengetiknya -- dan daftarnya berubah-
-     * ubah tergantung produk mana yang kebetulan sedang ter-render (katalog penuh saat create
-     * langsung, vs cuma baris yang pernah disimpan saat draft dibuka lagi), bukan berdasarkan apa
-     * yang staf ketik. "Disentuh" di sini = SETIDAKNYA satu satuan produk ini terisi -- baru untuk
-     * produk itu, satuan lain yang kosong DI DALAMNYA tetap boleh diisi dari stok sistem (itulah
-     * fungsi collapseProductFull()'s $existingByUnitId, dipertahankan apa adanya).
+     * >>> KEPUTUSAN 2026-09-05 (dipertegas ulang hari yang sama, membatalkan fix sehari
+     * sebelumnya yang sempat mengecualikan produk tak tersentuh): produk yang SAMA SEKALI tidak
+     * disentuh staf TETAP dievaluasi -- ini SENGAJA, bukan celah. Niatnya: pada titik dokumen
+     * benar-benar terbit, seluruh dokumen diperlakukan seakan sudah final -- stok sistem ditumpuk
+     * oleh input staf KALAU ADA, lalu diproyeksikan/digulung untuk SETIAP produk di dokumen ini
+     * (bukan cuma yang staf ketik). Ini justru dipakai untuk menangkap data lama yang sudah tidak
+     * kanonik di database (mis. 104 pcs padahal 1 DOS = 12 pcs) walau staf tidak mengetik apa pun
+     * untuk produk itu. Konsekuensinya: kelengkapan hasil ini bergantung pada $qtyByUnit yang
+     * dikirim pemanggil MEWAKILI SELURUH KATALOG dokumen (bukan cuma baris yang diisi) -- lihat
+     * CreateStockOpname.js's .btn-save/.btn-ajukan (keduanya sekarang memakai
+     * collectStockOpnameItems(false), TIDAK sparse, untuk pratinjau gulung) supaya popup
+     * konsisten baik dokumen baru maupun draft yang dibuka ulang.
      *
      * $changes[] diurutkan BESAR -> KECIL (keputusan user 2026-09-05: DOS di kiri, pcs di kanan
      * pada popup) lewat UnitRollUp::multipliersFromBottom() -- bukan urutan alami hasil collapse()
@@ -355,10 +353,6 @@ class OpnameLifecycle
      */
     private function buildRollupOpportunity(int $productVariantId, array $qtyByUnit, ?int $warehouseId, $variants, $products, $unitNames): ?array
     {
-        if (array_filter($qtyByUnit, fn ($q) => $q !== null) === []) {
-            return null;
-        }
-
         $existing = UnitRollUp::existingProductStockByUnit($productVariantId, $warehouseId);
 
         $baselineByUnit = collect(UnitRollUp::collapseProduct($productVariantId, $qtyByUnit, $warehouseId))

--- a/app/Support/StockOpname/OpnameLifecycle.php
+++ b/app/Support/StockOpname/OpnameLifecycle.php
@@ -40,6 +40,19 @@ use App\Support\UnitRollUp;
 class OpnameLifecycle
 {
     /**
+     * Saklar utama popup konfirmasi gulung (keputusan user 2026-09-06): false = popup TIDAK
+     * PERNAH tampil, apa pun kondisinya -- detectRollupOpportunities()/
+     * detectRollupOpportunitiesFromPayload() keluar duluan sebelum logika deteksi apa pun jalan,
+     * jadi tidak ada satu pun cara lain (rollup_decision, gudang, isi form) untuk memaksanya
+     * tetap muncul selama flag ini false. true = ikuti kondisi deteksi yang sudah dibangun
+     * (lihat buildRollupOpportunity()/computeFullProjectionChanges()) -- perilaku hari ini.
+     *
+     * Ubah nilai ini secara langsung di kode (bukan .env/config) -- sengaja "constant var" biasa
+     * per permintaan user, bukan config yang bisa di-override runtime.
+     */
+    public const ROLLUP_PROJECTION_ENABLED = true;
+
+    /**
      * Bekukan identitas dokumen kalau (dan hanya kalau) dokumen sudah keluar dari draft.
      * Idempoten: baris yang snapshot-nya sudah ada TIDAK PERNAH ditulis ulang, jadi mengedit
      * dokumen yang sudah diajukan tidak diam-diam menyegarkan nama yang sudah beku.
@@ -220,6 +233,10 @@ class OpnameLifecycle
      */
     public function detectRollupOpportunities($sto): array
     {
+        if (! self::ROLLUP_PROJECTION_ENABLED) {
+            return [];
+        }
+
         if (! $sto || $sto->is_old_version) {
             return [];
         }
@@ -277,6 +294,10 @@ class OpnameLifecycle
      */
     public function detectRollupOpportunitiesFromPayload(array $items, ?int $warehouseId): array
     {
+        if (! self::ROLLUP_PROJECTION_ENABLED) {
+            return [];
+        }
+
         if (self::isRetailWarehouse($warehouseId)) {
             return [];
         }

--- a/app/Support/StockOpname/OpnameLifecycle.php
+++ b/app/Support/StockOpname/OpnameLifecycle.php
@@ -221,7 +221,11 @@ class OpnameLifecycle
      *
      * Gudang ECERAN dikecualikan sama seperti rollUpUnits() -- alasannya sama persis.
      *
-     * @return array<int, array{product_variant_id: int, product_name: string}>
+     * Tiap produk yang punya peluang membawa `changes[]` (satuan, angka SEBELUM/SESUDAH gulung
+     * penuh) supaya popup konfirmasi bisa menampilkan rincian per satuan (keputusan user
+     * 2026-09-04 setelah popup pertama cuma menyebut nama produk) -- bukan cuma daftar nama.
+     *
+     * @return array<int, array{product_variant_id: int, product_name: string, changes: array<int, array{unit_id: int, unit_short_name: string, before: int, after: int}>}>
      */
     public function detectRollupOpportunities($sto): array
     {
@@ -234,15 +238,20 @@ class OpnameLifecycle
             return [];
         }
 
-        $lines = StockOpnameLine::getLines($sto->sto_id)->groupBy('product_variant_id');
-        if ($lines->isEmpty()) {
+        $flatLines = StockOpnameLine::getLines($sto->sto_id);
+        if ($flatLines->isEmpty()) {
             return [];
         }
+        $lines = $flatLines->groupBy('product_variant_id');
 
         $variants = ProductVariant::whereIn('product_variant_id', $lines->keys()->filter()->unique()->all())
             ->get()->keyBy('product_variant_id');
         $products = Product::whereIn('product_id', $variants->pluck('product_id')->filter()->unique()->all())
             ->get()->keyBy('product_id');
+        // $flatLines (BUKAN $lines yang sudah di-groupBy) -- groupBy() membungkus tiap grup jadi
+        // Collection tersendiri, jadi pluck('unit_id') di atasnya cuma menghasilkan array kosong.
+        $unitNames = Unit::whereIn('unit_id', $flatLines->pluck('unit_id')->filter()->unique()->all())
+            ->pluck('unit_short_name', 'unit_id');
 
         $opportunities = [];
 
@@ -260,17 +269,21 @@ class OpnameLifecycle
                 ->pluck('qty', 'unit_id')->all();
 
             $unitIds = array_unique(array_merge(array_keys($baselineByUnit), array_keys($fullByUnit)));
-            $changed = false;
+            $changes = [];
             foreach ($unitIds as $unitId) {
                 $before = $baselineByUnit[$unitId] ?? $qtyByUnit[$unitId] ?? $existing[$unitId] ?? 0;
                 $after = $fullByUnit[$unitId] ?? $before;
                 if ((int) $before !== (int) $after) {
-                    $changed = true;
-                    break;
+                    $changes[] = [
+                        'unit_id' => (int) $unitId,
+                        'unit_short_name' => $unitNames->get($unitId) ?? ('unit#'.$unitId),
+                        'before' => (int) $before,
+                        'after' => (int) $after,
+                    ];
                 }
             }
 
-            if (! $changed) {
+            if ($changes === []) {
                 continue;
             }
 
@@ -281,6 +294,7 @@ class OpnameLifecycle
             $opportunities[] = [
                 'product_variant_id' => (int) $productVariantId,
                 'product_name' => $name,
+                'changes' => $changes,
             ];
         }
 

--- a/app/Support/StockOpname/OpnameLifecycle.php
+++ b/app/Support/StockOpname/OpnameLifecycle.php
@@ -203,27 +203,18 @@ class OpnameLifecycle
     }
 
     /**
-     * Deteksi peluang gulung PENUH tanpa MENULIS apa pun -- gerbang konfirmasi dipanggil dari
-     * StockController::insertStockOpname()/submitStockOpname() SEBELUM dokumen benar-benar
-     * terbit (keputusan user 2026-09-04, bug report "93 Dos, 104 Piece": staf mengoreksi cuma
-     * Dos, Piece dibiarkan 104 apa adanya -- itu benar per aturan GH #78, tapi user ingin
-     * kesempatan menggulung PENUH ditawarkan secara eksplisit persis di titik dokumen terbit,
-     * bukan otomatis).
+     * Deteksi peluang gulung PENUH tanpa MENULIS apa pun, dari dokumen yang SUDAH tersimpan
+     * (draft yang sudah pernah disimpan, dibaca dari stock_opname_lines). Bandingkan dengan
+     * detectRollupOpportunitiesFromPayload() di bawah untuk dokumen yang BELUM tersimpan sama
+     * sekali -- keduanya berbagi buildRollupOpportunity(), cuma sumber $qtyByUnit-nya beda.
      *
-     * Membandingkan dua hasil gulung untuk tiap produk di dokumen:
-     *   - "baseline": UnitRollUp::collapseProduct() -- gulung PARSIAL yang aman, cuma satuan
-     *     yang staf isi sendiri yang ikut bergerak (ini yang akan ditulis kalau staf pilih
-     *     "Batal" pada popup).
-     *   - "full": UnitRollUp::collapseProductFull() -- gulung PENUH, termasuk melipat satuan
-     *     yang TIDAK disentuh staf (mis. Piece) ke satuan yang disentuh (mis. Dos).
-     * Kalau keduanya beda untuk satuan manapun, produk itu punya "peluang gulung" dan masuk
-     * daftar yang ditampilkan di popup konfirmasi.
+     * Dipakai StockController::submitStockOpname() sebagai jaring pengaman kalau frontend
+     * memanggilnya tanpa lebih dulu melewati /previewStockOpnameRollup (lihat CreateStockOpname.js)
+     * -- untuk alur UI normal, deteksi yang sebenarnya sudah selesai lewat payload SEBELUM draft-nya
+     * sendiri disimpan (keputusan user 2026-09-05: jangan ada tulisan DB apa pun sampai staf
+     * benar-benar menjawab popup).
      *
      * Gudang ECERAN dikecualikan sama seperti rollUpUnits() -- alasannya sama persis.
-     *
-     * Tiap produk yang punya peluang membawa `changes[]` (satuan, angka SEBELUM/SESUDAH gulung
-     * penuh) supaya popup konfirmasi bisa menampilkan rincian per satuan (keputusan user
-     * 2026-09-04 setelah popup pertama cuma menyebut nama produk) -- bukan cuma daftar nama.
      *
      * @return array<int, array{product_variant_id: int, product_name: string, changes: array<int, array{unit_id: int, unit_short_name: string, before: int, after: int}>}>
      */
@@ -254,51 +245,139 @@ class OpnameLifecycle
             ->pluck('unit_short_name', 'unit_id');
 
         $opportunities = [];
-
         foreach ($lines as $productVariantId => $group) {
             if (! $productVariantId) {
                 continue;
             }
 
             $qtyByUnit = $group->mapWithKeys(fn ($l) => [(int) $l->unit_id => $l->sol_counted_qty])->all();
-            $existing = UnitRollUp::existingProductStockByUnit((int) $productVariantId, $warehouseId);
-
-            $baselineByUnit = collect(UnitRollUp::collapseProduct((int) $productVariantId, $qtyByUnit, $warehouseId))
-                ->pluck('qty', 'unit_id')->all();
-            $fullByUnit = collect(UnitRollUp::collapseProductFull((int) $productVariantId, $qtyByUnit, $warehouseId))
-                ->pluck('qty', 'unit_id')->all();
-
-            $unitIds = array_unique(array_merge(array_keys($baselineByUnit), array_keys($fullByUnit)));
-            $changes = [];
-            foreach ($unitIds as $unitId) {
-                $before = $baselineByUnit[$unitId] ?? $qtyByUnit[$unitId] ?? $existing[$unitId] ?? 0;
-                $after = $fullByUnit[$unitId] ?? $before;
-                if ((int) $before !== (int) $after) {
-                    $changes[] = [
-                        'unit_id' => (int) $unitId,
-                        'unit_short_name' => $unitNames->get($unitId) ?? ('unit#'.$unitId),
-                        'before' => (int) $before,
-                        'after' => (int) $after,
-                    ];
-                }
+            $opportunity = $this->buildRollupOpportunity((int) $productVariantId, $qtyByUnit, $warehouseId, $variants, $products, $unitNames);
+            if ($opportunity !== null) {
+                $opportunities[] = $opportunity;
             }
-
-            if ($changes === []) {
-                continue;
-            }
-
-            $variant = $variants->get($productVariantId);
-            $product = $variant ? $products->get($variant->product_id) : null;
-            $name = trim(($product->product_name ?? 'produk#'.$productVariantId).' '.($variant->product_variant_name ?? ''));
-
-            $opportunities[] = [
-                'product_variant_id' => (int) $productVariantId,
-                'product_name' => $name,
-                'changes' => $changes,
-            ];
         }
 
         return $opportunities;
+    }
+
+    /**
+     * Kembaran detectRollupOpportunities() yang bekerja LANGSUNG dari payload frontend (bentuk
+     * item[] yang sama dengan StockOpnameLine::writeFromPayload()), tanpa dokumen apa pun perlu
+     * ada di database sama sekali -- "data bayangan" (keputusan user 2026-09-05): staf mengklik
+     * "Tambah Stok Opname"/"Ajukan", browser mengirim isi form apa adanya ke sini murni untuk
+     * dicek, TIDAK ADA StockOpname/StockOpnameLine yang ditulis. Baru kalau staf klik "Lanjut"
+     * pada popup, browser mengirim ulang payload yang SAMA ke endpoint create/submit sungguhan
+     * (StockController::insertStockOpname()/submitStockOpname()) dengan rollup_decision='full'.
+     *
+     * Dipanggil dari StockController::previewStockOpnameRollup() (route baru, read-only, tidak
+     * ada DB::transaction() sama sekali di sekitarnya).
+     *
+     * @param  array<int, array<string, mixed>>  $items
+     * @return array<int, array{product_variant_id: int, product_name: string, changes: array<int, array{unit_id: int, unit_short_name: string, before: int, after: int}>}>
+     */
+    public function detectRollupOpportunitiesFromPayload(array $items, ?int $warehouseId): array
+    {
+        if (self::isRetailWarehouse($warehouseId)) {
+            return [];
+        }
+
+        $byVariant = [];
+        foreach ($items as $item) {
+            $productVariantId = (int) ($item['product_variant_id'] ?? 0);
+            if (! $productVariantId) {
+                continue;
+            }
+            foreach (($item['units'] ?? []) as $unit) {
+                $unitId = (int) ($unit['unit_id'] ?? 0);
+                if (! $unitId) {
+                    continue;
+                }
+                // array_key_exists, bukan ?? -- null di sini BERMAKNA "tidak dihitung", sama
+                // seperti konvensi StockOpnameLine::upsertLine().
+                $byVariant[$productVariantId][$unitId] = array_key_exists('real_qty', $unit) && $unit['real_qty'] !== null
+                    ? (int) $unit['real_qty']
+                    : null;
+            }
+        }
+
+        if ($byVariant === []) {
+            return [];
+        }
+
+        $variantIds = array_keys($byVariant);
+        $variants = ProductVariant::whereIn('product_variant_id', $variantIds)->get()->keyBy('product_variant_id');
+        $products = Product::whereIn('product_id', $variants->pluck('product_id')->filter()->unique()->all())
+            ->get()->keyBy('product_id');
+        $allUnitIds = collect($byVariant)->flatMap(fn ($units) => array_keys($units))->unique()->all();
+        $unitNames = Unit::whereIn('unit_id', $allUnitIds)->pluck('unit_short_name', 'unit_id');
+
+        $opportunities = [];
+        foreach ($byVariant as $productVariantId => $qtyByUnit) {
+            $opportunity = $this->buildRollupOpportunity($productVariantId, $qtyByUnit, $warehouseId, $variants, $products, $unitNames);
+            if ($opportunity !== null) {
+                $opportunities[] = $opportunity;
+            }
+        }
+
+        return $opportunities;
+    }
+
+    /**
+     * Inti perbandingan gulung PARSIAL (aman) vs PENUH untuk SATU produk, dipakai
+     * detectRollupOpportunities()/detectRollupOpportunitiesFromPayload() -- lihat docblock
+     * keduanya untuk konteks. Kalau keduanya beda di satuan manapun, kembalikan array peluang
+     * (null kalau tidak ada apa-apa yang berubah).
+     *
+     * $changes[] diurutkan BESAR -> KECIL (keputusan user 2026-09-05: DOS di kiri, pcs di kanan
+     * pada popup) lewat UnitRollUp::multipliersFromBottom() -- bukan urutan alami hasil collapse()
+     * yang kebalikannya (kecil ke besar, dari cara carry naik dibangun).
+     *
+     * @param  array<int, int|null>  $qtyByUnit
+     * @param  \Illuminate\Support\Collection  $variants  keyBy('product_variant_id')
+     * @param  \Illuminate\Support\Collection  $products  keyBy('product_id')
+     * @param  \Illuminate\Support\Collection  $unitNames  unit_id => unit_short_name
+     * @return array{product_variant_id: int, product_name: string, changes: array<int, array{unit_id: int, unit_short_name: string, before: int, after: int}>}|null
+     */
+    private function buildRollupOpportunity(int $productVariantId, array $qtyByUnit, ?int $warehouseId, $variants, $products, $unitNames): ?array
+    {
+        $existing = UnitRollUp::existingProductStockByUnit($productVariantId, $warehouseId);
+
+        $baselineByUnit = collect(UnitRollUp::collapseProduct($productVariantId, $qtyByUnit, $warehouseId))
+            ->pluck('qty', 'unit_id')->all();
+        $fullByUnit = collect(UnitRollUp::collapseProductFull($productVariantId, $qtyByUnit, $warehouseId))
+            ->pluck('qty', 'unit_id')->all();
+
+        $unitIds = array_unique(array_merge(array_keys($baselineByUnit), array_keys($fullByUnit)));
+        $changes = [];
+        foreach ($unitIds as $unitId) {
+            $before = $baselineByUnit[$unitId] ?? $qtyByUnit[$unitId] ?? $existing[$unitId] ?? 0;
+            $after = $fullByUnit[$unitId] ?? $before;
+            if ((int) $before !== (int) $after) {
+                $changes[] = [
+                    'unit_id' => (int) $unitId,
+                    'unit_short_name' => $unitNames->get($unitId) ?? ('unit#'.$unitId),
+                    'before' => (int) $before,
+                    'after' => (int) $after,
+                ];
+            }
+        }
+
+        if ($changes === []) {
+            return null;
+        }
+
+        $multipliers = UnitRollUp::multipliersFromBottom(UnitRollUp::productChain($productVariantId));
+        usort($changes, fn ($a, $b) => ($multipliers[$b['unit_id']] ?? 0) <=> ($multipliers[$a['unit_id']] ?? 0));
+
+        $variant = $variants->get($productVariantId);
+        $product = $variant ? $products->get($variant->product_id) : null;
+        $name = trim(($product->product_name ?? 'produk#'.$productVariantId).' '.($variant->product_variant_name ?? ''));
+
+        return [
+            'product_variant_id' => $productVariantId,
+            'product_name' => $name,
+            'changes' => $changes,
+        ];
     }
 
     /**

--- a/app/Support/StockOpname/OpnameLifecycle.php
+++ b/app/Support/StockOpname/OpnameLifecycle.php
@@ -40,17 +40,35 @@ use App\Support\UnitRollUp;
 class OpnameLifecycle
 {
     /**
-     * Saklar utama popup konfirmasi gulung (keputusan user 2026-09-06): false = popup TIDAK
-     * PERNAH tampil, apa pun kondisinya -- detectRollupOpportunities()/
-     * detectRollupOpportunitiesFromPayload() keluar duluan sebelum logika deteksi apa pun jalan,
-     * jadi tidak ada satu pun cara lain (rollup_decision, gudang, isi form) untuk memaksanya
-     * tetap muncul selama flag ini false. true = ikuti kondisi deteksi yang sudah dibangun
-     * (lihat buildRollupOpportunity()/computeFullProjectionChanges()) -- perilaku hari ini.
+     * Saklar TAMPILAN popup konfirmasi gulung (keputusan user 2026-09-06, DIPERBAIKI SETELAH
+     * salah paham pertama pada hari yang sama -- lihat catatan di bawah):
+     *
+     * >>> INI BUKAN saklar "matikan deteksi/gulungnya" <<< Deteksi (detectRollupOpportunities()/
+     * detectRollupOpportunitiesFromPayload()) dan penulisan hasilnya (rollUpUnitsFull()) SELALU
+     * jalan apa adanya, TIDAK PERNAH dipengaruhi flag ini -- proyeksi & gulungnya tetap terjadi
+     * persis seperti yang sudah disepakati sebelumnya. Flag ini CUMA menentukan apakah staf
+     * masih perlu melihat & menjawab popup-nya:
+     *
+     *   true  -> tampilkan popup seperti biasa, staf klik Lanjut/Batal sendiri.
+     *   false -> popup TIDAK ditampilkan sama sekali, tapi alurnya berjalan SEAKAN staf sudah
+     *            klik "Lanjut" secara otomatis -- kalau ada peluang gulung, tetap digulung penuh
+     *            tanpa staf perlu konfirmasi apa pun.
+     *
+     * Dipakai di StockController::previewStockOpnameRollup() (dikirim ke frontend sebagai
+     * `show_popup` supaya CreateStockOpname.js tahu harus menampilkan modal atau langsung
+     * lanjut) dan sebagai default rollup_decision di insertStockOpname()/submitStockOpname()
+     * untuk pemanggil yang tidak membawa keputusan eksplisit sama sekali.
+     *
+     * >>> SALAH PAHAM PERTAMA (dikoreksi user pada percakapan yang sama) <<< Versi awal flag ini
+     * dipasang sebagai guard paling atas detectRollupOpportunities()/
+     * detectRollupOpportunitiesFromPayload(), membuat false berarti "tidak ada kandidat sama
+     * sekali, tidak ada apa pun yang tergulung" -- itu SALAH. Sudah diperbaiki: kedua method
+     * deteksi itu TIDAK LAGI mengecek flag ini sama sekali.
      *
      * Ubah nilai ini secara langsung di kode (bukan .env/config) -- sengaja "constant var" biasa
      * per permintaan user, bukan config yang bisa di-override runtime.
      */
-    public const ROLLUP_PROJECTION_ENABLED = true;
+    public const ROLLUP_PROJECTION_ENABLED = false;
 
     /**
      * Bekukan identitas dokumen kalau (dan hanya kalau) dokumen sudah keluar dari draft.
@@ -233,10 +251,6 @@ class OpnameLifecycle
      */
     public function detectRollupOpportunities($sto): array
     {
-        if (! self::ROLLUP_PROJECTION_ENABLED) {
-            return [];
-        }
-
         if (! $sto || $sto->is_old_version) {
             return [];
         }
@@ -294,10 +308,6 @@ class OpnameLifecycle
      */
     public function detectRollupOpportunitiesFromPayload(array $items, ?int $warehouseId): array
     {
-        if (! self::ROLLUP_PROJECTION_ENABLED) {
-            return [];
-        }
-
         if (self::isRetailWarehouse($warehouseId)) {
             return [];
         }

--- a/app/Support/StockOpname/OpnameLifecycle.php
+++ b/app/Support/StockOpname/OpnameLifecycle.php
@@ -202,6 +202,140 @@ class OpnameLifecycle
         }
     }
 
+    /**
+     * Deteksi peluang gulung PENUH tanpa MENULIS apa pun -- gerbang konfirmasi dipanggil dari
+     * StockController::insertStockOpname()/submitStockOpname() SEBELUM dokumen benar-benar
+     * terbit (keputusan user 2026-09-04, bug report "93 Dos, 104 Piece": staf mengoreksi cuma
+     * Dos, Piece dibiarkan 104 apa adanya -- itu benar per aturan GH #78, tapi user ingin
+     * kesempatan menggulung PENUH ditawarkan secara eksplisit persis di titik dokumen terbit,
+     * bukan otomatis).
+     *
+     * Membandingkan dua hasil gulung untuk tiap produk di dokumen:
+     *   - "baseline": UnitRollUp::collapseProduct() -- gulung PARSIAL yang aman, cuma satuan
+     *     yang staf isi sendiri yang ikut bergerak (ini yang akan ditulis kalau staf pilih
+     *     "Batal" pada popup).
+     *   - "full": UnitRollUp::collapseProductFull() -- gulung PENUH, termasuk melipat satuan
+     *     yang TIDAK disentuh staf (mis. Piece) ke satuan yang disentuh (mis. Dos).
+     * Kalau keduanya beda untuk satuan manapun, produk itu punya "peluang gulung" dan masuk
+     * daftar yang ditampilkan di popup konfirmasi.
+     *
+     * Gudang ECERAN dikecualikan sama seperti rollUpUnits() -- alasannya sama persis.
+     *
+     * @return array<int, array{product_variant_id: int, product_name: string}>
+     */
+    public function detectRollupOpportunities($sto): array
+    {
+        if (! $sto || $sto->is_old_version) {
+            return [];
+        }
+
+        $warehouseId = $sto->warehouse_id ?: null;
+        if (self::isRetailWarehouse($warehouseId)) {
+            return [];
+        }
+
+        $lines = StockOpnameLine::getLines($sto->sto_id)->groupBy('product_variant_id');
+        if ($lines->isEmpty()) {
+            return [];
+        }
+
+        $variants = ProductVariant::whereIn('product_variant_id', $lines->keys()->filter()->unique()->all())
+            ->get()->keyBy('product_variant_id');
+        $products = Product::whereIn('product_id', $variants->pluck('product_id')->filter()->unique()->all())
+            ->get()->keyBy('product_id');
+
+        $opportunities = [];
+
+        foreach ($lines as $productVariantId => $group) {
+            if (! $productVariantId) {
+                continue;
+            }
+
+            $qtyByUnit = $group->mapWithKeys(fn ($l) => [(int) $l->unit_id => $l->sol_counted_qty])->all();
+            $existing = UnitRollUp::existingProductStockByUnit((int) $productVariantId, $warehouseId);
+
+            $baselineByUnit = collect(UnitRollUp::collapseProduct((int) $productVariantId, $qtyByUnit, $warehouseId))
+                ->pluck('qty', 'unit_id')->all();
+            $fullByUnit = collect(UnitRollUp::collapseProductFull((int) $productVariantId, $qtyByUnit, $warehouseId))
+                ->pluck('qty', 'unit_id')->all();
+
+            $unitIds = array_unique(array_merge(array_keys($baselineByUnit), array_keys($fullByUnit)));
+            $changed = false;
+            foreach ($unitIds as $unitId) {
+                $before = $baselineByUnit[$unitId] ?? $qtyByUnit[$unitId] ?? $existing[$unitId] ?? 0;
+                $after = $fullByUnit[$unitId] ?? $before;
+                if ((int) $before !== (int) $after) {
+                    $changed = true;
+                    break;
+                }
+            }
+
+            if (! $changed) {
+                continue;
+            }
+
+            $variant = $variants->get($productVariantId);
+            $product = $variant ? $products->get($variant->product_id) : null;
+            $name = trim(($product->product_name ?? 'produk#'.$productVariantId).' '.($variant->product_variant_name ?? ''));
+
+            $opportunities[] = [
+                'product_variant_id' => (int) $productVariantId,
+                'product_name' => $name,
+            ];
+        }
+
+        return $opportunities;
+    }
+
+    /**
+     * Gulung PENUH: sama seperti rollUpUnits(), tapi lewat UnitRollUp::collapseProductFull() --
+     * satuan yang TIDAK disentuh staf ikut dilipat ke satuan yang disentuh, bukan dibiarkan NULL.
+     *
+     * >>> HANYA dipanggil setelah staf mengonfirmasi lewat popup ("Lanjut") yang menampilkan hasil
+     * detectRollupOpportunities() -- lihat StockController::insertStockOpname()/
+     * submitStockOpname() untuk gerbangnya. TIDAK PERNAH otomatis, TIDAK PERNAH dari draft.
+     * Jangan panggil ini dari update/simpan-antara mana pun -- alasannya sama persis dengan
+     * rollUpUnits() (GitHub #132).
+     */
+    public function rollUpUnitsFull($sto): void
+    {
+        if (! $sto || $sto->is_old_version || $sto->is_draft) {
+            return;
+        }
+
+        $lines = StockOpnameLine::getLines($sto->sto_id)->groupBy('product_variant_id');
+        $warehouseId = $sto->warehouse_id ?: null;
+
+        if (self::isRetailWarehouse($warehouseId)) {
+            return;
+        }
+
+        foreach ($lines as $productVariantId => $group) {
+            if (! $productVariantId) {
+                continue;
+            }
+
+            $qtyByUnit = $group->mapWithKeys(fn ($l) => [(int) $l->unit_id => $l->sol_counted_qty])->all();
+            $collapsed = UnitRollUp::collapseProductFull((int) $productVariantId, $qtyByUnit, $warehouseId);
+            if ($collapsed === []) {
+                continue;
+            }
+
+            $first = $group->first();
+
+            foreach ($collapsed as $credit) {
+                StockOpnameLine::upsertLine([
+                    'sto_id' => $sto->sto_id,
+                    'product_id' => $first->product_id,
+                    'product_variant_id' => $productVariantId,
+                    'unit_id' => $credit['unit_id'],
+                    'sol_counted_qty' => $credit['qty'],
+                    'sol_notes' => $first->sol_notes,
+                ]);
+            }
+        }
+    }
+
     /** Cap keputusan di header -- nama pemutus dibekukan supaya tidak ikut hilang kalau staf dihapus. */
     public function stampDecision($sto, ?int $accBy): void
     {

--- a/app/Support/StockOpname/OpnameLifecycle.php
+++ b/app/Support/StockOpname/OpnameLifecycle.php
@@ -378,13 +378,31 @@ class OpnameLifecycle
     }
 
     /**
-     * Inti perbandingan "apakah produk ini punya perubahan NYATA antara gulung parsial (aman) dan
-     * gulung penuh" -- diekstrak dari buildRollupOpportunity() (2026-09-05) supaya rollUpUnitsFull()
-     * bisa memakai perbandingan yang SAMA PERSIS sebagai gerbang tulis, bukan cuma "apakah
-     * collapseProductFull() mengembalikan sesuatu" (lihat docblock rollUpUnitsFull() untuk bug yang
-     * ini tutup: collapseProductFull() SELALU mengembalikan kredit -- termasuk {qty: 0} untuk
-     * produk yang stoknya sendiri sudah 0 di semua satuan dan tidak ada yang perlu digulung sama
-     * sekali -- jadi "collapsed !== []" saja bukan sinyal yang aman untuk menulis).
+     * Inti perbandingan "apakah produk ini punya perubahan NYATA antara apa yang tersimpan/
+     * diketik APA ADANYA dan proyeksi gulung PENUH" -- diekstrak dari buildRollupOpportunity()
+     * (2026-09-05) supaya rollUpUnitsFull() bisa memakai perbandingan yang SAMA PERSIS sebagai
+     * gerbang tulis.
+     *
+     * >>> GANTI 2026-09-06 (keputusan user: "setiap kali ada roll up yang terdeteksi, munculkan
+     * popup konfirmasinya") <<< Sebelumnya "before" di sini adalah hasil UnitRollUp::
+     * collapseProduct() (gulung PARSIAL yang aman, SELALU jalan otomatis tanpa konfirmasi lewat
+     * OpnameLifecycle::rollUpUnits()) -- popup cuma tampil kalau collapseProductFull() memberi
+     * hasil BERBEDA dari itu. Bug yang menutup ini: mengisi satuan TERKECIL sendirian (mis. 1000
+     * pcs, Dos dibiarkan kosong, 1 DOS = 12 pcs) SUDAH digulung otomatis lewat collapseProduct()
+     * TANPA popup sama sekali -- collapseProduct() dan collapseProductFull() kebetulan
+     * menghasilkan angka yang SAMA PERSIS untuk kasus ini (keduanya mulai menggulung dari satuan
+     * yang sama, satuan terkecil), jadi "before" (baseline) === "after" (full), tidak ada
+     * perbedaan untuk ditawarkan -- padahal jelas ADA gulungan yang terjadi (1000 pcs jadi
+     * beberapa Dos + sisa pcs).
+     *
+     * Sekarang: "before" adalah nilai APA ADANYA (yang diketik staf, atau stok sistem kalau
+     * satuan itu tidak diketik sama sekali) -- BUKAN hasil gulung parsial. Konsekuensinya,
+     * OpnameLifecycle::rollUpUnits() (gulung parsial otomatis) TIDAK LAGI dipanggil dari
+     * StockController::insertStockOpname()/submitStockOpname() sama sekali -- SETIAP gulung,
+     * termasuk yang dulu "otomatis aman", sekarang lewat gerbang popup yang sama (lihat kedua
+     * method itu). rollUpUnits() sendiri TIDAK dihapus (masih dipakai BahanOpnameLifecycle's
+     * kembarannya dan diuji langsung sebagai unit di tests/Workflow/StockOpnameV2LifecycleTest.php)
+     * -- cuma tidak lagi dipanggil dari kedua titik itu.
      *
      * @param  array<int, int|null>  $qtyByUnit
      * @return array<int, array{unit_id: int, before: int, after: int}>  kosong = tidak ada
@@ -393,16 +411,13 @@ class OpnameLifecycle
     private static function computeFullProjectionChanges(int $productVariantId, array $qtyByUnit, ?int $warehouseId): array
     {
         $existing = UnitRollUp::existingProductStockByUnit($productVariantId, $warehouseId);
-
-        $baselineByUnit = collect(UnitRollUp::collapseProduct($productVariantId, $qtyByUnit, $warehouseId))
-            ->pluck('qty', 'unit_id')->all();
         $fullByUnit = collect(UnitRollUp::collapseProductFull($productVariantId, $qtyByUnit, $warehouseId))
             ->pluck('qty', 'unit_id')->all();
 
-        $unitIds = array_unique(array_merge(array_keys($baselineByUnit), array_keys($fullByUnit)));
+        $unitIds = array_unique(array_merge(array_keys($qtyByUnit), array_keys($fullByUnit)));
         $changes = [];
         foreach ($unitIds as $unitId) {
-            $before = $baselineByUnit[$unitId] ?? $qtyByUnit[$unitId] ?? $existing[$unitId] ?? 0;
+            $before = $qtyByUnit[$unitId] ?? $existing[$unitId] ?? 0;
             $after = $fullByUnit[$unitId] ?? $before;
             if ((int) $before !== (int) $after) {
                 $changes[] = [

--- a/app/Support/UnitRollUp.php
+++ b/app/Support/UnitRollUp.php
@@ -230,19 +230,16 @@ class UnitRollUp
      */
     public static function collapseFull(array $chain, array $qtyByUnitId, array $allowedUnitIds, array $existingByUnitId = []): array
     {
-        // Bug ditemukan user 2026-09-05 (hari yang sama fitur ini dipasang): tanpa guard ini,
-        // produk yang SAMA SEKALI tidak disentuh staf ($qtyByUnitId semua null) tetap digulung
-        // dari stok LIVE murni ($seed() jatuh ke $existingByUnitId di semua tingkat) -- bukan
-        // "melipat kelebihan yang staf isi sendiri" seperti niatnya collapseFull(), tapi
-        // "mengarang ulang representasi stok produk yang tidak sedang di-opname sama sekali".
-        // Ini nyata berbahaya di jalur TULIS (OpnameLifecycle::rollUpUnitsFull(), dipanggil
-        // setelah staf klik "Lanjut"): dokumen non-draft (.btn-save) selalu mengirim SELURUH
-        // katalog yang sedang tampil (bukan cuma yang diisi -- itu memang disengaja, lihat
-        // keepSparse di CreateStockOpname.js), jadi baris NULL ("tidak dihitung") milik produk
-        // yang tidak disentuh bisa diam-diam tertimpa angka karangan. Sama seperti collapse()'s
-        // guard $entered===[] di atas, cuma versi ini untuk gulung PENUH.
-        $entered = array_filter($qtyByUnitId, fn ($q) => $q !== null);
-        if ($entered === [] || $chain === []) {
+        // >>> TIDAK ADA guard "produk ini tidak disentuh staf" di sini, SENGAJA <<< (keputusan
+        // user 2026-09-05, membatalkan fix sehari sebelumnya yang menambahkan guard itu):
+        // collapseFull() memang dimaksudkan memproyeksikan SELURUH produk seakan-akan dokumen ini
+        // sudah final -- stok sistem ditumpuk oleh input staf KALAU ADA, lalu digulung. Kalau staf
+        // tidak mengisi satuan apa pun untuk produk ini, itu proyeksi MURNI dari stok sistem yang
+        // sudah ada -- justru itulah yang dipakai untuk menangkap data lama yang sudah tidak
+        // kanonik (mis. 104 pcs padahal 1 DOS = 12 pcs) walau tidak ada yang sedang meng-opname
+        // produk itu secara eksplisit. Lihat App\Support\StockOpname\OpnameLifecycle::
+        // buildRollupOpportunity() untuk sisi pemanggilnya.
+        if ($chain === []) {
             return [];
         }
 

--- a/app/Support/UnitRollUp.php
+++ b/app/Support/UnitRollUp.php
@@ -204,6 +204,94 @@ class UnitRollUp
     }
 
     /**
+     * Gulung PENUH: seperti collapse(), tapi mulai dari DASAR tangga (satuan terkecil) dan
+     * dipakai bukan hanya satuan yang staf isi -- satuan yang tidak diisi ikut disumbang dari
+     * stok yang sudah ada ($existingByUnitId) di SETIAP tingkat, bukan cuma tingkat yang
+     * dilewati saat naik dari satuan yang diisi. Hasilnya: representasi kanonik PENUH atas
+     * seluruh tangga, termasuk melipat kelebihan satuan kecil yang TIDAK PERNAH disentuh staf
+     * ke satuan besar yang staf isi sendiri.
+     *
+     * >>> INI SENGAJA MELANGGAR aturan GH #78 yang dipegang collapse() ("jangan pernah mengarang
+     * angka satuan yang tidak pernah diperiksa staf") -- makanya TIDAK PERNAH dipanggil otomatis
+     * dari input mana pun. Satu-satunya pemanggil yang sah: OpnameLifecycle::rollUpUnitsFull(),
+     * dan itu HANYA dipanggil setelah staf melihat daftar produk yang akan tergulung dan
+     * mengklik "Lanjut" secara eksplisit pada popup konfirmasi (keputusan user 2026-09-04,
+     * GitHub bug report "93 Dos, 104 Piece") -- baca docblock rollUpUnitsFull() untuk alur
+     * lengkapnya. Jangan panggil ini dari collapseProduct()/rollUpUnits() (jalur otomatis,
+     * aman) atau dari draft mana pun.
+     *
+     * @param  array<int, array{small: int, big: int, ratio: int}>  $chain
+     * @param  array<int, int|null>  $qtyByUnitId  null/tidak ada = satuan ini TIDAK diisi
+     * @param  array<int, int>  $allowedUnitIds
+     * @param  array<int, int>  $existingByUnitId  stok live per satuan, dipakai untuk satuan yang
+     *         tidak diisi di $qtyByUnitId, di SETIAP tingkat (bukan cuma yang dilewati)
+     * @return array<int, array{unit_id: int, qty: int}>  seluruh satuan yang tersentuh gulungan
+     *         ini (bisa kosong kalau chain kosong atau tidak ada satuan apa pun yang punya nilai)
+     */
+    public static function collapseFull(array $chain, array $qtyByUnitId, array $allowedUnitIds, array $existingByUnitId = []): array
+    {
+        if ($chain === []) {
+            return [];
+        }
+
+        $multipliers = self::multipliersFromBottom($chain);
+        if ($multipliers === []) {
+            return [];
+        }
+        asort($multipliers);
+        $bottom = array_key_first($multipliers);
+
+        $seed = fn ($unitId) => $qtyByUnitId[$unitId] ?? $existingByUnitId[$unitId] ?? null;
+
+        $allowed = array_flip(array_map('intval', $allowedUnitIds));
+        $current = $bottom;
+        $carry = (int) ($seed($bottom) ?? 0);
+        $credits = [];
+        $hops = 0;
+
+        while ($hops < self::MAX_HOPS) {
+            $hops++;
+
+            $rel = null;
+            foreach ($chain as $link) {
+                if ($link['small'] === $current) {
+                    $rel = $link;
+                    break;
+                }
+            }
+
+            if ($rel === null || $rel['ratio'] <= 0 || $carry < $rel['ratio'] || ! isset($allowed[$rel['big']])) {
+                break;
+            }
+
+            $credits[] = ['unit_id' => $current, 'qty' => $carry % $rel['ratio']];
+            $carry = (int) floor($carry / $rel['ratio']) + (int) ($seed($rel['big']) ?? 0);
+            $current = $rel['big'];
+        }
+
+        $credits[] = ['unit_id' => $current, 'qty' => $carry];
+
+        return $credits;
+    }
+
+    /**
+     * Convenience wrapper: gulung PENUH satu baris produk (lihat collapseFull()) -- hanya dipakai
+     * di belakang konfirmasi eksplisit staf, lihat OpnameLifecycle::rollUpUnitsFull().
+     *
+     * @param  array<int, int|null>  $qtyByUnitId
+     * @return array<int, array{unit_id: int, qty: int}>
+     */
+    public static function collapseProductFull(int $productVariantId, array $qtyByUnitId, ?int $warehouseId = null): array
+    {
+        return self::collapseFull(
+            self::productChain($productVariantId),
+            $qtyByUnitId,
+            self::allowedProductUnitIds($productVariantId, $warehouseId),
+            self::existingProductStockByUnit($productVariantId, $warehouseId)
+        );
+    }
+
+    /**
      * Convenience wrapper: gulung satu baris produk, dibatasi ke satuan yang sudah punya baris
      * stok aktif (kebijakan yang sama dengan planProduct()).
      *

--- a/app/Support/UnitRollUp.php
+++ b/app/Support/UnitRollUp.php
@@ -230,7 +230,19 @@ class UnitRollUp
      */
     public static function collapseFull(array $chain, array $qtyByUnitId, array $allowedUnitIds, array $existingByUnitId = []): array
     {
-        if ($chain === []) {
+        // Bug ditemukan user 2026-09-05 (hari yang sama fitur ini dipasang): tanpa guard ini,
+        // produk yang SAMA SEKALI tidak disentuh staf ($qtyByUnitId semua null) tetap digulung
+        // dari stok LIVE murni ($seed() jatuh ke $existingByUnitId di semua tingkat) -- bukan
+        // "melipat kelebihan yang staf isi sendiri" seperti niatnya collapseFull(), tapi
+        // "mengarang ulang representasi stok produk yang tidak sedang di-opname sama sekali".
+        // Ini nyata berbahaya di jalur TULIS (OpnameLifecycle::rollUpUnitsFull(), dipanggil
+        // setelah staf klik "Lanjut"): dokumen non-draft (.btn-save) selalu mengirim SELURUH
+        // katalog yang sedang tampil (bukan cuma yang diisi -- itu memang disengaja, lihat
+        // keepSparse di CreateStockOpname.js), jadi baris NULL ("tidak dihitung") milik produk
+        // yang tidak disentuh bisa diam-diam tertimpa angka karangan. Sama seperti collapse()'s
+        // guard $entered===[] di atas, cuma versi ini untuk gulung PENUH.
+        $entered = array_filter($qtyByUnitId, fn ($q) => $q !== null);
+        if ($entered === [] || $chain === []) {
             return [];
         }
 

--- a/app/Support/UnitRollUp.php
+++ b/app/Support/UnitRollUp.php
@@ -371,13 +371,15 @@ class UnitRollUp
 
     /**
      * Pengali tiap satuan pada $chain relatif terhadap satuan PALING BAWAH tangga itu (satuan
-     * yang tidak pernah muncul sebagai `big`). Dipakai HANYA untuk mengurutkan "mana yang paling
-     * kecil di antara yang diisi" di collapse() -- bukan untuk konversi langsung.
+     * yang tidak pernah muncul sebagai `big`). Dipakai untuk mengurutkan "mana yang paling
+     * kecil di antara yang diisi" di collapse() -- bukan untuk konversi langsung. Public (bukan
+     * private lagi, 2026-09-05): App\Support\StockOpname\OpnameLifecycle juga memakainya untuk
+     * mengurutkan popup konfirmasi gulung dari satuan BESAR ke KECIL (DOS di kiri, pcs di kanan).
      *
      * @param  array<int, array{small: int, big: int, ratio: int}>  $chain
      * @return array<int, int> unit_id => pengali relatif terhadap satuan paling bawah
      */
-    private static function multipliersFromBottom(array $chain): array
+    public static function multipliersFromBottom(array $chain): array
     {
         $smalls = array_unique(array_map(fn ($l) => $l['small'], $chain));
         $bigs = array_unique(array_map(fn ($l) => $l['big'], $chain));

--- a/public/Custom_js/Backoffice/Inventory/CreateStockOpname.js
+++ b/public/Custom_js/Backoffice/Inventory/CreateStockOpname.js
@@ -397,33 +397,55 @@ $(document).on("click", ".btn-ajukan", function () {
             btnSelector: ".btn-ajukan",
             doneText: "Ajukan",
             onSuccess: function () {
-                $.ajax({
-                    url: "/submitStockOpname",
-                    data: { sto_id: data.sto_id, _token: token },
-                    method: "post",
-                    success: function (e) {
-                        if (e && e.status == -1) {
-                            notifikasi(
-                                "error",
-                                "Gagal Mengajukan",
-                                e.message || "Terjadi kesalahan",
-                            );
-                            ResetLoadingButton(".btn-ajukan", "Ajukan");
-                            return;
-                        }
-                        toastr.success("", "Berhasil mengajukan Stock Opname");
-                        window.location.href = "/stockOpname";
-                    },
-                    error: function (e) {
-                        ResetLoadingButton(".btn-ajukan", "Ajukan");
-                        if (handlePermissionError(e)) return;
-                        console.log(e);
-                    },
-                });
+                submitStockOpname();
             },
         });
     });
 });
+
+/**
+ * Ajukan draft (dipanggil setelah insertData/updateData yang menyimpan draft berhasil). Sama
+ * seperti insertData(): backend bisa membalas status==2 (ada peluang gulung, lihat
+ * showRollupConfirm()) sebelum benar-benar mengajukan -- panggil ulang dirinya sendiri dengan
+ * keputusan staf. is_draft masih true sampai backend benar-benar mengajukan, jadi memanggil
+ * /submitStockOpname dua kali (sekali lihat popup, sekali bawa keputusan) aman.
+ */
+function submitStockOpname(rollupDecision) {
+    var param = { sto_id: data.sto_id, _token: token };
+    if (rollupDecision) {
+        param.rollup_decision = rollupDecision;
+    }
+
+    $.ajax({
+        url: "/submitStockOpname",
+        data: param,
+        method: "post",
+        success: function (e) {
+            if (e && e.status == -1) {
+                notifikasi(
+                    "error",
+                    "Gagal Mengajukan",
+                    e.message || "Terjadi kesalahan",
+                );
+                ResetLoadingButton(".btn-ajukan", "Ajukan");
+                return;
+            }
+            if (e && e.status == 2 && Array.isArray(e.rollup_candidates)) {
+                showRollupConfirm(e.rollup_candidates, function (decision) {
+                    submitStockOpname(decision);
+                });
+                return;
+            }
+            toastr.success("", "Berhasil mengajukan Stock Opname");
+            window.location.href = "/stockOpname";
+        },
+        error: function (e) {
+            ResetLoadingButton(".btn-ajukan", "Ajukan");
+            if (handlePermissionError(e)) return;
+            console.log(e);
+        },
+    });
+}
 
 $(document).on("click", ".btn-delete-draft", function () {
     showModalDelete(
@@ -592,6 +614,14 @@ function insertData(options) {
         is_draft: isDraft ? 1 : 0,
         _token: token,
     };
+    // Panggilan kedua setelah staf menjawab popup konfirmasi gulung (lihat status==2 di bawah):
+    // sto_id dokumen yang sudah dibuat panggilan pertama supaya backend tidak membuatnya dua kali.
+    if (options.rollupDecision) {
+        param.rollup_decision = options.rollupDecision;
+    }
+    if (options.existingStoId) {
+        param.sto_id = options.existingStoId;
+    }
     if (mode == 2) {
         url = "/updateStockOpname";
         param.sto_id = data.sto_id;
@@ -614,6 +644,20 @@ function insertData(options) {
                 ResetLoadingButton(btnSelector, doneText);
                 return;
             }
+            // Ada satuan yang tidak disentuh staf tapi bisa digulung ke satuan yang staf koreksi
+            // (mis. Dos dikoreksi, Piece dibiarkan) -- dokumen SUDAH tersimpan (backend menulis
+            // barisnya sebelum mengecek ini), tinggal tanya staf mau digulung atau tidak.
+            if (e && e.status == 2 && Array.isArray(e.rollup_candidates)) {
+                showRollupConfirm(e.rollup_candidates, function (decision) {
+                    insertData(
+                        Object.assign({}, options, {
+                            rollupDecision: decision,
+                            existingStoId: e.sto_id,
+                        }),
+                    );
+                });
+                return;
+            }
             if (typeof onSuccess === "function") {
                 onSuccess(e);
                 return;
@@ -628,6 +672,39 @@ function insertData(options) {
             toastr.error("", "Terjadi Kesalahan Saat Tambah Stok Opname");
             console.log(e);
         },
+    });
+}
+
+/**
+ * Popup konfirmasi gulung PENUH (keputusan user 2026-09-04, bug report "93 Dos, 104 Piece"):
+ * ditampilkan HANYA kalau backend mendeteksi ada produk yang satuan kecilnya tidak disentuh staf
+ * tapi bisa dilipat ke satuan besar yang staf koreksi. onDecision dipanggil dengan "full" (staf
+ * klik Lanjut) atau "skip" (Batal -- gulung parsial otomatis yang aman tetap jalan seperti biasa).
+ */
+function showRollupConfirm(candidates, onDecision) {
+    var list = candidates
+        .map(function (c) {
+            return (
+                "<li>" +
+                escapeHtml(c.product_name || "Produk#" + c.product_variant_id) +
+                "</li>"
+            );
+        })
+        .join("");
+
+    Swal.fire({
+        icon: "warning",
+        title: "Ada satuan yang bisa digulung",
+        html:
+            "Satuan kecil yang tidak dihitung ulang akan dilipat ke satuan besar yang baru dikoreksi untuk produk berikut:" +
+            '<ul style="text-align:left">' +
+            list +
+            "</ul>Lanjutkan gulung satuan?",
+        showCancelButton: true,
+        confirmButtonText: "Lanjut",
+        cancelButtonText: "Batal",
+    }).then(function (result) {
+        onDecision(result.isConfirmed ? "full" : "skip");
     });
 }
 

--- a/public/Custom_js/Backoffice/Inventory/CreateStockOpname.js
+++ b/public/Custom_js/Backoffice/Inventory/CreateStockOpname.js
@@ -624,6 +624,13 @@ function previewStockOpnameRollup(items, onProceed, onCancel) {
                 onProceed("skip");
                 return;
             }
+            // show_popup: OpnameLifecycle::ROLLUP_PROJECTION_ENABLED (backend) CUMA mengatur
+            // tampilan popup, bukan deteksi/gulungnya sendiri (koreksi 2026-09-06) -- kalau
+            // false, langsung anggap staf sudah klik "Lanjut" tanpa menampilkan modal sama sekali.
+            if (e && e.show_popup === false) {
+                onProceed("full");
+                return;
+            }
             showRollupConfirm(candidates, function (decision) {
                 if (decision === "full") {
                     onProceed("full");

--- a/public/Custom_js/Backoffice/Inventory/CreateStockOpname.js
+++ b/public/Custom_js/Backoffice/Inventory/CreateStockOpname.js
@@ -361,7 +361,22 @@ $(document).on("click", ".btn-save", function () {
     clearTimeout(searchProdukDebounce);
     $("#filter_pr_name").val("");
     refreshStockOpname(function () {
-        insertData({ btnSelector: ".btn-save", doneText: "Tambah Stok Opname" });
+        // Keputusan user 2026-09-05: cek peluang gulung DULU (murni baca DOM + panggilan
+        // read-only, tidak ada apa pun tertulis ke DB) sebelum insertData() beneran menyimpan --
+        // kalau staf klik "Batal" pada popup, insertData() TIDAK PERNAH dipanggil sama sekali.
+        previewStockOpnameRollup(
+            collectStockOpnameItems(false),
+            function (decision) {
+                insertData({
+                    btnSelector: ".btn-save",
+                    doneText: "Tambah Stok Opname",
+                    rollupDecision: decision,
+                });
+            },
+            function () {
+                ResetLoadingButton(".btn-save", "Tambah Stok Opname");
+            },
+        );
     });
 });
 
@@ -392,23 +407,35 @@ $(document).on("click", ".btn-ajukan", function () {
     clearTimeout(searchProdukDebounce);
     $("#filter_pr_name").val("");
     refreshStockOpname(function () {
-        insertData({
-            isDraft: true,
-            btnSelector: ".btn-ajukan",
-            doneText: "Ajukan",
-            onSuccess: function () {
-                submitStockOpname();
+        // Sama seperti .btn-save: cek peluang gulung DULU dari DOM langsung, SEBELUM draft-nya
+        // sendiri disimpan (insertData(isDraft:true)) atau diajukan (submitStockOpname()) --
+        // klik "Batal" pada popup berarti benar-benar batal, tidak ada draft yang ikut tersimpan.
+        previewStockOpnameRollup(
+            collectStockOpnameItems(true),
+            function (decision) {
+                insertData({
+                    isDraft: true,
+                    keepSparse: true,
+                    btnSelector: ".btn-ajukan",
+                    doneText: "Ajukan",
+                    onSuccess: function () {
+                        submitStockOpname(decision);
+                    },
+                });
             },
-        });
+            function () {
+                ResetLoadingButton(".btn-ajukan", "Ajukan");
+            },
+        );
     });
 });
 
 /**
- * Ajukan draft (dipanggil setelah insertData/updateData yang menyimpan draft berhasil). Sama
- * seperti insertData(): backend bisa membalas status==2 (ada peluang gulung, lihat
- * showRollupConfirm()) sebelum benar-benar mengajukan -- panggil ulang dirinya sendiri dengan
- * keputusan staf. is_draft masih true sampai backend benar-benar mengajukan, jadi memanggil
- * /submitStockOpname dua kali (sekali lihat popup, sekali bawa keputusan) aman.
+ * Ajukan draft (dipanggil setelah insertData/updateData yang menyimpan draft berhasil).
+ * rollupDecision datang dari previewStockOpnameRollup() yang sudah dijawab staf SEBELUM draft-nya
+ * sendiri disimpan -- lihat klik-handler .btn-ajukan di atas. Tetap mengerti status==2 (jaring
+ * pengaman kalau backend somehow belum tahu keputusannya, lihat OpnameLifecycle::
+ * detectRollupOpportunities()'s docblock) tapi jalur normal harusnya tidak pernah lewat situ lagi.
  */
 function submitStockOpname(rollupDecision) {
     var param = { sto_id: data.sto_id, _token: token };
@@ -494,53 +521,15 @@ function getData(id) {
     return data.items[ada];
 }
 
-function insertData(options) {
-    options = options || {};
-    var isDraft = !!options.isDraft;
-    var btnSelector = options.btnSelector || ".btn-save";
-    var doneText = options.doneText || "Tambah Stok Opname";
-    var onSuccess = options.onSuccess;
-    // Draft: hanya simpan produk yang benar-benar diisi user. Kalau tidak,
-    // seluruh katalog produk (yang cuma tampil karena pencarian kosong) ikut
-    // tersimpan dengan real_qty otomatis = stok sistem, dan saat draft dibuka
-    // lagi user akan melihat angka yang tidak pernah mereka masukkan sendiri.
-    var keepSparse = !!options.keepSparse;
-
-    $(".is-invalid").removeClass("is-invalid");
-    $(".invalid").removeClass("invalid");
-    var url = "/insertStockOpname";
-    var valid = 1;
-
-    $(".fill").each(function () {
-        if (
-            $(this).val() == null ||
-            $(this).val() == "null" ||
-            $(this).val() == ""
-        ) {
-            valid = -1;
-            $(this).addClass("is-invalid");
-        }
-    });
-
-    if (
-        $("#penanggung-jawab").val() == null ||
-        $("#penanggung-jawab").val() == ""
-    ) {
-        $(".row-staff .select2-selection--single").addClass("invalid");
-        valid = -1;
-    }
-
-    if (valid == -1) {
-        notifikasi(
-            "error",
-            "Gagal Insert",
-            "Silahkan cek kembali inputan anda",
-        );
-        ResetLoadingButton(btnSelector, doneText);
-        return false;
-    }
-
-    productSubmit = [];
+/**
+ * Bangun array item (per varian x per satuan) langsung dari DOM tabel Stock Opname -- MURNI baca,
+ * tidak ada validasi maupun AJAX di sini. Dipakai insertData() untuk payload SUNGGUHAN, dan
+ * previewStockOpnameRollup() (dipanggil dari klik-handler .btn-save/.btn-ajukan, SEBELUM
+ * insertData() pernah dipanggil) untuk cek peluang gulung tanpa menyentuh DB sama sekali --
+ * "data bayangan", keputusan user 2026-09-05.
+ */
+function collectStockOpnameItems(keepSparse) {
+    var items = [];
     $(".row-stock").each(function () {
         let row = $(this);
         let item = {};
@@ -601,8 +590,96 @@ function insertData(options) {
         // dipakai PDF (Backoffice/PDF/Opname.blade.php) untuk highlight.
         item.stod_touched = hasValue ? 1 : 0;
 
-        productSubmit.push(item);
+        items.push(item);
     });
+
+    return items;
+}
+
+/**
+ * Cek peluang gulung TANPA menulis apa pun ke DB (keputusan user 2026-09-05) -- panggil SEBELUM
+ * insertData()/submitStockOpname() beneran menyimpan. items dari collectStockOpnameItems().
+ * onProceed(decision) dipanggil kalau boleh lanjut ("full" kalau staf klik Lanjut pada popup,
+ * "skip" kalau tidak ada peluang sama sekali -- popup tidak pernah muncul). onCancel() dipanggil
+ * HANYA kalau staf klik Batal pada popup -- setelah itu TIDAK ADA AJAX submit apa pun yang boleh
+ * jalan, jadi tidak ada database yang tersentuh sama sekali.
+ */
+function previewStockOpnameRollup(items, onProceed, onCancel) {
+    $.ajax({
+        url: "/previewStockOpnameRollup",
+        data: { item: JSON.stringify(items), _token: token },
+        method: "post",
+        success: function (e) {
+            var candidates = (e && e.rollup_candidates) || [];
+            if (!Array.isArray(candidates) || candidates.length === 0) {
+                onProceed("skip");
+                return;
+            }
+            showRollupConfirm(candidates, function (decision) {
+                if (decision === "full") {
+                    onProceed("full");
+                } else if (typeof onCancel === "function") {
+                    onCancel();
+                }
+            });
+        },
+        error: function (e) {
+            if (handlePermissionError(e)) return;
+            console.log(e);
+            // Preview gagal (mis. jaringan) -- jangan diam-diam memblokir submit, lanjut dengan
+            // gulung PARSIAL yang aman seperti sebelum fitur konfirmasi ini ada.
+            onProceed("skip");
+        },
+    });
+}
+
+function insertData(options) {
+    options = options || {};
+    var isDraft = !!options.isDraft;
+    var btnSelector = options.btnSelector || ".btn-save";
+    var doneText = options.doneText || "Tambah Stok Opname";
+    var onSuccess = options.onSuccess;
+    // Draft: hanya simpan produk yang benar-benar diisi user. Kalau tidak,
+    // seluruh katalog produk (yang cuma tampil karena pencarian kosong) ikut
+    // tersimpan dengan real_qty otomatis = stok sistem, dan saat draft dibuka
+    // lagi user akan melihat angka yang tidak pernah mereka masukkan sendiri.
+    var keepSparse = !!options.keepSparse;
+
+    $(".is-invalid").removeClass("is-invalid");
+    $(".invalid").removeClass("invalid");
+    var url = "/insertStockOpname";
+    var valid = 1;
+
+    $(".fill").each(function () {
+        if (
+            $(this).val() == null ||
+            $(this).val() == "null" ||
+            $(this).val() == ""
+        ) {
+            valid = -1;
+            $(this).addClass("is-invalid");
+        }
+    });
+
+    if (
+        $("#penanggung-jawab").val() == null ||
+        $("#penanggung-jawab").val() == ""
+    ) {
+        $(".row-staff .select2-selection--single").addClass("invalid");
+        valid = -1;
+    }
+
+    if (valid == -1) {
+        notifikasi(
+            "error",
+            "Gagal Insert",
+            "Silahkan cek kembali inputan anda",
+        );
+        ResetLoadingButton(btnSelector, doneText);
+        return false;
+    }
+
+    productSubmit = collectStockOpnameItems(keepSparse);
     console.log(productSubmit);
 
     param = {
@@ -614,13 +691,11 @@ function insertData(options) {
         is_draft: isDraft ? 1 : 0,
         _token: token,
     };
-    // Panggilan kedua setelah staf menjawab popup konfirmasi gulung (lihat status==2 di bawah):
-    // sto_id dokumen yang sudah dibuat panggilan pertama supaya backend tidak membuatnya dua kali.
+    // Keputusan gulung sudah dijawab staf lewat previewStockOpnameRollup() SEBELUM insertData()
+    // ini pernah dipanggil (lihat klik-handler .btn-save/.btn-ajukan) -- endpoint di bawah ini
+    // selalu single-shot, tidak ada lagi jalur "tulis dulu, tanya nanti".
     if (options.rollupDecision) {
         param.rollup_decision = options.rollupDecision;
-    }
-    if (options.existingStoId) {
-        param.sto_id = options.existingStoId;
     }
     if (mode == 2) {
         url = "/updateStockOpname";
@@ -642,20 +717,6 @@ function insertData(options) {
                     e.message || "Terjadi kesalahan",
                 );
                 ResetLoadingButton(btnSelector, doneText);
-                return;
-            }
-            // Ada satuan yang tidak disentuh staf tapi bisa digulung ke satuan yang staf koreksi
-            // (mis. Dos dikoreksi, Piece dibiarkan) -- dokumen SUDAH tersimpan (backend menulis
-            // barisnya sebelum mengecek ini), tinggal tanya staf mau digulung atau tidak.
-            if (e && e.status == 2 && Array.isArray(e.rollup_candidates)) {
-                showRollupConfirm(e.rollup_candidates, function (decision) {
-                    insertData(
-                        Object.assign({}, options, {
-                            rollupDecision: decision,
-                            existingStoId: e.sto_id,
-                        }),
-                    );
-                });
                 return;
             }
             if (typeof onSuccess === "function") {
@@ -689,6 +750,10 @@ function showRollupConfirm(candidates, onDecision) {
     $rows.empty();
 
     candidates.forEach(function (c) {
+        // Backend sudah mengurutkan ch dari satuan BESAR ke KECIL (OpnameLifecycle::
+        // buildRollupOpportunity()) -- di sini tinggal dicetak apa adanya. Panah (&larr;) SENGAJA
+        // di LUAR <span class="rollup-unit-before"> supaya coret cuma menembus angkanya, bukan
+        // ikut mencoret panahnya (2026-09-05, dulu satu span yang sama membungkus keduanya).
         var chips = (c.changes || [])
             .map(function (ch) {
                 return (
@@ -696,7 +761,8 @@ function showRollupConfirm(candidates, onDecision) {
                     escapeHtml(ch.unit_short_name || "") +
                     " " +
                     ch.after +
-                    ' <span class="rollup-unit-before">&larr; ' +
+                    ' <span class="rollup-arrow">&larr;</span> ' +
+                    '<span class="rollup-unit-before">' +
                     ch.before +
                     "</span></span>"
                 );

--- a/public/Custom_js/Backoffice/Inventory/CreateStockOpname.js
+++ b/public/Custom_js/Backoffice/Inventory/CreateStockOpname.js
@@ -678,34 +678,67 @@ function insertData(options) {
 /**
  * Popup konfirmasi gulung PENUH (keputusan user 2026-09-04, bug report "93 Dos, 104 Piece"):
  * ditampilkan HANYA kalau backend mendeteksi ada produk yang satuan kecilnya tidak disentuh staf
- * tapi bisa dilipat ke satuan besar yang staf koreksi. onDecision dipanggil dengan "full" (staf
- * klik Lanjut) atau "skip" (Batal -- gulung parsial otomatis yang aman tetap jalan seperti biasa).
+ * tapi bisa dilipat ke satuan besar yang staf koreksi. Modal PG bergradien (#modalRollupConfirm,
+ * components/modals/stock-opname/rollup-confirm.blade.php) -- bukan SweetAlert2 -- dengan tabel
+ * rincian per produk x per satuan (before -> after), dikunci 4 baris tinggi lalu scroll.
+ * onDecision dipanggil dengan "full" (staf klik Lanjut) atau "skip" (Batal -- gulung parsial
+ * otomatis yang aman tetap jalan seperti biasa).
  */
 function showRollupConfirm(candidates, onDecision) {
-    var list = candidates
-        .map(function (c) {
-            return (
-                "<li>" +
-                escapeHtml(c.product_name || "Produk#" + c.product_variant_id) +
-                "</li>"
-            );
-        })
-        .join("");
+    var $rows = $("#rollup-confirm-rows");
+    $rows.empty();
 
-    Swal.fire({
-        icon: "warning",
-        title: "Ada satuan yang bisa digulung",
-        html:
-            "Satuan kecil yang tidak dihitung ulang akan dilipat ke satuan besar yang baru dikoreksi untuk produk berikut:" +
-            '<ul style="text-align:left">' +
-            list +
-            "</ul>Lanjutkan gulung satuan?",
-        showCancelButton: true,
-        confirmButtonText: "Lanjut",
-        cancelButtonText: "Batal",
-    }).then(function (result) {
-        onDecision(result.isConfirmed ? "full" : "skip");
+    candidates.forEach(function (c) {
+        var chips = (c.changes || [])
+            .map(function (ch) {
+                return (
+                    '<span class="rollup-unit-chip">' +
+                    escapeHtml(ch.unit_short_name || "") +
+                    " " +
+                    ch.after +
+                    ' <span class="rollup-unit-before">&larr; ' +
+                    ch.before +
+                    "</span></span>"
+                );
+            })
+            .join(" ");
+
+        $rows.append(
+            $("<tr>").append(
+                $("<td>").text(
+                    c.product_name || "Produk#" + c.product_variant_id,
+                ),
+                $("<td>").html(
+                    '<div class="d-flex flex-wrap gap-1">' + chips + "</div>",
+                ),
+            ),
+        );
     });
+
+    var $modal = $("#modalRollupConfirm");
+    // decided dipegang di closure ini, bukan langsung memanggil onDecision di handler klik --
+    // supaya menutup modal lewat X/backdrop/ESC (bukan klik salah satu tombol) juga sampai ke
+    // onDecision (dianggap "Batal") lewat SATU titik (hidden.bs.modal), bukan dua jalur berbeda
+    // yang bisa saling menumpuk. .off() dulu di semuanya supaya popup sebelumnya tidak ikut
+    // memanggil onDecision dua kali.
+    var decided = null;
+    $("#btn-rollup-confirm-lanjut")
+        .off("click")
+        .on("click", function () {
+            decided = "full";
+            $modal.modal("hide");
+        });
+    $("#btn-rollup-confirm-batal")
+        .off("click")
+        .on("click", function () {
+            decided = "skip";
+            $modal.modal("hide");
+        });
+    $modal.off("hidden.bs.modal").on("hidden.bs.modal", function () {
+        onDecision(decided || "skip");
+    });
+
+    $modal.modal("show");
 }
 
 $(document).on("click", ".btnBack", function () {

--- a/public/Custom_js/Backoffice/Inventory/CreateStockOpname.js
+++ b/public/Custom_js/Backoffice/Inventory/CreateStockOpname.js
@@ -410,12 +410,21 @@ $(document).on("click", ".btn-ajukan", function () {
         // Sama seperti .btn-save: cek peluang gulung DULU dari DOM langsung, SEBELUM draft-nya
         // sendiri disimpan (insertData(isDraft:true)) atau diajukan (submitStockOpname()) --
         // klik "Batal" pada popup berarti benar-benar batal, tidak ada draft yang ikut tersimpan.
+        //
+        // keepSparse=false (BUKAN true) di SINI -- beda dari .btn-save-draft di atas (keepSparse
+        // tetap true di sana, itu memang "simpan progres saja"). "Ajukan" berarti MENERBITKAN
+        // dokumen ini, jadi harus memperlakukan SELURUH katalog yang sedang tampil seakan sudah
+        // final -- sama persis semangatnya dengan .btn-save (create langsung) -- supaya popup
+        // gulung konsisten baik diajukan langsung maupun sesudah sempat disimpan sebagai draft
+        // lalu dibuka lagi (keputusan user 2026-09-05, bug report: draft yang cuma menyimpan
+        // baris yang diisi tadinya membuat pratinjau kedua kalinya kehilangan kandidat gulung
+        // yang sebelumnya muncul). Baris untuk produk yang tidak diisi tetap masuk dengan
+        // real_qty null -- konsisten dengan bagaimana .btn-save selalu mengirim seluruh katalog.
         previewStockOpnameRollup(
-            collectStockOpnameItems(true),
+            collectStockOpnameItems(false),
             function (decision) {
                 insertData({
                     isDraft: true,
-                    keepSparse: true,
                     btnSelector: ".btn-ajukan",
                     doneText: "Ajukan",
                     onSuccess: function () {

--- a/resources/views/Backoffice/Inventory/CreateStockOpname.blade.php
+++ b/resources/views/Backoffice/Inventory/CreateStockOpname.blade.php
@@ -407,5 +407,5 @@
     var mode = @json($mode);
     var sessionUser = @json(Session::get('user'));
   </script>
-  <script src="{{ asset('Custom_js/Backoffice/Inventory/CreateStockOpname.js') }}?v=14"></script>
+  <script src="{{ asset('Custom_js/Backoffice/Inventory/CreateStockOpname.js') }}?v=15"></script>
 @endsection

--- a/resources/views/Backoffice/Inventory/CreateStockOpname.blade.php
+++ b/resources/views/Backoffice/Inventory/CreateStockOpname.blade.php
@@ -396,6 +396,8 @@
     </div>
   </div>
   <!-- /Page Wrapper -->
+
+  @include('components.modals.stock-opname.rollup-confirm')
 @endsection
 
 @section('custom_js')
@@ -405,5 +407,5 @@
     var mode = @json($mode);
     var sessionUser = @json(Session::get('user'));
   </script>
-  <script src="{{ asset('Custom_js/Backoffice/Inventory/CreateStockOpname.js') }}?v=12"></script>
+  <script src="{{ asset('Custom_js/Backoffice/Inventory/CreateStockOpname.js') }}?v=13"></script>
 @endsection

--- a/resources/views/Backoffice/Inventory/CreateStockOpname.blade.php
+++ b/resources/views/Backoffice/Inventory/CreateStockOpname.blade.php
@@ -407,5 +407,5 @@
     var mode = @json($mode);
     var sessionUser = @json(Session::get('user'));
   </script>
-  <script src="{{ asset('Custom_js/Backoffice/Inventory/CreateStockOpname.js') }}?v=13"></script>
+  <script src="{{ asset('Custom_js/Backoffice/Inventory/CreateStockOpname.js') }}?v=14"></script>
 @endsection

--- a/resources/views/components/modals/stock-opname/rollup-confirm.blade.php
+++ b/resources/views/components/modals/stock-opname/rollup-confirm.blade.php
@@ -1,0 +1,96 @@
+<style>
+  /* Tabel rincian gulung satuan (App\Support\StockOpname\OpnameLifecycle::detectRollupOpportunities()):
+     dikunci ke TEPAT 4 baris tinggi lalu scroll -- sengaja TIDAK memakai
+     PG_POPUP_TABLE.MAX_VISIBLE_ROWS (public/Custom_js/Shared/popup-table.js), permintaan khusus
+     modal ini (2026-09-04), bukan aturan tabel input-baris app-wide yang dipakai modal lain.
+     Baris = padding 12px atas+bawah + line-height ~20px = ~44px; 4 baris = ~176px. */
+  #modalRollupConfirm .modal-dialog {
+    max-width: 640px;
+  }
+  #modalRollupConfirm .rollup-confirm-table-scroll {
+    max-height: 176px;
+    overflow-y: auto;
+    border: 1px solid #e2e8f0;
+    border-radius: 8px;
+  }
+  #modalRollupConfirm table {
+    width: 100%;
+    margin-bottom: 0;
+  }
+  #modalRollupConfirm thead th {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    background: #f1f5f9;
+    color: #64748b;
+    font-size: 11px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: .4px;
+    padding: 10px 14px;
+    border-bottom: 1px solid #e2e8f0;
+  }
+  #modalRollupConfirm tbody td {
+    padding: 10px 14px;
+    vertical-align: middle;
+    color: #334155;
+    font-size: 13px;
+    border-bottom: 1px solid #f1f5f9;
+  }
+  #modalRollupConfirm tbody tr:last-child td {
+    border-bottom: 0;
+  }
+  #modalRollupConfirm .rollup-unit-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    background: #eff6ff;
+    color: #1d4ed8;
+    border: 1px solid #bfdbfe;
+    border-radius: 6px;
+    padding: 3px 8px;
+    font-size: 12px;
+    font-weight: 600;
+    white-space: nowrap;
+  }
+  #modalRollupConfirm .rollup-unit-chip .rollup-unit-before {
+    color: #94a3b8;
+    font-weight: 500;
+    text-decoration: line-through;
+  }
+</style>
+
+<div class="modal fade pg-modal--confirm" id="modalRollupConfirm" tabindex="-1" role="dialog" style="z-index: 1065;">
+  <div class="modal-dialog modal-dialog-centered" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <div class="d-flex align-items-center gap-3">
+          <div class="pg-modal-icon"><i class="fe fe-refresh-cw"></i></div>
+          <div>
+            <h5 class="modal-title mb-0">Ada Satuan yang Bisa Digulung</h5>
+            <small class="modal-subtitle">Satuan kecil yang tidak dihitung ulang akan dilipat ke satuan besar yang baru dikoreksi</small>
+          </div>
+        </div>
+        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body p-4">
+        <div class="table-responsive rollup-confirm-table-scroll">
+          <table>
+            <thead>
+              <tr>
+                <th style="width:40%;">Produk</th>
+                <th>Perubahan Satuan</th>
+              </tr>
+            </thead>
+            <tbody id="rollup-confirm-rows"></tbody>
+          </table>
+        </div>
+        <p class="text-muted mb-0 mt-3" style="font-size:12px;">Lanjutkan gulung satuan untuk semua produk di atas?</p>
+      </div>
+      <div class="modal-footer pg-modal-footer">
+        <button type="button" class="btn pg-btn-cancel" id="btn-rollup-confirm-batal">Batal</button>
+        <button type="button" class="btn pg-btn-confirm" id="btn-rollup-confirm-lanjut"><i class="fe fe-check-circle me-1"></i>Lanjut</button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/resources/views/components/modals/stock-opname/rollup-confirm.blade.php
+++ b/resources/views/components/modals/stock-opname/rollup-confirm.blade.php
@@ -53,6 +53,11 @@
     font-weight: 600;
     white-space: nowrap;
   }
+  /* Panah dan angka "before" adalah DUA span terpisah (2026-09-05) -- coret cuma boleh menembus
+     angkanya sendiri, bukan ikut menembus panah &larr; di sebelahnya. */
+  #modalRollupConfirm .rollup-unit-chip .rollup-arrow {
+    color: #94a3b8;
+  }
   #modalRollupConfirm .rollup-unit-chip .rollup-unit-before {
     color: #94a3b8;
     font-weight: 500;
@@ -67,7 +72,7 @@
         <div class="d-flex align-items-center gap-3">
           <div class="pg-modal-icon"><i class="fe fe-refresh-cw"></i></div>
           <div>
-            <h5 class="modal-title mb-0">Ada Satuan yang Bisa Digulung</h5>
+            <h5 class="modal-title mb-0">Stock Produk Ini Akan Di Roll Up</h5>
             <small class="modal-subtitle">Satuan kecil yang tidak dihitung ulang akan dilipat ke satuan besar yang baru dikoreksi</small>
           </div>
         </div>

--- a/resources/views/components/modals/stock-opname/rollup-confirm.blade.php
+++ b/resources/views/components/modals/stock-opname/rollup-confirm.blade.php
@@ -90,7 +90,7 @@
             <tbody id="rollup-confirm-rows"></tbody>
           </table>
         </div>
-        <p class="text-muted mb-0 mt-3" style="font-size:12px;">Lanjutkan gulung satuan untuk semua produk di atas?</p>
+        <p class="text-muted mb-0 mt-3" style="font-size:12px;">Lanjutkan roll up stock untuk semua produk di atas?</p>
       </div>
       <div class="modal-footer pg-modal-footer">
         <button type="button" class="btn pg-btn-cancel" id="btn-rollup-confirm-batal">Batal</button>

--- a/resources/views/layout/partials/footer-scripts.blade.php
+++ b/resources/views/layout/partials/footer-scripts.blade.php
@@ -633,6 +633,18 @@ https://cdn.jsdelivr.net/npm/toastr@2.1.4/toastr.min.js
   function LoadingButton(id) {
     var $btn = $(id);
     if (!$btn.length) return;
+    // Simpan height/min-width ASLI (dari style="..." di HTML, kalau ada) SEBELUM dikunci --
+    // ResetLoadingButton dulu cuma css({height:''}), yang menghapus property yang barusan
+    // ditulis JS ini, BUKAN mengembalikan ke teks asli attribute style: begitu jQuery
+    // menyentuh property inline style yang sama, teks aslinya hilang untuk selamanya (browser
+    // memutasi attribute style itu sendiri, bukan menyimpan dua salinan terpisah). Tanpa ini
+    // tombol dengan height tetap di HTML-nya (mis. .btn-save height:40px) jadi "penyet" --
+    // turun ke tinggi default browser -- begitu loading selesai. Guard pakai data() supaya
+    // panggilan bertingkat/berulang tidak menimpa nilai asli dengan nilai yang sudah dikunci.
+    if ($btn.data('pg-loading-orig-height') === undefined) {
+      $btn.data('pg-loading-orig-height', $btn[0].style.height || '');
+      $btn.data('pg-loading-orig-min-width', $btn[0].style.minWidth || '');
+    }
     // Lock current size so button doesn't expand when text changes
     $btn.css({
       'min-width': $btn.outerWidth() + 'px',
@@ -646,10 +658,13 @@ https://cdn.jsdelivr.net/npm/toastr@2.1.4/toastr.min.js
   function ResetLoadingButton(id, text = null) {
     var $btn = $(id);
     if (!$btn.length) return;
+    var origHeight = $btn.data('pg-loading-orig-height');
+    var origMinWidth = $btn.data('pg-loading-orig-min-width');
     $btn.css({
-      'min-width': '',
-      'height': ''
+      'min-width': origMinWidth !== undefined ? origMinWidth : '',
+      'height': origHeight !== undefined ? origHeight : ''
     });
+    $btn.removeData('pg-loading-orig-height').removeData('pg-loading-orig-min-width');
     $btn.html(`${text ? text : 'Save Changes'}`).prop("disabled", false);
   }
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -198,6 +198,10 @@ Route::middleware(checkLogin::class)->group(function () {
         Route::get('/generateStockOpname/{id}', [StockController::class, 'generateStockOpname'])->name('generateStockOpname');
         Route::get('/detailStockOpname/{id}', [StockController::class, 'DetailStockOpname'])->name('detailStockOpname');
         Route::get('/getDetailStockOpname', [StockController::class, 'getDetailStockOpname'])->name('getDetailStockOpname');
+        // Baca-saja, dipanggil dari CreateStockOpname.js SEBELUM insertStockOpname()/
+        // submitStockOpname() beneran jalan (baik jalur create maupun edit-draft-lalu-ajukan) --
+        // ditaruh di grup |view (bukan |create atau |edit) supaya berlaku untuk keduanya.
+        Route::post('/previewStockOpnameRollup', [StockController::class, 'previewStockOpnameRollup'])->name('previewStockOpnameRollup');
     });
     Route::middleware('check.access:Stok Opname Produk|create')->group(function () {
         Route::post('/insertStockOpname', [StockController::class, 'insertStockOpname'])->name('insertStockOpname');

--- a/tests/Workflow/StockOpnameBahanFlowTest.php
+++ b/tests/Workflow/StockOpnameBahanFlowTest.php
@@ -178,4 +178,26 @@ class StockOpnameBahanFlowTest extends TestCase
         $stock->refresh();
         $this->assertSame($realQty, $stock->ss_stock);
     }
+
+    /**
+     * Kembaran StockOpnameDraftPrivacyTest's PDF guard, sisi Bahan (2026-09-04): draft belum
+     * punya snapshot apa pun, tombol Print-nya sendiri sudah disembunyikan client-side
+     * (Stock_Opname_Bahan.js's `item.is_draft`), tapi endpoint-nya harus menolak juga -- termasuk
+     * untuk pembuat dokumennya sendiri, bukan cuma staf lain.
+     */
+    public function test_generate_pdf_rejects_a_draft_even_for_its_own_owner(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $stock = $this->pickFixtureStock();
+        $stobId = $this->insertStockOpnameBahan($stock, isDraft: true, realQty: $stock->ss_stock - 1);
+
+        $this->get('/generateStockOpnameBahan/'.$stobId)->assertStatus(404);
+
+        $this->post('/submitStockOpnameBahan', ['stob_id' => $stobId])->assertStatus(200);
+
+        $response = $this->get('/generateStockOpnameBahan/'.$stobId);
+        $response->assertStatus(200);
+        $response->assertHeader('content-type', 'application/pdf');
+    }
 }

--- a/tests/Workflow/StockOpnameDraftPrivacyTest.php
+++ b/tests/Workflow/StockOpnameDraftPrivacyTest.php
@@ -132,4 +132,46 @@ class StockOpnameDraftPrivacyTest extends TestCase
         $this->actingAsSuperAdminStaff();
         $this->get('/detailStockOpname/'.$stoId)->assertStatus(200);
     }
+
+    /**
+     * 2026-09-04: a draft has no snapshot at all (identity/system stock only freeze at publish,
+     * GitHub #115) -- the Print/PDF icon is already hidden client-side for a draft row
+     * (Stock_Opname.js's `item.is_draft` check), but that alone is only UI hiding, not
+     * enforcement. Hitting /generateStockOpname/{id} directly must 404 for a DRAFT regardless of
+     * who's asking -- even the document's own owner (detailStockOpname()'s "am I allowed to see
+     * this draft at all" check on its own is NOT enough here, since the owner legitimately passes
+     * that and would otherwise reach a PDF of half-typed data).
+     */
+    public function test_owner_cannot_generate_pdf_of_their_own_draft(): void
+    {
+        $this->actingAsStaffWithOnlyPermission('Stok Opname Produk', ['view', 'create', 'edit'], ['staff_id' => 555005]);
+        $stock = $this->pickFixtureStock();
+        $stoId = $this->insertDraft($stock, $stock->ps_stock - 1);
+
+        $this->get('/generateStockOpname/'.$stoId)->assertStatus(404);
+    }
+
+    public function test_super_admin_cannot_generate_pdf_of_a_draft_either(): void
+    {
+        $this->actingAsStaffWithOnlyPermission('Stok Opname Produk', ['view', 'create', 'edit'], ['staff_id' => 555006]);
+        $stock = $this->pickFixtureStock();
+        $stoId = $this->insertDraft($stock, $stock->ps_stock - 1);
+
+        $this->actingAsSuperAdminStaff();
+        $this->get('/generateStockOpname/'.$stoId)->assertStatus(404);
+    }
+
+    /** Once the draft is submitted (out of draft), the PDF must work again -- the guard is is_draft-only. */
+    public function test_pdf_works_again_once_the_draft_is_submitted(): void
+    {
+        $this->actingAsStaffWithOnlyPermission('Stok Opname Produk', ['view', 'create', 'edit'], ['staff_id' => 555007]);
+        $stock = $this->pickFixtureStock();
+        $stoId = $this->insertDraft($stock, $stock->ps_stock - 1);
+
+        $this->post('/submitStockOpname', ['sto_id' => $stoId, 'rollup_decision' => 'skip'])->assertStatus(200);
+
+        $response = $this->get('/generateStockOpname/'.$stoId);
+        $response->assertStatus(200);
+        $response->assertHeader('content-type', 'application/pdf');
+    }
 }

--- a/tests/Workflow/StockOpnameFlowTest.php
+++ b/tests/Workflow/StockOpnameFlowTest.php
@@ -50,6 +50,10 @@ class StockOpnameFlowTest extends TestCase
             'category_id' => $this->categoryId(),
             'sto_notes' => 'Workflow test opname',
             'is_draft' => $isDraft ? 1 : 0,
+            // Fixture produk punya lebih dari satu satuan aktif -- ini bisa memicu popup
+            // konfirmasi gulung baru (2026-09-04, bug report "93 Dos, 104 Piece"); skip di sini
+            // karena test-test ini tidak menguji perilaku itu (lihat StockOpnameRollupConfirmTest).
+            'rollup_decision' => 'skip',
             'item' => json_encode([[
                 'product_id' => $stock->product_id,
                 'product_variant_id' => $stock->product_variant_id,
@@ -175,7 +179,7 @@ class StockOpnameFlowTest extends TestCase
         $this->assertSame($startingStock, $stock->ps_stock, 'a blocked (still-draft) approval must not touch stock');
 
         // Submitting takes it out of draft...
-        $this->post('/submitStockOpname', ['sto_id' => $stoId])->assertStatus(200);
+        $this->post('/submitStockOpname', ['sto_id' => $stoId, 'rollup_decision' => 'skip'])->assertStatus(200);
         $sto->refresh();
         $this->assertFalse((bool) $sto->is_draft, 'submitStockOpname must clear is_draft');
         $this->assertSame(1, (int) $sto->status, 'submitting does not itself change status — it was already pending');

--- a/tests/Workflow/StockOpnameRollupConfirmTest.php
+++ b/tests/Workflow/StockOpnameRollupConfirmTest.php
@@ -265,15 +265,16 @@ class StockOpnameRollupConfirmTest extends TestCase
         $this->assertSame(104, (int) ProductStock::where('product_variant_id', $v->product_variant_id)->where('unit_id', $this->units['pcs']->unit_id)->value('ps_stock'));
     }
 
-    public function test_insert_without_rollup_decision_defaults_to_the_old_safe_partial_behavior(): void
+    public function test_insert_without_rollup_decision_applies_no_rollup_at_all(): void
     {
         $this->actingAsSuperAdminStaff();
 
         $v = $this->makeLadderedItem(dosStock: 90, pcsStock: 104);
         $items = $this->dosOnlyItemPayload($v, 93);
 
-        // Tidak ada rollup_decision dikirim -- default 'skip' (pemanggil yang tidak lewat preview
-        // sama sekali, mis. panggilan API langsung) tidak pernah diam-diam menggulung penuh.
+        // Tidak ada rollup_decision dikirim -- pemanggil yang tidak lewat preview sama sekali
+        // (mis. panggilan API langsung) tidak pernah diam-diam menggulung apa pun, bahkan yang
+        // dulu "otomatis aman" sekalipun (keputusan user 2026-09-06).
         $response = $this->insertOpname($items);
         $response->assertStatus(200);
         $response->assertJson(['status' => 1]);
@@ -281,7 +282,7 @@ class StockOpnameRollupConfirmTest extends TestCase
 
         $lines = StockOpnameLine::getLines($stoId)->keyBy('unit_id');
         $this->assertSame(93, (int) $lines[$this->units['dos']->unit_id]->sol_counted_qty, 'Dos tetap 93, tidak berubah');
-        $this->assertNull($lines[$this->units['pcs']->unit_id]->sol_counted_qty, 'Piece TETAP null -- perilaku lama, tidak digulung');
+        $this->assertNull($lines[$this->units['pcs']->unit_id]->sol_counted_qty, 'Piece TETAP null -- tidak digulung');
 
         $sto = StockOpname::find($stoId);
         $this->assertNotNull($sto->sto_staff_name, 'publish() harus tetap jalan untuk dokumen non-draft');
@@ -290,6 +291,57 @@ class StockOpnameRollupConfirmTest extends TestCase
         $this->post('/accStockOpname', ['sto_id' => $stoId, 'item' => json_encode([['dummy' => 1]])])->assertOk();
         $this->assertSame(93, (int) ProductStock::where('product_variant_id', $v->product_variant_id)->where('unit_id', $this->units['dos']->unit_id)->value('ps_stock'));
         $this->assertSame(104, (int) ProductStock::where('product_variant_id', $v->product_variant_id)->where('unit_id', $this->units['pcs']->unit_id)->value('ps_stock'));
+    }
+
+    /**
+     * Bug report user 2026-09-06: "setiap kali ada roll up yang terdeteksi, munculkan popup
+     * konfirmasinya" -- mengisi satuan TERKECIL sendirian (Piece=1000, Dos dibiarkan kosong)
+     * dulu digulung otomatis TANPA popup sama sekali, karena hasil gulung "aman" (parsial) dan
+     * "penuh" kebetulan identik untuk kasus ini (keduanya mulai menggulung dari satuan yang sama
+     * persis, satuan terkecil) -- lihat OpnameLifecycle::computeFullProjectionChanges()'s
+     * docblock. Sekarang perbandingannya bukan lagi "parsial vs penuh" tapi "apa adanya vs
+     * penuh", jadi kasus ini TERDETEKSI juga, dan tanpa rollup_decision='full' TIDAK ADA gulung
+     * sama sekali (1000 pcs tersimpan APA ADANYA, bukan otomatis jadi beberapa Dos).
+     */
+    public function test_filling_only_the_smallest_unit_now_also_requires_confirmation(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        // 1 DOS = 12 pcs. Dos existing 90, staf isi Piece 1000 sendirian.
+        $v = $this->makeLadderedItem(dosStock: 90, pcsStock: 0, ratio: 12);
+        $items = [[
+            'product_id' => $v->product_id,
+            'product_variant_id' => $v->product_variant_id,
+            'units' => [
+                ['unit_id' => $this->units['dos']->unit_id, 'system_qty' => 0, 'real_qty' => null],
+                ['unit_id' => $this->units['pcs']->unit_id, 'system_qty' => 0, 'real_qty' => 1000],
+            ],
+        ]];
+
+        // 1000 pcs = 83 Dos + 4 pcs sisa; + 90 Dos existing = 173 Dos + 4 pcs kanonik.
+        $preview = $this->preview($items);
+        $preview->assertStatus(200);
+        $candidates = $preview->json('rollup_candidates');
+        $this->assertCount(1, $candidates, 'mengisi satuan terkecil sendirian sekarang HARUS terdeteksi juga');
+        $changes = collect($candidates[0]['changes'])->keyBy('unit_id');
+        $this->assertSame(90, $changes[$this->units['dos']->unit_id]['before']);
+        $this->assertSame(173, $changes[$this->units['dos']->unit_id]['after']);
+        $this->assertSame(1000, $changes[$this->units['pcs']->unit_id]['before']);
+        $this->assertSame(4, $changes[$this->units['pcs']->unit_id]['after']);
+
+        // Tanpa konfirmasi ('full'), TIDAK ADA gulung sama sekali -- 1000 pcs tersimpan apa adanya.
+        $noConfirm = $this->insertOpname($items);
+        $noConfirmId = (int) $noConfirm->json('sto_id');
+        $lines = StockOpnameLine::getLines($noConfirmId)->keyBy('unit_id');
+        $this->assertNull($lines[$this->units['dos']->unit_id]->sol_counted_qty, 'Dos TETAP null tanpa konfirmasi -- tidak ada gulung otomatis lagi');
+        $this->assertSame(1000, (int) $lines[$this->units['pcs']->unit_id]->sol_counted_qty, 'Piece tersimpan 1000 apa adanya');
+
+        // Dengan konfirmasi ('full'), tergulung persis seperti yang ditampilkan popup.
+        $confirmed = $this->insertOpname($items, ['rollup_decision' => 'full']);
+        $confirmedId = (int) $confirmed->json('sto_id');
+        $lines2 = StockOpnameLine::getLines($confirmedId)->keyBy('unit_id');
+        $this->assertSame(173, (int) $lines2[$this->units['dos']->unit_id]->sol_counted_qty);
+        $this->assertSame(4, (int) $lines2[$this->units['pcs']->unit_id]->sol_counted_qty);
     }
 
     public function test_lanjut_creates_the_document_in_one_shot_with_full_rollup(): void

--- a/tests/Workflow/StockOpnameRollupConfirmTest.php
+++ b/tests/Workflow/StockOpnameRollupConfirmTest.php
@@ -36,15 +36,30 @@ use Tests\TestCase;
  * dengan rollup_decision='full'. insertStockOpname() sendiri sekarang selalu single-shot lagi
  * (tidak ada lagi jalur tulis-dulu-tanya-nanti).
  *
+ * >>> GANTI KEPUTUSAN 2026-09-05 (hari yang sama, follow-up KEDUA) <<< sempat ada fix yang
+ * mengecualikan produk yang SAMA SEKALI tidak disentuh staf dari deteksi gulung -- user
+ * membatalkan itu: memang SENGAJA produk yang tidak disentuh tetap dievaluasi murni dari stok
+ * sistemnya (dipakai untuk menangkap data lama yang sudah tidak kanonik di database). Akar
+ * masalah SEBENARNYA dari bug report "3 baris jadi 1 sesudah draft" bukan di situ, tapi karena
+ * .btn-ajukan memakai keepSparse=true (cuma baris yang diisi) untuk pratinjau MAUPUN draft-save
+ * di baliknya, beda dari .btn-save yang selalu memakai katalog PENUH -- popup jadi tidak
+ * konsisten tergantung baris mana yang kebetulan disimpan ke draft. Fix: .btn-ajukan sekarang
+ * SELALU memakai keepSparse=false juga (baik untuk pratinjau maupun draft-save di baliknya) --
+ * "Ajukan" = menerbitkan dokumen, jadi harus memperlakukan seluruh katalog sebagai final, persis
+ * semangat .btn-save. .btn-save-draft (tombol "Simpan sebagai Draft" eksplisit) TETAP
+ * keepSparse=true -- itu memang "simpan progres saja", bukan menerbitkan.
+ *
  * Skenario di sini:
  *  1. /previewStockOpnameRollup mendeteksi peluang gulung (Dos diisi, Piece TIDAK, existing Piece
  *     > 1 ratio Dos) TANPA MENULIS APA PUN -- tidak ada StockOpname/StockOpnameLine yang tercipta.
- *  2. rollup_decision diabaikan/'skip' (mis. staf klik Batal, TIDAK melanjutkan ke
+ *  2. Produk yang SAMA SEKALI tidak disentuh staf TETAP jadi kandidat kalau stok sistemnya sendiri
+ *     tidak kanonik -- ini disengaja, bukan bug.
+ *  3. rollup_decision diabaikan/'skip' (mis. staf klik Batal, TIDAK melanjutkan ke
  *     insertStockOpname() sama sekali) -> tidak ada dokumen yang tercipta sama sekali.
- *  3. rollup_decision='full' (staf klik Lanjut) -> insertStockOpname() single-shot langsung
+ *  4. rollup_decision='full' (staf klik Lanjut) -> insertStockOpname() single-shot langsung
  *     menggulung penuh, Piece ikut dilipat ke Dos.
- *  4. submitStockOpname() (ajukan draft) menerima rollup_decision dengan cara yang sama.
- *  5. Gudang ECERAN: /previewStockOpnameRollup tidak pernah mendeteksi peluang di sana.
+ *  5. submitStockOpname() (ajukan draft) menerima rollup_decision dengan cara yang sama.
+ *  6. Gudang ECERAN: /previewStockOpnameRollup tidak pernah mendeteksi peluang di sana.
  */
 class StockOpnameRollupConfirmTest extends TestCase
 {
@@ -186,27 +201,20 @@ class StockOpnameRollupConfirmTest extends TestCase
     }
 
     /**
-     * Bug report user 2026-09-05: ajukan langsung (tanpa draft) -> popup menampilkan 3 baris
-     * termasuk baris yang benar-benar diisi. Simpan sebagai draft (cuma baris yang diisi ikut
-     * tersimpan, sesuai desain) -> buka lagi & ajukan ulang -> cuma 1 baris yang tersisa di
-     * popup. Akar masalah: .btn-save mengirim SELURUH katalog yang sedang tampil di tabel (bukan
-     * cuma yang diisi -- itu memang disengaja untuk dokumen non-draft), dan
-     * UnitRollUp::collapseFull() tidak punya guard "produk ini tidak disentuh sama sekali" --
-     * jadi produk APA PUN yang kebetulan sedang ter-render DAN kebetulan stok sistemnya sendiri
-     * tidak kanonik (mis. dari data lama) ikut ditawarkan sebagai "peluang gulung", padahal staf
-     * tidak pernah menyentuhnya. Daftarnya jadi berbeda-beda tergantung produk mana yang
-     * kebetulan ter-render (katalog penuh vs cuma baris draft yang tersimpan), bukan berdasarkan
-     * input staf -- persis simtom yang dilaporkan.
+     * Keputusan user 2026-09-05: produk yang SAMA SEKALI tidak disentuh staf TETAP jadi kandidat
+     * gulung kalau stok sistemnya sendiri sudah tidak kanonik -- dipakai untuk menangkap data
+     * lama yang salah di database (mis. 104 pcs padahal 1 DOS = 12 pcs), bukan cuma satuan yang
+     * staf baru ketik. Ini kebalikan dari fix yang sempat dipasang sehari sebelumnya (dan
+     * dibatalkan hari yang sama) -- lihat docblock class ini.
      */
-    public function test_an_entirely_untouched_product_is_never_a_rollup_candidate_even_with_noncanonical_stock(): void
+    public function test_an_entirely_untouched_product_is_still_a_rollup_candidate_when_its_own_stock_is_noncanonical(): void
     {
         $this->actingAsSuperAdminStaff();
 
         // Produk yang BENAR-BENAR diisi staf.
         $touched = $this->makeLadderedItem(dosStock: 90, pcsStock: 104);
-        // Produk LAIN yang kebetulan sedang ter-render di tabel (mis. katalog penuh saat create
-        // langsung) tapi TIDAK PERNAH disentuh staf sama sekali -- stok sistemnya sendiri sudah
-        // tidak kanonik (104 pcs > 1 ratio Dos), persis kondisi yang memicu bug.
+        // Produk LAIN yang sedang ter-render di tabel (katalog penuh) tapi TIDAK PERNAH disentuh
+        // staf sama sekali -- stok sistemnya sendiri sudah tidak kanonik (30 pcs > 1 ratio Dos).
         $untouched = $this->makeLadderedItem(dosStock: 5, pcsStock: 30, ratio: 12);
 
         $items = array_merge(
@@ -224,9 +232,17 @@ class StockOpnameRollupConfirmTest extends TestCase
         $response = $this->preview($items);
         $response->assertStatus(200);
 
-        $candidates = $response->json('rollup_candidates');
-        $this->assertCount(1, $candidates, 'produk yang tidak disentuh staf tidak boleh ikut jadi kandidat gulung');
-        $this->assertSame($touched->product_variant_id, $candidates[0]['product_variant_id']);
+        $candidates = collect($response->json('rollup_candidates'))->keyBy('product_variant_id');
+        $this->assertCount(2, $candidates, 'produk yang tidak disentuh staf tetap harus jadi kandidat kalau stoknya tidak kanonik');
+
+        $untouchedCandidate = $candidates[$untouched->product_variant_id];
+        // 5 Dos + 30 pcs (existing, tidak diisi) = 60 + 30 = 90 pcs = 7 DOS + 6 pcs kanonik --
+        // proyeksi MURNI dari stok sistem, staf tidak mengetik apa pun untuk produk ini.
+        $changes = collect($untouchedCandidate['changes'])->keyBy('unit_id');
+        $this->assertSame(5, $changes[$this->units['dos']->unit_id]['before']);
+        $this->assertSame(7, $changes[$this->units['dos']->unit_id]['after']);
+        $this->assertSame(30, $changes[$this->units['pcs']->unit_id]['before']);
+        $this->assertSame(6, $changes[$this->units['pcs']->unit_id]['after']);
     }
 
     public function test_batal_never_touches_the_database_at_all(): void
@@ -324,6 +340,70 @@ class StockOpnameRollupConfirmTest extends TestCase
         $lines = StockOpnameLine::getLines($stoId)->keyBy('unit_id');
         $this->assertSame(101, (int) $lines[$this->units['dos']->unit_id]->sol_counted_qty);
         $this->assertSame(8, (int) $lines[$this->units['pcs']->unit_id]->sol_counted_qty);
+    }
+
+    /**
+     * Bug report user 2026-09-05: ajukan langsung (tanpa draft) -> popup menampilkan 3 baris.
+     * Simpan sebagai draft (cuma baris yang diisi ikut tersimpan, sesuai desain) -> buka lagi &
+     * ajukan ulang -> cuma 1 baris yang tersisa di popup, padahal seharusnya tetap 3.
+     *
+     * Akar masalah SEBENARNYA (bukan di deteksi produk tak tersentuh -- itu memang disengaja,
+     * lihat test di atas): CreateStockOpname.js's .btn-ajukan memakai keepSparse=true untuk
+     * pratinjau (JUGA untuk draft-save di baliknya), beda dari .btn-save yang selalu memakai
+     * katalog PENUH -- jadi payload yang dikirim ke /previewStockOpnameRollup beda tergantung
+     * jalur, bukan konsisten. Fix-nya di JS (.btn-ajukan sekarang SELALU keepSparse=false, sama
+     * seperti .btn-save) -- di level backend ini, buktikan bahwa SELAMA payload yang dikirim
+     * KONSISTEN (katalog penuh, apa pun yang sudah/belum tersimpan sebagai draft), hasil
+     * previewnya SAMA -- tidak bergantung pada apa yang kebetulan sudah dipersist ke DB.
+     */
+    public function test_preview_result_is_identical_before_and_after_a_sparse_draft_save_when_the_same_full_payload_is_sent(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $touched = $this->makeLadderedItem(dosStock: 90, pcsStock: 104);
+        $untouchedA = $this->makeLadderedItem(dosStock: 5, pcsStock: 30, ratio: 12);
+        $untouchedB = $this->makeLadderedItem(dosStock: 3, pcsStock: 50, ratio: 12);
+
+        $fullCatalogPayload = fn () => array_merge(
+            $this->dosOnlyItemPayload($touched, 93),
+            [[
+                'product_id' => $untouchedA->product_id,
+                'product_variant_id' => $untouchedA->product_variant_id,
+                'units' => [
+                    ['unit_id' => $this->units['dos']->unit_id, 'system_qty' => 0, 'real_qty' => null],
+                    ['unit_id' => $this->units['pcs']->unit_id, 'system_qty' => 0, 'real_qty' => null],
+                ],
+            ], [
+                'product_id' => $untouchedB->product_id,
+                'product_variant_id' => $untouchedB->product_variant_id,
+                'units' => [
+                    ['unit_id' => $this->units['dos']->unit_id, 'system_qty' => 0, 'real_qty' => null],
+                    ['unit_id' => $this->units['pcs']->unit_id, 'system_qty' => 0, 'real_qty' => null],
+                ],
+            ]],
+        );
+
+        // 1. Ajukan langsung, belum pernah disimpan sebagai draft -- payload katalog penuh.
+        $first = $this->preview($fullCatalogPayload());
+        $first->assertStatus(200);
+        $firstIds = collect($first->json('rollup_candidates'))->pluck('product_variant_id')->sort()->values();
+        $this->assertCount(3, $firstIds, 'ketiga produk (1 diisi + 2 tidak kanonik) harus jadi kandidat');
+
+        // 2. Simpan sebagai draft -- SPARSE, cuma baris yang diisi staf yang tersimpan (desain
+        // yang tetap dipertahankan, dikonfirmasi user).
+        $draft = $this->insertOpname($this->dosOnlyItemPayload($touched, 93), ['is_draft' => 1]);
+        $draft->assertStatus(200);
+        $stoId = (int) $draft->json('sto_id');
+        $draftProductIds = StockOpnameLine::getLines($stoId)->pluck('product_variant_id')->unique();
+        $this->assertCount(1, $draftProductIds, 'draft cuma menyimpan produk yang diisi, bukan seluruh katalog');
+
+        // 3. Buka lagi & ajukan ulang -- JS mengirim katalog PENUH lagi (bukan cuma yang
+        // tersimpan di draft), jadi hasilnya harus SAMA PERSIS dengan langkah 1.
+        $second = $this->preview($fullCatalogPayload());
+        $second->assertStatus(200);
+        $secondIds = collect($second->json('rollup_candidates'))->pluck('product_variant_id')->sort()->values();
+
+        $this->assertSame($firstIds->all(), $secondIds->all(), 'proyeksi rollup harus sama persis sebelum dan sesudah draft disimpan');
     }
 
     public function test_retail_warehouse_never_offers_rollup_confirmation(): void

--- a/tests/Workflow/StockOpnameRollupConfirmTest.php
+++ b/tests/Workflow/StockOpnameRollupConfirmTest.php
@@ -181,6 +181,9 @@ class StockOpnameRollupConfirmTest extends TestCase
         $response = $this->preview($this->dosOnlyItemPayload($v, 93));
         $response->assertStatus(200);
 
+        // Deteksi SELALU jalan apa adanya, tidak pernah dipengaruhi ROLLUP_PROJECTION_ENABLED --
+        // flag itu cuma soal tampilan popup (lihat show_popup di bawah), bukan deteksi/gulungnya
+        // sendiri (koreksi 2026-09-06 setelah salah paham pertama).
         $candidates = $response->json('rollup_candidates');
         $this->assertCount(1, $candidates);
         $this->assertSame($v->product_variant_id, $candidates[0]['product_variant_id']);
@@ -265,17 +268,19 @@ class StockOpnameRollupConfirmTest extends TestCase
         $this->assertSame(104, (int) ProductStock::where('product_variant_id', $v->product_variant_id)->where('unit_id', $this->units['pcs']->unit_id)->value('ps_stock'));
     }
 
-    public function test_insert_without_rollup_decision_applies_no_rollup_at_all(): void
+    public function test_insert_with_explicit_skip_decision_applies_no_rollup_at_all(): void
     {
         $this->actingAsSuperAdminStaff();
 
         $v = $this->makeLadderedItem(dosStock: 90, pcsStock: 104);
         $items = $this->dosOnlyItemPayload($v, 93);
 
-        // Tidak ada rollup_decision dikirim -- pemanggil yang tidak lewat preview sama sekali
-        // (mis. panggilan API langsung) tidak pernah diam-diam menggulung apa pun, bahkan yang
-        // dulu "otomatis aman" sekalipun (keputusan user 2026-09-06).
-        $response = $this->insertOpname($items);
+        // rollup_decision='skip' EKSPLISIT (beda dari tidak membawa rollup_decision sama sekali,
+        // yang perilakunya bergantung OpnameLifecycle::ROLLUP_PROJECTION_ENABLED -- lihat
+        // test_insert_without_an_explicit_decision_follows_the_show_popup_flag) -- tidak pernah
+        // diam-diam menggulung apa pun, bahkan yang dulu "otomatis aman" sekalipun (keputusan
+        // user 2026-09-06).
+        $response = $this->insertOpname($items, ['rollup_decision' => 'skip']);
         $response->assertStatus(200);
         $response->assertJson(['status' => 1]);
         $stoId = (int) $response->json('sto_id');
@@ -329,8 +334,11 @@ class StockOpnameRollupConfirmTest extends TestCase
         $this->assertSame(1000, $changes[$this->units['pcs']->unit_id]['before']);
         $this->assertSame(4, $changes[$this->units['pcs']->unit_id]['after']);
 
-        // Tanpa konfirmasi ('full'), TIDAK ADA gulung sama sekali -- 1000 pcs tersimpan apa adanya.
-        $noConfirm = $this->insertOpname($items);
+        // Staf klik "Batal" secara eksplisit (rollup_decision='skip') -- TIDAK ADA gulung sama
+        // sekali, 1000 pcs tersimpan apa adanya. Ini beda dari "tidak membawa rollup_decision
+        // sama sekali", yang perilakunya bergantung OpnameLifecycle::ROLLUP_PROJECTION_ENABLED
+        // (lihat test_insert_without_an_explicit_decision_follows_the_show_popup_flag).
+        $noConfirm = $this->insertOpname($items, ['rollup_decision' => 'skip']);
         $noConfirmId = (int) $noConfirm->json('sto_id');
         $lines = StockOpnameLine::getLines($noConfirmId)->keyBy('unit_id');
         $this->assertNull($lines[$this->units['dos']->unit_id]->sol_counted_qty, 'Dos TETAP null tanpa konfirmasi -- tidak ada gulung otomatis lagi');
@@ -534,21 +542,55 @@ class StockOpnameRollupConfirmTest extends TestCase
     }
 
     /**
-     * Saklar utama popup (keputusan user 2026-09-06): OpnameLifecycle::ROLLUP_PROJECTION_ENABLED
-     * const biasa (bukan config/.env), jadi tidak bisa di-toggle aman di dalam test PHPUnit tanpa
-     * menulis ulang file sumbernya -- perilaku "false = popup tidak pernah tampil apa pun
-     * kondisinya" sudah diverifikasi manual sebelum commit ini (di percakapan, bukan lewat test
-     * otomatis): dengan const-nya sementara diset false, detectRollupOpportunitiesFromPayload()
-     * untuk skenario Piece=1000 (yang jelas-jelas punya peluang gulung, lihat
-     * test_filling_only_the_smallest_unit_now_also_requires_confirmation) membalas [] -- tidak
-     * ada satu kandidat pun. Test ini cuma memastikan flag-nya tidak sengaja ke-nonaktifkan lagi
-     * di kemudian hari (default harus tetap true).
+     * KOREKSI 2026-09-06 (salah paham pertama, dibetulkan user pada percakapan yang sama):
+     * ROLLUP_PROJECTION_ENABLED CUMA mengatur apakah popup DITAMPILKAN -- bukan apakah
+     * deteksi/gulungnya jalan. Deteksi SELALU jalan (lihat test-test di atas, tidak satu pun
+     * dibungkus kondisi flag lagi) -- yang berubah sesuai flag ini HANYA `show_popup` di respons
+     * /previewStockOpnameRollup. const biasa (bukan config/.env) per permintaan user, jadi
+     * test ini membaca nilainya APA ADANYA saat ini, tidak mengasumsikan true atau false.
      */
-    public function test_rollup_projection_flag_defaults_to_enabled(): void
+    public function test_preview_reports_the_current_show_popup_flag(): void
     {
-        $this->assertTrue(
+        $this->actingAsSuperAdminStaff();
+
+        $v = $this->makeLadderedItem(dosStock: 90, pcsStock: 104);
+        $response = $this->preview($this->dosOnlyItemPayload($v, 93));
+        $response->assertStatus(200);
+
+        $this->assertNotEmpty($response->json('rollup_candidates'), 'sanity: skenario ini memang punya peluang gulung');
+        $this->assertSame(
             \App\Support\StockOpname\OpnameLifecycle::ROLLUP_PROJECTION_ENABLED,
-            'ROLLUP_PROJECTION_ENABLED harus true secara default -- kalau memang mau dimatikan, ubah nilainya langsung di kode dan verifikasi manual seperti dijelaskan di docblock test ini',
+            $response->json('show_popup'),
+            'show_popup di respons preview harus persis mengikuti nilai const-nya saat ini',
         );
+    }
+
+    /**
+     * Tidak membawa rollup_decision SAMA SEKALI (beda dari 'skip' eksplisit, lihat test lain di
+     * atas) berarti pemanggil tidak pernah lewat preview -- defaultnya mengikuti
+     * ROLLUP_PROJECTION_ENABLED: kalau flag-nya false ("jangan tampilkan popup, langsung anggap
+     * staf klik Lanjut"), gulung PENUH tetap diterapkan otomatis walau tidak ada rollup_decision
+     * apa pun yang dikirim. Kalau flag-nya true, tetap default aman ('skip', tidak digulung)
+     * seperti sebelum flag ini ada.
+     */
+    public function test_insert_without_an_explicit_decision_follows_the_show_popup_flag(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $v = $this->makeLadderedItem(dosStock: 90, pcsStock: 104);
+        $items = $this->dosOnlyItemPayload($v, 93);
+
+        $response = $this->insertOpname($items);
+        $response->assertStatus(200);
+        $stoId = (int) $response->json('sto_id');
+        $lines = StockOpnameLine::getLines($stoId)->keyBy('unit_id');
+
+        if (\App\Support\StockOpname\OpnameLifecycle::ROLLUP_PROJECTION_ENABLED) {
+            $this->assertSame(93, (int) $lines[$this->units['dos']->unit_id]->sol_counted_qty, 'flag ON -> default aman, tidak digulung tanpa keputusan eksplisit');
+            $this->assertNull($lines[$this->units['pcs']->unit_id]->sol_counted_qty);
+        } else {
+            $this->assertSame(101, (int) $lines[$this->units['dos']->unit_id]->sol_counted_qty, 'flag OFF -> otomatis "Lanjut", tetap tergulung penuh walau tidak ada rollup_decision');
+            $this->assertSame(8, (int) $lines[$this->units['pcs']->unit_id]->sol_counted_qty);
+        }
     }
 }

--- a/tests/Workflow/StockOpnameRollupConfirmTest.php
+++ b/tests/Workflow/StockOpnameRollupConfirmTest.php
@@ -145,7 +145,19 @@ class StockOpnameRollupConfirmTest extends TestCase
         $response->assertJson(['status' => 2]);
         $stoId = (int) $response->json('sto_id');
         $this->assertNotSame(0, $stoId);
-        $this->assertSame(1, count($response->json('rollup_candidates')));
+        $candidates = $response->json('rollup_candidates');
+        $this->assertCount(1, $candidates);
+        $this->assertSame($v->product_variant_id, $candidates[0]['product_variant_id']);
+        // Rincian per satuan (2026-09-04): popup harus bisa menunjukkan "DOS 101 <- 93" dan
+        // "PCS 8 <- (tidak dihitung)" tanpa panggilan tambahan.
+        $changesByUnit = collect($candidates[0]['changes'])->keyBy('unit_id');
+        $dosChange = $changesByUnit[$this->units['dos']->unit_id];
+        $this->assertSame(93, $dosChange['before']);
+        $this->assertSame(101, $dosChange['after']);
+        $this->assertSame($this->units['dos']->unit_short_name, $dosChange['unit_short_name']);
+        $pcsChange = $changesByUnit[$this->units['pcs']->unit_id];
+        $this->assertSame(104, $pcsChange['before']);
+        $this->assertSame(8, $pcsChange['after']);
 
         // Dokumen SUDAH tersimpan (baris ditulis) tapi BELUM terbit -- identitas belum dibekukan
         // (publish() belum jalan), sesuai desain "belum ada keputusan staf".

--- a/tests/Workflow/StockOpnameRollupConfirmTest.php
+++ b/tests/Workflow/StockOpnameRollupConfirmTest.php
@@ -532,4 +532,23 @@ class StockOpnameRollupConfirmTest extends TestCase
         $response->assertStatus(200);
         $this->assertSame([], $response->json('rollup_candidates'), 'gudang eceran tidak pernah punya peluang gulung');
     }
+
+    /**
+     * Saklar utama popup (keputusan user 2026-09-06): OpnameLifecycle::ROLLUP_PROJECTION_ENABLED
+     * const biasa (bukan config/.env), jadi tidak bisa di-toggle aman di dalam test PHPUnit tanpa
+     * menulis ulang file sumbernya -- perilaku "false = popup tidak pernah tampil apa pun
+     * kondisinya" sudah diverifikasi manual sebelum commit ini (di percakapan, bukan lewat test
+     * otomatis): dengan const-nya sementara diset false, detectRollupOpportunitiesFromPayload()
+     * untuk skenario Piece=1000 (yang jelas-jelas punya peluang gulung, lihat
+     * test_filling_only_the_smallest_unit_now_also_requires_confirmation) membalas [] -- tidak
+     * ada satu kandidat pun. Test ini cuma memastikan flag-nya tidak sengaja ke-nonaktifkan lagi
+     * di kemudian hari (default harus tetap true).
+     */
+    public function test_rollup_projection_flag_defaults_to_enabled(): void
+    {
+        $this->assertTrue(
+            \App\Support\StockOpname\OpnameLifecycle::ROLLUP_PROJECTION_ENABLED,
+            'ROLLUP_PROJECTION_ENABLED harus true secara default -- kalau memang mau dimatikan, ubah nilainya langsung di kode dan verifikasi manual seperti dijelaskan di docblock test ini',
+        );
+    }
 }

--- a/tests/Workflow/StockOpnameRollupConfirmTest.php
+++ b/tests/Workflow/StockOpnameRollupConfirmTest.php
@@ -1,0 +1,271 @@
+<?php
+
+namespace Tests\Workflow;
+
+use App\Models\Category;
+use App\Models\Product;
+use App\Models\ProductRelation;
+use App\Models\ProductStock;
+use App\Models\ProductVariant;
+use App\Models\StockOpname;
+use App\Models\StockOpnameLine;
+use App\Models\Unit;
+use App\Models\Warehouse;
+use App\Models\WarehouseType;
+use Illuminate\Support\Facades\DB;
+use Tests\Support\ActingAsStaff;
+use Tests\TestCase;
+
+/**
+ * Bug report user 2026-09-04: "Posisi awal stok Produk A = 90 Dos, 104 Piece. Aku stok opname
+ * ubah dos aja jadi 93 Dos. Saat create dan print document jadinya 93 Dos, 104 Piece."
+ *
+ * Investigasi: angka itu SUDAH BENAR per aturan GH #78 (UnitRollUp::collapse()'s docblock --
+ * jangan pernah mengarang angka satuan yang tidak pernah diperiksa staf, Piece TETAP 104 apa
+ * adanya). Tapi user secara eksplisit minta ini ditawarkan sebagai PILIHAN eksplisit di titik
+ * dokumen terbit (insertStockOpname is_draft=0, atau submitStockOpname) -- bukan otomatis --
+ * lewat popup konfirmasi. Baca App\Support\StockOpname\OpnameLifecycle::detectRollupOpportunities()/
+ * rollUpUnitsFull() untuk desainnya.
+ *
+ * Ketiga skenario di sini:
+ *  1. Ada peluang gulung (Dos diisi, Piece TIDAK, existing Piece > 1 ratio Dos) -> endpoint
+ *     membalas status=2 + daftar produk, TIDAK menulis apa pun ke stock_opname_lines yang
+ *     mengubah publish/rollup, dokumen sudah tersimpan tapi belum terbit.
+ *  2. Staf menjawab "Batal" (rollup_decision=skip) -> perilaku SEBELUMNYA (parsial, aman) --
+ *     Piece tetap NULL/tidak tersentuh, sama seperti sebelum fitur ini ada.
+ *  3. Staf menjawab "Lanjut" (rollup_decision=full) -> Piece ikut dilipat ke Dos.
+ *  4. Gudang ECERAN: tidak pernah ditawari popup sama sekali (rollUpUnits() pun sudah
+ *     mengecualikan eceran, lihat OpnameLifecycle::isRetailWarehouse()).
+ */
+class StockOpnameRollupConfirmTest extends TestCase
+{
+    use ActingAsStaff;
+
+    private array $units = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $rows = Unit::where('status', 1)->limit(2)->get();
+        $this->assertGreaterThanOrEqual(2, $rows->count(), 'fixture butuh minimal 2 satuan aktif');
+        $this->units = ['dos' => $rows[0], 'pcs' => $rows[1]];
+    }
+
+    private function staffId(): int
+    {
+        return (int) DB::table('staffs')->where('status', 1)->value('staff_id');
+    }
+
+    private function categoryId(): int
+    {
+        $id = (int) DB::table('categories')->where('status', 1)->value('category_id');
+        if ($id) {
+            return $id;
+        }
+
+        $c = new Category();
+        $c->category_name = 'Opname Rollup Confirm Test Category';
+        $c->status = 1;
+        $c->save();
+
+        return $c->category_id;
+    }
+
+    /** Produk + ladder (1 DOS = $ratio pcs) + stok awal di kedua satuan, gudang utama (id 1). */
+    private function makeLadderedItem(int $dosStock, int $pcsStock, int $ratio = 12, ?int $warehouseId = 1): ProductVariant
+    {
+        $product = new Product();
+        $product->product_name = 'ROLLUP CONFIRM TEST PRODUCT';
+        $product->category_id = $this->categoryId();
+        $product->product_unit = json_encode([$this->units['dos']->unit_id, $this->units['pcs']->unit_id]);
+        $product->unit_id = $this->units['dos']->unit_id;
+        $product->status = 1;
+        $product->save();
+
+        $variant = new ProductVariant();
+        $variant->product_id = $product->product_id;
+        $variant->product_variant_name = 'ROLLUP-CONFIRM-'.uniqid();
+        $variant->product_variant_sku = 'RUC-'.uniqid();
+        $variant->product_variant_price = 0;
+        $variant->status = 1;
+        $variant->save();
+
+        foreach ([['dos', $dosStock], ['pcs', $pcsStock]] as [$key, $qty]) {
+            $s = new ProductStock();
+            $s->product_id = $product->product_id;
+            $s->product_variant_id = $variant->product_variant_id;
+            $s->unit_id = $this->units[$key]->unit_id;
+            $s->warehouse_id = $warehouseId;
+            $s->ps_stock = $qty;
+            $s->status = 1;
+            $s->save();
+        }
+
+        $relation = new ProductRelation();
+        $relation->product_variant_id = $variant->product_variant_id;
+        $relation->pr_unit_id_1 = $this->units['dos']->unit_id; // besar
+        $relation->pr_unit_value_1 = 1;
+        $relation->pr_unit_id_2 = $this->units['pcs']->unit_id; // kecil
+        $relation->pr_unit_value_2 = $ratio;
+        $relation->status = 1;
+        $relation->save();
+
+        return $variant;
+    }
+
+    /** Insert dokumen: cuma Dos yang diisi ($dosQty), Piece dikirim sebagai unit_id + real_qty:null. */
+    private function insertDosOnlyOpname(ProductVariant $v, int $dosQty, array $extra = []): \Illuminate\Testing\TestResponse
+    {
+        return $this->post('/insertStockOpname', array_merge([
+            'sto_date' => now()->toDateString(),
+            'staff_id' => $this->staffId(),
+            'category_id' => $this->categoryId(),
+            'sto_notes' => 'Rollup confirm test',
+            'is_draft' => 0,
+            'item' => json_encode([[
+                'product_id' => $v->product_id,
+                'product_variant_id' => $v->product_variant_id,
+                'units' => [
+                    ['unit_id' => $this->units['dos']->unit_id, 'system_qty' => 0, 'real_qty' => $dosQty],
+                    ['unit_id' => $this->units['pcs']->unit_id, 'system_qty' => 0, 'real_qty' => null],
+                ],
+            ]]),
+        ], $extra));
+    }
+
+    public function test_direct_publish_detects_and_offers_rollup_confirmation(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        // Meniru laporan bug: 90 Dos, 104 Piece -- staf cuma mengoreksi Dos jadi 93.
+        $v = $this->makeLadderedItem(dosStock: 90, pcsStock: 104);
+
+        $response = $this->insertDosOnlyOpname($v, 93);
+        $response->assertStatus(200);
+        $response->assertJson(['status' => 2]);
+        $stoId = (int) $response->json('sto_id');
+        $this->assertNotSame(0, $stoId);
+        $this->assertSame(1, count($response->json('rollup_candidates')));
+
+        // Dokumen SUDAH tersimpan (baris ditulis) tapi BELUM terbit -- identitas belum dibekukan
+        // (publish() belum jalan), sesuai desain "belum ada keputusan staf".
+        $sto = StockOpname::find($stoId);
+        $this->assertNull($sto->sto_staff_name, 'publish() belum boleh jalan sebelum staf menjawab popup');
+        $lines = StockOpnameLine::getLines($stoId)->keyBy('unit_id');
+        $this->assertSame(93, (int) $lines[$this->units['dos']->unit_id]->sol_counted_qty);
+        $this->assertNull($lines[$this->units['pcs']->unit_id]->sol_counted_qty);
+    }
+
+    public function test_answering_batal_keeps_the_old_safe_partial_behavior(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $v = $this->makeLadderedItem(dosStock: 90, pcsStock: 104);
+        $first = $this->insertDosOnlyOpname($v, 93);
+        $stoId = (int) $first->json('sto_id');
+
+        // Panggilan kedua: staf klik "Batal" -> rollup_decision=skip, kirim ulang sto_id yang sama.
+        $second = $this->insertDosOnlyOpname($v, 93, [
+            'rollup_decision' => 'skip',
+            'sto_id' => $stoId,
+        ]);
+        $second->assertStatus(200);
+        $second->assertJson(['status' => 1, 'sto_id' => $stoId]);
+
+        $lines = StockOpnameLine::getLines($stoId)->keyBy('unit_id');
+        $this->assertSame(93, (int) $lines[$this->units['dos']->unit_id]->sol_counted_qty, 'Dos tetap 93, tidak berubah');
+        $this->assertNull($lines[$this->units['pcs']->unit_id]->sol_counted_qty, 'Piece TETAP null -- perilaku lama, tidak digulung');
+
+        $sto = StockOpname::find($stoId);
+        $this->assertNotNull($sto->sto_staff_name, 'publish() harus jalan setelah keputusan dijawab');
+
+        // ACC: cuma Dos yang tertulis ke ps_stock, Piece tidak tersentuh -- persis laporan bug user.
+        $accResp = $this->post('/accStockOpname', ['sto_id' => $stoId, 'item' => json_encode([['dummy' => 1]])]);
+        $accResp->assertOk();
+        $this->assertSame(93, (int) ProductStock::where('product_variant_id', $v->product_variant_id)->where('unit_id', $this->units['dos']->unit_id)->value('ps_stock'));
+        $this->assertSame(104, (int) ProductStock::where('product_variant_id', $v->product_variant_id)->where('unit_id', $this->units['pcs']->unit_id)->value('ps_stock'));
+    }
+
+    public function test_answering_lanjut_rolls_untouched_piece_into_dos(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        // 1 DOS = 12 pcs. 93 Dos (diisi) + 104 pcs (existing, tidak diisi) = 1116 + 104 = 1220 pcs
+        // = 101 DOS + 8 pcs kanonik.
+        $v = $this->makeLadderedItem(dosStock: 90, pcsStock: 104, ratio: 12);
+        $first = $this->insertDosOnlyOpname($v, 93);
+        $stoId = (int) $first->json('sto_id');
+
+        $second = $this->insertDosOnlyOpname($v, 93, [
+            'rollup_decision' => 'full',
+            'sto_id' => $stoId,
+        ]);
+        $second->assertStatus(200);
+        $second->assertJson(['status' => 1, 'sto_id' => $stoId]);
+
+        $lines = StockOpnameLine::getLines($stoId)->keyBy('unit_id');
+        $this->assertSame(101, (int) $lines[$this->units['dos']->unit_id]->sol_counted_qty, 'Dos ikut menyerap kelebihan Piece');
+        $this->assertSame(8, (int) $lines[$this->units['pcs']->unit_id]->sol_counted_qty, 'Piece jadi sisa kanonik, bukan NULL lagi');
+
+        $this->post('/accStockOpname', ['sto_id' => $stoId, 'item' => json_encode([['dummy' => 1]])])->assertOk();
+        $this->assertSame(101, (int) ProductStock::where('product_variant_id', $v->product_variant_id)->where('unit_id', $this->units['dos']->unit_id)->value('ps_stock'));
+        $this->assertSame(8, (int) ProductStock::where('product_variant_id', $v->product_variant_id)->where('unit_id', $this->units['pcs']->unit_id)->value('ps_stock'));
+    }
+
+    public function test_submit_stock_opname_offers_the_same_confirmation_for_a_draft(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $v = $this->makeLadderedItem(dosStock: 90, pcsStock: 104);
+        $draft = $this->insertDosOnlyOpname($v, 93, ['is_draft' => 1]);
+        $draft->assertStatus(200);
+        $draft->assertJson(['status' => 1]);
+        $stoId = (int) $draft->json('sto_id');
+
+        $first = $this->post('/submitStockOpname', ['sto_id' => $stoId]);
+        $first->assertStatus(200);
+        $first->assertJson(['status' => 2]);
+        $this->assertTrue((bool) StockOpname::find($stoId)->is_draft, 'belum ada keputusan -- draft belum diajukan');
+
+        $second = $this->post('/submitStockOpname', ['sto_id' => $stoId, 'rollup_decision' => 'full']);
+        $second->assertStatus(200);
+        $this->assertFalse((bool) StockOpname::find($stoId)->refresh()->is_draft);
+
+        $lines = StockOpnameLine::getLines($stoId)->keyBy('unit_id');
+        $this->assertSame(101, (int) $lines[$this->units['dos']->unit_id]->sol_counted_qty);
+        $this->assertSame(8, (int) $lines[$this->units['pcs']->unit_id]->sol_counted_qty);
+    }
+
+    public function test_retail_warehouse_never_offers_rollup_confirmation(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $type = WarehouseType::where('is_main_warehouse', '!=', 1)->first();
+        $warehouse = Warehouse::where('warehouse_type_id', $type->id ?? 0)->first();
+        if (! $type || ! $warehouse) {
+            $this->markTestSkipped('fixture butuh gudang eceran (warehouse_types.is_main_warehouse != 1)');
+        }
+
+        $v = $this->makeLadderedItem(dosStock: 90, pcsStock: 104, warehouseId: $warehouse->id);
+
+        $response = $this->post('/insertStockOpname', [
+            'sto_date' => now()->toDateString(),
+            'staff_id' => $this->staffId(),
+            'category_id' => $this->categoryId(),
+            'sto_notes' => 'Rollup confirm test (eceran)',
+            'is_draft' => 0,
+            'warehouse_id' => $warehouse->id,
+            'item' => json_encode([[
+                'product_id' => $v->product_id,
+                'product_variant_id' => $v->product_variant_id,
+                'units' => [
+                    ['unit_id' => $this->units['dos']->unit_id, 'system_qty' => 0, 'real_qty' => 93],
+                    ['unit_id' => $this->units['pcs']->unit_id, 'system_qty' => 0, 'real_qty' => null],
+                ],
+            ]]),
+        ]);
+
+        $response->assertStatus(200);
+        $response->assertJson(['status' => 1], 'gudang eceran tidak pernah ditawari popup gulung');
+    }
+}

--- a/tests/Workflow/StockOpnameRollupConfirmTest.php
+++ b/tests/Workflow/StockOpnameRollupConfirmTest.php
@@ -22,20 +22,29 @@ use Tests\TestCase;
  *
  * Investigasi: angka itu SUDAH BENAR per aturan GH #78 (UnitRollUp::collapse()'s docblock --
  * jangan pernah mengarang angka satuan yang tidak pernah diperiksa staf, Piece TETAP 104 apa
- * adanya). Tapi user secara eksplisit minta ini ditawarkan sebagai PILIHAN eksplisit di titik
- * dokumen terbit (insertStockOpname is_draft=0, atau submitStockOpname) -- bukan otomatis --
- * lewat popup konfirmasi. Baca App\Support\StockOpname\OpnameLifecycle::detectRollupOpportunities()/
- * rollUpUnitsFull() untuk desainnya.
+ * adanya). User minta ini ditawarkan sebagai PILIHAN eksplisit di titik dokumen terbit lewat
+ * popup konfirmasi.
  *
- * Ketiga skenario di sini:
- *  1. Ada peluang gulung (Dos diisi, Piece TIDAK, existing Piece > 1 ratio Dos) -> endpoint
- *     membalas status=2 + daftar produk, TIDAK menulis apa pun ke stock_opname_lines yang
- *     mengubah publish/rollup, dokumen sudah tersimpan tapi belum terbit.
- *  2. Staf menjawab "Batal" (rollup_decision=skip) -> perilaku SEBELUMNYA (parsial, aman) --
- *     Piece tetap NULL/tidak tersentuh, sama seperti sebelum fitur ini ada.
- *  3. Staf menjawab "Lanjut" (rollup_decision=full) -> Piece ikut dilipat ke Dos.
- *  4. Gudang ECERAN: tidak pernah ditawari popup sama sekali (rollUpUnits() pun sudah
- *     mengecualikan eceran, lihat OpnameLifecycle::isRetailWarehouse()).
+ * >>> GANTI DESAIN 2026-09-05 <<< (follow-up dari user setelah popup pertama terpasang):
+ * Versi pertama (2026-09-04) menulis dokumen (header + baris) DULU cuma untuk bisa mengecek
+ * peluang gulung, baru membalas status=2 kalau ada -- artinya kalau staf klik "Batal", dokumen
+ * yang sudah ditulis itu tetap disimpan (cuma tanpa gulung penuh). User bilang itu salah: klik
+ * "Batal" harus berarti BATAL AJUKAN SAMA SEKALI, tidak ada DB yang tersentuh. Sekarang deteksi
+ * dipisah total dari penulisan: /previewStockOpnameRollup (baca-saja, OpnameLifecycle::
+ * detectRollupOpportunitiesFromPayload()) dipanggil DULU dengan payload mentah dari form -- kalau
+ * staf klik Lanjut, browser BARU memanggil insertStockOpname()/submitStockOpname() sungguhan
+ * dengan rollup_decision='full'. insertStockOpname() sendiri sekarang selalu single-shot lagi
+ * (tidak ada lagi jalur tulis-dulu-tanya-nanti).
+ *
+ * Skenario di sini:
+ *  1. /previewStockOpnameRollup mendeteksi peluang gulung (Dos diisi, Piece TIDAK, existing Piece
+ *     > 1 ratio Dos) TANPA MENULIS APA PUN -- tidak ada StockOpname/StockOpnameLine yang tercipta.
+ *  2. rollup_decision diabaikan/'skip' (mis. staf klik Batal, TIDAK melanjutkan ke
+ *     insertStockOpname() sama sekali) -> tidak ada dokumen yang tercipta sama sekali.
+ *  3. rollup_decision='full' (staf klik Lanjut) -> insertStockOpname() single-shot langsung
+ *     menggulung penuh, Piece ikut dilipat ke Dos.
+ *  4. submitStockOpname() (ajukan draft) menerima rollup_decision dengan cara yang sama.
+ *  5. Gudang ECERAN: /previewStockOpnameRollup tidak pernah mendeteksi peluang di sana.
  */
 class StockOpnameRollupConfirmTest extends TestCase
 {
@@ -113,8 +122,27 @@ class StockOpnameRollupConfirmTest extends TestCase
         return $variant;
     }
 
-    /** Insert dokumen: cuma Dos yang diisi ($dosQty), Piece dikirim sebagai unit_id + real_qty:null. */
-    private function insertDosOnlyOpname(ProductVariant $v, int $dosQty, array $extra = []): \Illuminate\Testing\TestResponse
+    /** Payload item[]: cuma Dos yang diisi ($dosQty), Piece dikirim sebagai unit_id + real_qty:null. */
+    private function dosOnlyItemPayload(ProductVariant $v, int $dosQty): array
+    {
+        return [[
+            'product_id' => $v->product_id,
+            'product_variant_id' => $v->product_variant_id,
+            'units' => [
+                ['unit_id' => $this->units['dos']->unit_id, 'system_qty' => 0, 'real_qty' => $dosQty],
+                ['unit_id' => $this->units['pcs']->unit_id, 'system_qty' => 0, 'real_qty' => null],
+            ],
+        ]];
+    }
+
+    private function preview(array $items, array $extra = []): \Illuminate\Testing\TestResponse
+    {
+        return $this->post('/previewStockOpnameRollup', array_merge([
+            'item' => json_encode($items),
+        ], $extra));
+    }
+
+    private function insertOpname(array $items, array $extra = []): \Illuminate\Testing\TestResponse
     {
         return $this->post('/insertStockOpname', array_merge([
             'sto_date' => now()->toDateString(),
@@ -122,98 +150,105 @@ class StockOpnameRollupConfirmTest extends TestCase
             'category_id' => $this->categoryId(),
             'sto_notes' => 'Rollup confirm test',
             'is_draft' => 0,
-            'item' => json_encode([[
-                'product_id' => $v->product_id,
-                'product_variant_id' => $v->product_variant_id,
-                'units' => [
-                    ['unit_id' => $this->units['dos']->unit_id, 'system_qty' => 0, 'real_qty' => $dosQty],
-                    ['unit_id' => $this->units['pcs']->unit_id, 'system_qty' => 0, 'real_qty' => null],
-                ],
-            ]]),
+            'item' => json_encode($items),
         ], $extra));
     }
 
-    public function test_direct_publish_detects_and_offers_rollup_confirmation(): void
+    public function test_preview_detects_a_rollup_opportunity_without_writing_anything(): void
     {
         $this->actingAsSuperAdminStaff();
 
         // Meniru laporan bug: 90 Dos, 104 Piece -- staf cuma mengoreksi Dos jadi 93.
         $v = $this->makeLadderedItem(dosStock: 90, pcsStock: 104);
+        $stoCountBefore = StockOpname::count();
+        $lineCountBefore = StockOpnameLine::count();
 
-        $response = $this->insertDosOnlyOpname($v, 93);
+        $response = $this->preview($this->dosOnlyItemPayload($v, 93));
         $response->assertStatus(200);
-        $response->assertJson(['status' => 2]);
-        $stoId = (int) $response->json('sto_id');
-        $this->assertNotSame(0, $stoId);
+
         $candidates = $response->json('rollup_candidates');
         $this->assertCount(1, $candidates);
         $this->assertSame($v->product_variant_id, $candidates[0]['product_variant_id']);
-        // Rincian per satuan (2026-09-04): popup harus bisa menunjukkan "DOS 101 <- 93" dan
-        // "PCS 8 <- (tidak dihitung)" tanpa panggilan tambahan.
-        $changesByUnit = collect($candidates[0]['changes'])->keyBy('unit_id');
-        $dosChange = $changesByUnit[$this->units['dos']->unit_id];
+        // Rincian per satuan, diurutkan BESAR -> KECIL (keputusan user 2026-09-05: DOS di kiri).
+        $this->assertSame($this->units['dos']->unit_id, $candidates[0]['changes'][0]['unit_id']);
+        $dosChange = $candidates[0]['changes'][0];
         $this->assertSame(93, $dosChange['before']);
         $this->assertSame(101, $dosChange['after']);
         $this->assertSame($this->units['dos']->unit_short_name, $dosChange['unit_short_name']);
-        $pcsChange = $changesByUnit[$this->units['pcs']->unit_id];
+        $pcsChange = $candidates[0]['changes'][1];
+        $this->assertSame($this->units['pcs']->unit_id, $pcsChange['unit_id']);
         $this->assertSame(104, $pcsChange['before']);
         $this->assertSame(8, $pcsChange['after']);
 
-        // Dokumen SUDAH tersimpan (baris ditulis) tapi BELUM terbit -- identitas belum dibekukan
-        // (publish() belum jalan), sesuai desain "belum ada keputusan staf".
-        $sto = StockOpname::find($stoId);
-        $this->assertNull($sto->sto_staff_name, 'publish() belum boleh jalan sebelum staf menjawab popup');
-        $lines = StockOpnameLine::getLines($stoId)->keyBy('unit_id');
-        $this->assertSame(93, (int) $lines[$this->units['dos']->unit_id]->sol_counted_qty);
-        $this->assertNull($lines[$this->units['pcs']->unit_id]->sol_counted_qty);
+        // "Data bayangan" (keputusan user 2026-09-05): TIDAK ADA satu baris pun tertulis ke DB.
+        $this->assertSame($stoCountBefore, StockOpname::count(), 'preview tidak boleh membuat dokumen apa pun');
+        $this->assertSame($lineCountBefore, StockOpnameLine::count(), 'preview tidak boleh membuat baris apa pun');
     }
 
-    public function test_answering_batal_keeps_the_old_safe_partial_behavior(): void
+    public function test_batal_never_touches_the_database_at_all(): void
     {
         $this->actingAsSuperAdminStaff();
 
         $v = $this->makeLadderedItem(dosStock: 90, pcsStock: 104);
-        $first = $this->insertDosOnlyOpname($v, 93);
-        $stoId = (int) $first->json('sto_id');
+        $items = $this->dosOnlyItemPayload($v, 93);
+        $stoCountBefore = StockOpname::count();
+        $lineCountBefore = StockOpnameLine::count();
 
-        // Panggilan kedua: staf klik "Batal" -> rollup_decision=skip, kirim ulang sto_id yang sama.
-        $second = $this->insertDosOnlyOpname($v, 93, [
-            'rollup_decision' => 'skip',
-            'sto_id' => $stoId,
-        ]);
-        $second->assertStatus(200);
-        $second->assertJson(['status' => 1, 'sto_id' => $stoId]);
+        // Staf melihat popup lewat preview, lalu klik "Batal" -- browser TIDAK PERNAH memanggil
+        // insertStockOpname() sama sekali. Cukup pastikan preview sendiri tidak menulis apa pun
+        // (sudah dites di atas) dan tidak ada endpoint lain yang perlu dipanggil untuk "batal".
+        $this->preview($items)->assertStatus(200);
+
+        $this->assertSame($stoCountBefore, StockOpname::count());
+        $this->assertSame($lineCountBefore, StockOpnameLine::count());
+        $this->assertSame(90, (int) ProductStock::where('product_variant_id', $v->product_variant_id)->where('unit_id', $this->units['dos']->unit_id)->value('ps_stock'));
+        $this->assertSame(104, (int) ProductStock::where('product_variant_id', $v->product_variant_id)->where('unit_id', $this->units['pcs']->unit_id)->value('ps_stock'));
+    }
+
+    public function test_insert_without_rollup_decision_defaults_to_the_old_safe_partial_behavior(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $v = $this->makeLadderedItem(dosStock: 90, pcsStock: 104);
+        $items = $this->dosOnlyItemPayload($v, 93);
+
+        // Tidak ada rollup_decision dikirim -- default 'skip' (pemanggil yang tidak lewat preview
+        // sama sekali, mis. panggilan API langsung) tidak pernah diam-diam menggulung penuh.
+        $response = $this->insertOpname($items);
+        $response->assertStatus(200);
+        $response->assertJson(['status' => 1]);
+        $stoId = (int) $response->json('sto_id');
 
         $lines = StockOpnameLine::getLines($stoId)->keyBy('unit_id');
         $this->assertSame(93, (int) $lines[$this->units['dos']->unit_id]->sol_counted_qty, 'Dos tetap 93, tidak berubah');
         $this->assertNull($lines[$this->units['pcs']->unit_id]->sol_counted_qty, 'Piece TETAP null -- perilaku lama, tidak digulung');
 
         $sto = StockOpname::find($stoId);
-        $this->assertNotNull($sto->sto_staff_name, 'publish() harus jalan setelah keputusan dijawab');
+        $this->assertNotNull($sto->sto_staff_name, 'publish() harus tetap jalan untuk dokumen non-draft');
 
         // ACC: cuma Dos yang tertulis ke ps_stock, Piece tidak tersentuh -- persis laporan bug user.
-        $accResp = $this->post('/accStockOpname', ['sto_id' => $stoId, 'item' => json_encode([['dummy' => 1]])]);
-        $accResp->assertOk();
+        $this->post('/accStockOpname', ['sto_id' => $stoId, 'item' => json_encode([['dummy' => 1]])])->assertOk();
         $this->assertSame(93, (int) ProductStock::where('product_variant_id', $v->product_variant_id)->where('unit_id', $this->units['dos']->unit_id)->value('ps_stock'));
         $this->assertSame(104, (int) ProductStock::where('product_variant_id', $v->product_variant_id)->where('unit_id', $this->units['pcs']->unit_id)->value('ps_stock'));
     }
 
-    public function test_answering_lanjut_rolls_untouched_piece_into_dos(): void
+    public function test_lanjut_creates_the_document_in_one_shot_with_full_rollup(): void
     {
         $this->actingAsSuperAdminStaff();
 
         // 1 DOS = 12 pcs. 93 Dos (diisi) + 104 pcs (existing, tidak diisi) = 1116 + 104 = 1220 pcs
         // = 101 DOS + 8 pcs kanonik.
         $v = $this->makeLadderedItem(dosStock: 90, pcsStock: 104, ratio: 12);
-        $first = $this->insertDosOnlyOpname($v, 93);
-        $stoId = (int) $first->json('sto_id');
+        $items = $this->dosOnlyItemPayload($v, 93);
+        $stoCountBefore = StockOpname::count();
 
-        $second = $this->insertDosOnlyOpname($v, 93, [
-            'rollup_decision' => 'full',
-            'sto_id' => $stoId,
-        ]);
-        $second->assertStatus(200);
-        $second->assertJson(['status' => 1, 'sto_id' => $stoId]);
+        // Staf klik Lanjut -- browser memanggil insertStockOpname() SATU KALI dengan
+        // rollup_decision=full, tidak ada panggilan pertama yang menulis apa pun sebelumnya.
+        $response = $this->insertOpname($items, ['rollup_decision' => 'full']);
+        $response->assertStatus(200);
+        $response->assertJson(['status' => 1]);
+        $stoId = (int) $response->json('sto_id');
+        $this->assertSame($stoCountBefore + 1, StockOpname::count(), 'cuma SATU dokumen yang tercipta, bukan dua');
 
         $lines = StockOpnameLine::getLines($stoId)->keyBy('unit_id');
         $this->assertSame(101, (int) $lines[$this->units['dos']->unit_id]->sol_counted_qty, 'Dos ikut menyerap kelebihan Piece');
@@ -224,23 +259,22 @@ class StockOpnameRollupConfirmTest extends TestCase
         $this->assertSame(8, (int) ProductStock::where('product_variant_id', $v->product_variant_id)->where('unit_id', $this->units['pcs']->unit_id)->value('ps_stock'));
     }
 
-    public function test_submit_stock_opname_offers_the_same_confirmation_for_a_draft(): void
+    public function test_submit_stock_opname_still_accepts_an_explicit_rollup_decision(): void
     {
         $this->actingAsSuperAdminStaff();
 
         $v = $this->makeLadderedItem(dosStock: 90, pcsStock: 104);
-        $draft = $this->insertDosOnlyOpname($v, 93, ['is_draft' => 1]);
+        $items = $this->dosOnlyItemPayload($v, 93);
+
+        // Draft-nya sendiri (halaman "Ajukan" selalu autosave draft dulu) -- ini pra-syarat yang
+        // TIDAK berubah oleh perubahan 2026-09-05 (menyimpan draft bukan "menerbitkan").
+        $draft = $this->insertOpname($items, ['is_draft' => 1]);
         $draft->assertStatus(200);
-        $draft->assertJson(['status' => 1]);
         $stoId = (int) $draft->json('sto_id');
 
-        $first = $this->post('/submitStockOpname', ['sto_id' => $stoId]);
-        $first->assertStatus(200);
-        $first->assertJson(['status' => 2]);
-        $this->assertTrue((bool) StockOpname::find($stoId)->is_draft, 'belum ada keputusan -- draft belum diajukan');
-
-        $second = $this->post('/submitStockOpname', ['sto_id' => $stoId, 'rollup_decision' => 'full']);
-        $second->assertStatus(200);
+        // Frontend sudah menjawab popup lewat preview SEBELUM memanggil ini -- langsung bawa
+        // rollup_decision, satu panggilan saja.
+        $this->post('/submitStockOpname', ['sto_id' => $stoId, 'rollup_decision' => 'full'])->assertStatus(200);
         $this->assertFalse((bool) StockOpname::find($stoId)->refresh()->is_draft);
 
         $lines = StockOpnameLine::getLines($stoId)->keyBy('unit_id');
@@ -260,24 +294,8 @@ class StockOpnameRollupConfirmTest extends TestCase
 
         $v = $this->makeLadderedItem(dosStock: 90, pcsStock: 104, warehouseId: $warehouse->id);
 
-        $response = $this->post('/insertStockOpname', [
-            'sto_date' => now()->toDateString(),
-            'staff_id' => $this->staffId(),
-            'category_id' => $this->categoryId(),
-            'sto_notes' => 'Rollup confirm test (eceran)',
-            'is_draft' => 0,
-            'warehouse_id' => $warehouse->id,
-            'item' => json_encode([[
-                'product_id' => $v->product_id,
-                'product_variant_id' => $v->product_variant_id,
-                'units' => [
-                    ['unit_id' => $this->units['dos']->unit_id, 'system_qty' => 0, 'real_qty' => 93],
-                    ['unit_id' => $this->units['pcs']->unit_id, 'system_qty' => 0, 'real_qty' => null],
-                ],
-            ]]),
-        ]);
-
+        $response = $this->preview($this->dosOnlyItemPayload($v, 93), ['warehouse_id' => $warehouse->id]);
         $response->assertStatus(200);
-        $response->assertJson(['status' => 1], 'gudang eceran tidak pernah ditawari popup gulung');
+        $this->assertSame([], $response->json('rollup_candidates'), 'gudang eceran tidak pernah punya peluang gulung');
     }
 }

--- a/tests/Workflow/StockOpnameRollupConfirmTest.php
+++ b/tests/Workflow/StockOpnameRollupConfirmTest.php
@@ -185,6 +185,50 @@ class StockOpnameRollupConfirmTest extends TestCase
         $this->assertSame($lineCountBefore, StockOpnameLine::count(), 'preview tidak boleh membuat baris apa pun');
     }
 
+    /**
+     * Bug report user 2026-09-05: ajukan langsung (tanpa draft) -> popup menampilkan 3 baris
+     * termasuk baris yang benar-benar diisi. Simpan sebagai draft (cuma baris yang diisi ikut
+     * tersimpan, sesuai desain) -> buka lagi & ajukan ulang -> cuma 1 baris yang tersisa di
+     * popup. Akar masalah: .btn-save mengirim SELURUH katalog yang sedang tampil di tabel (bukan
+     * cuma yang diisi -- itu memang disengaja untuk dokumen non-draft), dan
+     * UnitRollUp::collapseFull() tidak punya guard "produk ini tidak disentuh sama sekali" --
+     * jadi produk APA PUN yang kebetulan sedang ter-render DAN kebetulan stok sistemnya sendiri
+     * tidak kanonik (mis. dari data lama) ikut ditawarkan sebagai "peluang gulung", padahal staf
+     * tidak pernah menyentuhnya. Daftarnya jadi berbeda-beda tergantung produk mana yang
+     * kebetulan ter-render (katalog penuh vs cuma baris draft yang tersimpan), bukan berdasarkan
+     * input staf -- persis simtom yang dilaporkan.
+     */
+    public function test_an_entirely_untouched_product_is_never_a_rollup_candidate_even_with_noncanonical_stock(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        // Produk yang BENAR-BENAR diisi staf.
+        $touched = $this->makeLadderedItem(dosStock: 90, pcsStock: 104);
+        // Produk LAIN yang kebetulan sedang ter-render di tabel (mis. katalog penuh saat create
+        // langsung) tapi TIDAK PERNAH disentuh staf sama sekali -- stok sistemnya sendiri sudah
+        // tidak kanonik (104 pcs > 1 ratio Dos), persis kondisi yang memicu bug.
+        $untouched = $this->makeLadderedItem(dosStock: 5, pcsStock: 30, ratio: 12);
+
+        $items = array_merge(
+            $this->dosOnlyItemPayload($touched, 93),
+            [[
+                'product_id' => $untouched->product_id,
+                'product_variant_id' => $untouched->product_variant_id,
+                'units' => [
+                    ['unit_id' => $this->units['dos']->unit_id, 'system_qty' => 0, 'real_qty' => null],
+                    ['unit_id' => $this->units['pcs']->unit_id, 'system_qty' => 0, 'real_qty' => null],
+                ],
+            ]],
+        );
+
+        $response = $this->preview($items);
+        $response->assertStatus(200);
+
+        $candidates = $response->json('rollup_candidates');
+        $this->assertCount(1, $candidates, 'produk yang tidak disentuh staf tidak boleh ikut jadi kandidat gulung');
+        $this->assertSame($touched->product_variant_id, $candidates[0]['product_variant_id']);
+    }
+
     public function test_batal_never_touches_the_database_at_all(): void
     {
         $this->actingAsSuperAdminStaff();

--- a/tests/Workflow/StockOpnameRollupConfirmTest.php
+++ b/tests/Workflow/StockOpnameRollupConfirmTest.php
@@ -319,6 +319,64 @@ class StockOpnameRollupConfirmTest extends TestCase
         $this->assertSame(8, (int) ProductStock::where('product_variant_id', $v->product_variant_id)->where('unit_id', $this->units['pcs']->unit_id)->value('ps_stock'));
     }
 
+    /**
+     * Bug report user 2026-09-05: PDF penuh baris "0 DOS, 0 pcs" ter-highlight HIJAU (seakan
+     * "dihitung dan cocok") untuk produk yang staf tidak pernah sentuh sama sekali, muncul
+     * setelah dokumen diajukan (rollup_decision=full). Akar masalah: rollUpUnitsFull() (versi
+     * lama) menulis untuk SETIAP produk selama collapseProductFull() mengembalikan ARRAY APA PUN
+     * -- tapi collapseProductFull() SELALU mengembalikan sesuatu begitu chain-nya ada, termasuk
+     * kredit {qty: 0} untuk produk yang stoknya sendiri sudah 0 di semua satuan (tidak ada yang
+     * perlu digulung). Baris yang seharusnya tetap NULL ("tidak dihitung") tertimpa
+     * sol_counted_qty=0 -- highlight HIJAU muncul karena sol_counted_qty !== null dianggap
+     * "pernah dihitung", walau nilainya cuma kebetulan cocok 0=0 dengan sistem.
+     */
+    public function test_lanjut_never_overwrites_an_untouched_already_canonical_product_with_zero(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $touched = $this->makeLadderedItem(dosStock: 90, pcsStock: 104, ratio: 12);
+        // Produk lain, sudah 0/0 di semua satuan, TIDAK PERNAH disentuh staf -- ikut terkirim
+        // karena .btn-ajukan sekarang mengirim katalog penuh (keputusan user 2026-09-05).
+        $untouchedCanonical = $this->makeLadderedItem(dosStock: 0, pcsStock: 0, ratio: 12);
+
+        $items = array_merge(
+            $this->dosOnlyItemPayload($touched, 93),
+            [[
+                'product_id' => $untouchedCanonical->product_id,
+                'product_variant_id' => $untouchedCanonical->product_variant_id,
+                'units' => [
+                    ['unit_id' => $this->units['dos']->unit_id, 'system_qty' => 0, 'real_qty' => null],
+                    ['unit_id' => $this->units['pcs']->unit_id, 'system_qty' => 0, 'real_qty' => null],
+                ],
+            ]],
+        );
+
+        // Sanity: memang tidak jadi kandidat di popup sama sekali (0/0 sudah kanonik).
+        $preview = $this->preview($items);
+        $candidateIds = collect($preview->json('rollup_candidates'))->pluck('product_variant_id');
+        $this->assertNotContains($untouchedCanonical->product_variant_id, $candidateIds);
+
+        $response = $this->insertOpname($items, ['rollup_decision' => 'full']);
+        $response->assertStatus(200);
+        $stoId = (int) $response->json('sto_id');
+
+        $untouchedLines = StockOpnameLine::where('sto_id', $stoId)
+            ->where('product_variant_id', $untouchedCanonical->product_variant_id)
+            ->get();
+        foreach ($untouchedLines as $line) {
+            $this->assertNull($line->sol_counted_qty, 'produk yang tidak disentuh & sudah kanonik harus TETAP null, bukan 0');
+        }
+
+        // PDF: baris ini TIDAK BOLEH ikut ter-highlight hijau -- OpnameLineReader's viewRow()
+        // hanya menghijaukan baris yang punya minimal satu satuan counted !== null.
+        $sto = StockOpname::find($stoId);
+        $row = collect((new \App\Support\StockOpname\OpnameLineReader())->read($sto))
+            ->firstWhere('product_variant_id', $untouchedCanonical->product_variant_id);
+        $this->assertNotNull($row);
+        $this->assertFalse($row['counted'], 'baris ini tidak boleh dianggap "pernah dihitung"');
+        $this->assertNull($row['highlight'], 'baris ini tidak boleh ter-highlight sama sekali');
+    }
+
     public function test_submit_stock_opname_still_accepts_an_explicit_rollup_decision(): void
     {
         $this->actingAsSuperAdminStaff();

--- a/tests/Workflow/StockOpnameV2EndToEndTest.php
+++ b/tests/Workflow/StockOpnameV2EndToEndTest.php
@@ -131,7 +131,7 @@ class StockOpnameV2EndToEndTest extends TestCase
      * @param  array<int, array{variant: ProductVariant, dos: int|null, pcs: int|null}>  $lines
      *         null = satuan itu dibiarkan tidak dihitung.
      */
-    private function insertOpname(array $lines, bool $isDraft = false, string $notes = 'E2E test'): int
+    private function insertOpname(array $lines, bool $isDraft = false, string $notes = 'E2E test', ?string $rollupDecision = null): int
     {
         $items = [];
         foreach ($lines as $line) {
@@ -155,14 +155,15 @@ class StockOpnameV2EndToEndTest extends TestCase
             ];
         }
 
-        $response = $this->post('/insertStockOpname', [
+        $response = $this->post('/insertStockOpname', array_filter([
             'sto_date' => now()->toDateString(),
             'staff_id' => $this->staffId(),
             'category_id' => $this->categoryId(),
             'sto_notes' => $notes,
             'is_draft' => $isDraft ? 1 : 0,
             'item' => json_encode($items),
-        ]);
+            'rollup_decision' => $rollupDecision,
+        ], fn ($v) => $v !== null));
         $response->assertStatus(200);
         $response->assertJson(['status' => 1]);
 
@@ -716,8 +717,16 @@ class StockOpnameV2EndToEndTest extends TestCase
      * Contoh persis dari PM, LEWAT /insertStockOpname sungguhan (bukan lifecycle langsung seperti
      * StockOpnameV2LifecycleTest): 1 DOS = 12 pcs, isi 30 pcs -> tersimpan 2 DOS + 6 pcs, dan itu
      * yang tercetak di PDF-nya juga.
+     *
+     * >>> GANTI KEPUTUSAN (user, 2026-09-06): "setiap kali ada roll up yang terdeteksi,
+     * munculkan popup konfirmasinya" -- gulung ini dulu terjadi OTOMATIS tanpa konfirmasi sama
+     * sekali (rollUpUnits() dipanggil tanpa syarat dari insertStockOpname()). Sekarang SEMUA
+     * gulung, termasuk mengisi satuan terkecil sendirian seperti contoh PM ini, wajib lewat
+     * /previewStockOpnameRollup dan rollup_decision='full' -- lihat OpnameLifecycle::
+     * computeFullProjectionChanges()'s docblock untuk bug yang mendorong perubahan ini
+     * (mengisi 1000 pcs sendirian dulu tergulung tanpa staf pernah melihat popup-nya).
      */
-    public function test_insert_endpoint_rolls_up_a_filled_small_unit_automatically(): void
+    public function test_insert_endpoint_rolls_up_a_filled_small_unit_when_confirmed(): void
     {
         $this->actingAsSuperAdminStaff();
 
@@ -725,15 +734,31 @@ class StockOpnameV2EndToEndTest extends TestCase
 
         $stoId = $this->insertOpname([[
             'variant' => $v, 'dos' => null, 'pcs' => 30,
-        ]]);
+        ]], rollupDecision: 'full');
 
         $lines = StockOpnameLine::getLines($stoId)->keyBy('unit_id');
         $this->assertSame(6, (int) $lines[$this->units['pcs']->unit_id]->sol_counted_qty);
-        $this->assertSame(2, (int) $lines[$this->units['dos']->unit_id]->sol_counted_qty, 'DOS harus otomatis terisi dari kelebihan pcs, lewat endpoint sungguhan');
+        $this->assertSame(2, (int) $lines[$this->units['dos']->unit_id]->sol_counted_qty, 'DOS harus terisi dari kelebihan pcs setelah rollup_decision=full');
 
         $row = $this->extractRow($this->pdf($stoId), $v->product_variant_sku);
         $this->assertStringContainsString('6 '.$this->units['pcs']->unit_short_name, $row);
         $this->assertStringContainsString('2 '.$this->units['dos']->unit_short_name, $row);
+    }
+
+    /** Kembaran test di atas: TANPA rollup_decision='full', tidak ada gulung sama sekali lagi. */
+    public function test_insert_endpoint_no_longer_rolls_up_a_filled_small_unit_without_confirmation(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $v = $this->withLadder($this->makeCatalogItem('HIKARI SUPER GREASE B', '18 X 450 GR', 'HSG450GRB', dosStock: 0, pcsStock: 0));
+
+        $stoId = $this->insertOpname([[
+            'variant' => $v, 'dos' => null, 'pcs' => 30,
+        ]]);
+
+        $lines = StockOpnameLine::getLines($stoId)->keyBy('unit_id');
+        $this->assertSame(30, (int) $lines[$this->units['pcs']->unit_id]->sol_counted_qty, 'pcs tersimpan apa adanya tanpa konfirmasi');
+        $this->assertNull($lines[$this->units['dos']->unit_id]->sol_counted_qty, 'DOS TETAP null tanpa konfirmasi -- tidak ada gulung otomatis lagi');
     }
 
     /**

--- a/tests/Workflow/StockOpnameV2EndToEndTest.php
+++ b/tests/Workflow/StockOpnameV2EndToEndTest.php
@@ -752,9 +752,12 @@ class StockOpnameV2EndToEndTest extends TestCase
 
         $v = $this->withLadder($this->makeCatalogItem('HIKARI SUPER GREASE B', '18 X 450 GR', 'HSG450GRB', dosStock: 0, pcsStock: 0));
 
+        // rollup_decision='skip' EKSPLISIT -- beda dari tidak membawanya sama sekali, yang
+        // perilakunya bergantung OpnameLifecycle::ROLLUP_PROJECTION_ENABLED (lihat
+        // StockOpnameRollupConfirmTest::test_insert_without_an_explicit_decision_follows_the_show_popup_flag).
         $stoId = $this->insertOpname([[
             'variant' => $v, 'dos' => null, 'pcs' => 30,
-        ]]);
+        ]], rollupDecision: 'skip');
 
         $lines = StockOpnameLine::getLines($stoId)->keyBy('unit_id');
         $this->assertSame(30, (int) $lines[$this->units['pcs']->unit_id]->sol_counted_qty, 'pcs tersimpan apa adanya tanpa konfirmasi');


### PR DESCRIPTION
## Ringkasan

Bug report: stok awal Produk A 90 Dos, 104 Piece. Staf mengoreksi Stock Opname cuma Dos jadi 93 (Piece dibiarkan tidak dihitung ulang). Hasil dokumen: "93 Dos, 104 Piece".

Investigasi menunjukkan angka itu sebenarnya **sudah benar** sesuai aturan GitHub #78 (satuan yang tidak pernah diperiksa staf tidak boleh diisi otomatis) — Piece tetap 104 apa adanya, dan ACC cuma menimpa `ps_stock` untuk baris yang benar-benar dihitung. Bukan korupsi data. Juga sudah diverifikasi tidak ada kaitan dengan commit rekan tim di hari yang sama (`dbe0d899`, `e3781534`).

Setelah didiskusikan, keputusan user: tetap tawarkan opsi menggulung PENUH satuan yang tidak disentuh staf, tapi HANYA sebagai konfirmasi eksplisit tepat di titik dokumen terbit (insert langsung non-draft, atau draft yang diajukan lewat "Ajukan") — bukan otomatis, dan hanya untuk gudang utama.

## Perubahan

- `App\Support\UnitRollUp::collapseFull()`/`collapseProductFull()` — gulung penuh seluruh tangga satuan, dipakai HANYA di belakang konfirmasi staf (sengaja melanggar aturan aman GH #78, didokumentasikan sebagai demikian di docblock-nya).
- `App\Support\StockOpname\OpnameLifecycle::detectRollupOpportunities()`/`rollUpUnitsFull()` — deteksi tanpa menulis apa pun, lalu eksekusi setelah staf konfirmasi.
- `StockController::insertStockOpname()`/`submitStockOpname()` — membalas `status: 2` + daftar produk kalau ada peluang gulung; panggilan kedua membawa `rollup_decision` ('full'|'skip').
- `CreateStockOpname.js` — popup SweetAlert2 (`showRollupConfirm()`).

## Test

`php vendor/bin/phpunit tests/Workflow/StockOpnameRollupConfirmTest.php tests/Workflow/StockOpnameFlowTest.php tests/Workflow/StockOpnameV2EndToEndTest.php tests/Workflow/StockOpnameV2LifecycleTest.php` — hijau kecuali 3 kegagalan baseline yang sudah ada sebelum perubahan ini (diverifikasi dengan `git stash`).

Closes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)