### PR TITLE
fix(changelog): trigger tutup 'open' per sesi login, bukan per staf

### DIFF
--- a/app/Http/Controllers/DashboardActivityController.php
+++ b/app/Http/Controllers/DashboardActivityController.php
@@ -41,7 +41,15 @@ class DashboardActivityController extends Controller
             if ($token !== '') {
                 DashboardChangeLog::closeOpenSessionByToken($staffId, $token, now());
             } else {
-                DashboardChangeLog::closeOpenSession($staffId, now(), null);
+                // Fallback ini juga di-scope ke marker sesi (session data, bukan session ID --
+                // lihat LogDashboardActivity::sessionMarker()) supaya dua sesi login staf yang
+                // sama (2 device/browser) tidak saling menutup baris 'open' satu sama lain.
+                // Kalau markernya belum pernah ada (mis. baris lama pra-fix), jangan generate
+                // baru di sini -- beacon TIDAK bikin baris baru, cuma menutup yang sudah ada.
+                $marker = $request->session()->get('_dashboard_activity_sid');
+                if (is_string($marker) && $marker !== '') {
+                    DashboardChangeLog::closeOpenSession($staffId, now(), null, $marker);
+                }
             }
         }
 

--- a/app/Http/Middleware/LogDashboardActivity.php
+++ b/app/Http/Middleware/LogDashboardActivity.php
@@ -74,6 +74,7 @@ class LogDashboardActivity
         $moduleKey = $this->detectModuleKey($request);
         $moduleLabel = $this->formatModuleLabel($moduleKey);
         $now = now();
+        $sessionId = $this->sessionMarker($request);
 
         // Ditambahkan (2026-08-14), dihapus lagi (2026-08-15): sempat ada debounce 15 menit
         // per staf+modul di sini supaya klik-klik/refresh cepat tidak jadi baris baru tiap
@@ -84,14 +85,16 @@ class LogDashboardActivity
         // terbuka -- persis gejala yang dilaporkan user ("Dashboard nav click still not
         // ending the previous page session"). Setiap kunjungan sekarang selalu dicatat.
 
-        // Tutup baris 'open' terakhir milik staf ini (modul manapun) yang belum punya durasi —
-        // durasinya = jarak ke pembukaan menu berikutnya ini. Kalau jaraknya lebih dari 4 jam,
-        // anggap tab lama itu cuma ditinggal (idle/browser ditutup tanpa navigasi lagi) dan
-        // jangan diisi durasi yang menyesatkan. Lihat juga DashboardActivityController::closeSession()
-        // -- sinyal AKTIF (tab ditutup) yang ditembak lewat navigator.sendBeacon() saat unload,
-        // supaya baris 'open' tidak nyangkut "Sedang dibuka" selamanya kalau user tidak pernah
-        // buka menu lain lagi.
-        DashboardChangeLog::closeOpenSession($staffId, $now);
+        // Tutup baris 'open' terakhir milik SESI LOGIN ini (modul manapun) yang belum punya
+        // durasi — durasinya = jarak ke pembukaan menu berikutnya ini. Di-scope ke $sessionId
+        // supaya staf yang sama login bersamaan di device/browser lain tidak ikut ditutup
+        // (lihat catatan di DashboardChangeLog::closeOpenSession()). Kalau jaraknya lebih dari
+        // 4 jam, anggap tab lama itu cuma ditinggal (idle/browser ditutup tanpa navigasi lagi)
+        // dan jangan diisi durasi yang menyesatkan. Lihat juga
+        // DashboardActivityController::closeSession() -- sinyal AKTIF (tab ditutup) yang
+        // ditembak lewat navigator.sendBeacon() saat unload, supaya baris 'open' tidak nyangkut
+        // "Sedang dibuka" selamanya kalau user tidak pernah buka menu lain lagi.
+        DashboardChangeLog::closeOpenSession($staffId, $now, 4 * 3600, $sessionId);
 
         $staffName = session('user')->staff_name ?? '-';
 
@@ -121,11 +124,35 @@ class LogDashboardActivity
                 'method' => $request->method(),
                 'path' => $request->path(),
                 'client_token' => $clientToken,
+                'session_id' => $sessionId,
             ],
             'duration_seconds' => null,
         ]);
 
         $this->injectClientToken($response, $clientToken);
+    }
+
+    /**
+     * Identitas SESI LOGIN saat ini (per browser/device), beda dari staff_id yang cuma
+     * identitas akunnya. Dua sesi login staf yang sama (2 device/tab login bersamaan) dapat
+     * marker berbeda -- inilah kunci supaya baris 'open' masing-masing tidak saling menutup
+     * (lihat DashboardChangeLog::closeOpenSession()).
+     *
+     * SENGAJA bukan $request->session()->getId() -- Laravel session ID tidak stabil untuk
+     * dipakai sebagai penanda ini: bisa berbeda tiap request (mis. StartSession meregenerasi
+     * ID dari cookie tiap kali) walau isi sesinya sendiri tetap sama. Marker kustom ini
+     * disimpan di DALAM data sesi (bukan ID-nya) sekali per sesi lalu dipakai ulang, jadi
+     * tetap sama selama sesi login yang sama berlangsung.
+     */
+    private function sessionMarker(Request $request): string
+    {
+        $marker = $request->session()->get('_dashboard_activity_sid');
+        if (!is_string($marker) || $marker === '') {
+            $marker = (string) Str::uuid();
+            $request->session()->put('_dashboard_activity_sid', $marker);
+        }
+
+        return $marker;
     }
 
     /**

--- a/app/Models/DashboardChangeLog.php
+++ b/app/Models/DashboardChangeLog.php
@@ -27,10 +27,18 @@ class DashboardChangeLog extends Model
     ];
 
     /**
-     * Tutup baris 'open' terakhir milik staf ini (modul manapun) yang belum punya durasi,
-     * dengan durasi = jarak waktu ke $endedAt. Dipakai dari dua tempat: LogDashboardActivity
-     * (estimasi pasif -- ditutup oleh pembukaan menu BERIKUTNYA) dan tab-close beacon
-     * (sinyal aktif -- ditutup oleh browser saat tab/halaman benar-benar ditinggalkan).
+     * Tutup baris 'open' terakhir milik SESI LOGIN ini (modul manapun) yang belum punya
+     * durasi, dengan durasi = jarak waktu ke $endedAt. Dipakai dari dua tempat:
+     * LogDashboardActivity (estimasi pasif -- ditutup oleh pembukaan menu BERIKUTNYA) dan
+     * tab-close beacon (sinyal aktif -- ditutup oleh browser saat tab/halaman benar-benar
+     * ditinggalkan).
+     *
+     * $sessionId WAJIB diisi (Laravel session ID milik request yang sedang berjalan) supaya
+     * query di-scope ke sesi login itu saja, bukan ke SEMUA baris 'open' milik $staffId.
+     * Tanpa scoping ini, staf yang login bersamaan di 2 device/browser (akun yang sama, dua
+     * sesi login berbeda) saling menutup baris 'open' satu sama lain -- device A tak sengaja
+     * ikut "ditutup" begitu device B membuka menu apa pun, padahal tab A masih benar-benar
+     * terbuka. Null hanya untuk baris lama (pra-fix) yang belum punya session_id di meta-nya.
      *
      * $maxSeconds membatasi durasi yang menyesatkan (tab lama ditinggal idle tanpa navigasi
      * lagi); default 4 jam sama seperti estimasi pasif. Beacon boleh melewati batas ini
@@ -39,11 +47,12 @@ class DashboardChangeLog extends Model
      * Idempotent lewat whereNull('duration_seconds') di query pemanggil -- baris yang sudah
      * ditutup (oleh salah satu jalur) tidak akan tertimpa oleh jalur lainnya.
      */
-    public static function closeOpenSession(int $staffId, $endedAt, ?int $maxSeconds = 4 * 3600): ?self
+    public static function closeOpenSession(int $staffId, $endedAt, ?int $maxSeconds = 4 * 3600, ?string $sessionId = null): ?self
     {
         $previous = self::where('created_by', $staffId)
             ->where('activity_type', 'open')
             ->whereNull('duration_seconds')
+            ->when($sessionId !== null, fn ($q) => $q->where('meta->session_id', $sessionId))
             ->orderByDesc('created_at')
             ->first();
 

--- a/tests/Workflow/DashboardChangelogMenuOpenTrackingTest.php
+++ b/tests/Workflow/DashboardChangelogMenuOpenTrackingTest.php
@@ -214,6 +214,57 @@ class DashboardChangelogMenuOpenTrackingTest extends TestCase
         $this->assertNotNull($customerOpen->duration_seconds, "revisiting Dashboard must close Customer's session even though Dashboard was opened moments ago");
     }
 
+    /**
+     * User-reported: "when 2 users logged in the same time... they share a time trigger" --
+     * two concurrent login sessions of the SAME staff account (e.g. logged in on two
+     * devices/browsers at once) used to close each other's 'open' row, because the only
+     * scoping was staff_id. Each login session now gets its own marker (stored in the
+     * session's own data, not the volatile Laravel session ID) so opening a page on device B
+     * must NOT touch device A's still-genuinely-open row.
+     */
+    public function test_two_concurrent_sessions_of_the_same_staff_do_not_close_each_others_open_row(): void
+    {
+        $staff = $this->actingAsSuperAdminStaff();
+
+        // "Device A" opens Stock Opname.
+        $this->get('/stockOpname')->assertStatus(200);
+        $deviceA = DashboardChangeLog::where('created_by', $staff->staff_id)
+            ->where('module_key', 'stockopname')->where('activity_type', 'open')
+            ->firstOrFail();
+        $this->assertNull($deviceA->duration_seconds);
+        $markerA = $deviceA->meta['session_id'] ?? null;
+        $this->assertNotNull($markerA, 'the open row must carry a session marker');
+
+        // Simulate a second, independent login session for the SAME staff account (a
+        // different browser/device) by dropping the session marker before the next request --
+        // LogDashboardActivity::sessionMarker() then mints a fresh one, same as a brand new
+        // browser session would get.
+        session()->forget('_dashboard_activity_sid');
+        $this->actingAsSuperAdminStaff();
+        $this->get('/purchaseOrder')->assertStatus(200);
+
+        $deviceA->refresh();
+        $this->assertNull($deviceA->duration_seconds, "device B's navigation must not close device A's still-open session");
+
+        $deviceB = DashboardChangeLog::where('created_by', $staff->staff_id)
+            ->where('module_key', 'purchaseorder')->where('activity_type', 'open')
+            ->firstOrFail();
+        $markerB = $deviceB->meta['session_id'] ?? null;
+        $this->assertNotNull($markerB);
+        $this->assertNotSame($markerA, $markerB, 'each login session must get its own marker');
+
+        // Back on "device A" (its own marker restored) -- opening another page must still
+        // correctly close device A's own previous row.
+        session(['_dashboard_activity_sid' => $markerA]);
+        $this->get('/customer')->assertStatus(200);
+
+        $deviceA->refresh();
+        $this->assertNotNull($deviceA->duration_seconds, "device A's own navigation must still close its own previous row");
+
+        $deviceB->refresh();
+        $this->assertNull($deviceB->duration_seconds, "device A's navigation must not close device B's still-open session");
+    }
+
     public function test_menu_open_rows_are_excluded_from_the_changelog_pending_kpi(): void
     {
         $staff = $this->actingAsSuperAdminStaff();


### PR DESCRIPTION
## Masalah

Setelah PR #144 (deteksi tab ditutup), ditemukan bug baru: kalau staf yang **sama** login bersamaan di 2 device/browser (2 sesi login berbeda), keduanya **berbagi trigger penutup baris 'open'** yang sama. Membuka menu apa pun di device B tanpa sengaja ikut menutup baris 'open' milik device A, padahal tab A masih benar-benar terbuka.

Akar masalahnya: `LogDashboardActivity::logOpen()` menutup baris 'open' terakhir hanya di-scope ke `created_by` (staff_id) -- tidak ada pembeda antar sesi login untuk staf yang sama.

## Perbaikan

- Setiap sesi login sekarang dapat **marker per-sesi** (`_dashboard_activity_sid`, UUID), disimpan **di dalam data sesi** itu sendiri, bukan Laravel session ID mentah. Ini penting: Laravel session ID ternyata tidak stabil untuk dipakai sebagai penanda -- bisa berubah tiap request (mis. saat `StartSession` meregenerasi ID dari cookie) walau isi sesinya sendiri tetap sama.
- `DashboardChangeLog::closeOpenSession()` menerima parameter `$sessionId` opsional untuk scoping tambahan (di atas `created_by`).
- `LogDashboardActivity::logOpen()` (estimasi pasif) dan `DashboardActivityController::closeSession()` (fallback beacon tanpa `client_token`) keduanya memakai marker ini sekarang.
- Jalur beacon dengan `client_token` (jalur utama, dari fix sebelumnya) sudah aman dari masalah ini sejak awal karena token-nya sudah unik per-pageview -- tidak perlu diubah.

## Testing

- Test regresi baru: `test_two_concurrent_sessions_of_the_same_staff_do_not_close_each_others_open_row` -- mensimulasikan 2 sesi login staf yang sama, membuktikan baris 'open' masing-masing device tidak saling menutup, dan device masing-masing tetap bisa menutup barisnya sendiri.
- Seluruh suite `tests/Workflow/DashboardChangelogMenuOpenTrackingTest.php` (9 test, termasuk yang baru) hijau.
- `php -l` pada semua file PHP yang diubah -- tidak ada syntax error.

## File yang berubah

- `app/Http/Middleware/LogDashboardActivity.php` — `sessionMarker()` baru, dipakai di `logOpen()`.
- `app/Models/DashboardChangeLog.php` — `closeOpenSession()` menerima `$sessionId` opsional.
- `app/Http/Controllers/DashboardActivityController.php` — fallback beacon (tanpa token) memakai marker yang sama.
- `tests/Workflow/DashboardChangelogMenuOpenTrackingTest.php` — test regresi baru.

🤖 Generated with [Claude Code](https://claude.com/claude-code)