### PR TITLE
fix(produk): perbaiki Ajax error saat search di Daftar Produk (collation mismatch)

### DIFF
--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -213,8 +213,10 @@ class ProductController extends Controller
                             ->where('units.status', 1)
                             ->where('units.unit_name', 'like', $like)
                             ->whereRaw(
-                                // product_unit = JSON array id satuan, mis. ["7","9"] — LIKE saja (MariaDB-safe)
-                                "products.product_unit LIKE CONCAT('%\"', CAST(units.unit_id AS CHAR), '\"%')"
+                                // product_unit = JSON array id satuan, mis. ["7","9"] — LIKE saja (MariaDB-safe).
+                                // products/units punya collation yang berbeda-beda antar tabel (drift lama),
+                                // jadi kedua sisi di-COLLATE eksplisit supaya tidak "Illegal mix of collations".
+                                "CONVERT(products.product_unit USING utf8mb4) COLLATE utf8mb4_unicode_ci LIKE CONCAT('%\"', CAST(units.unit_id AS CHAR) COLLATE utf8mb4_unicode_ci, '\"%')"
                             );
                     });
             });

--- a/tests/Regression/ProductListSearchAjaxErrorIssue149Test.php
+++ b/tests/Regression/ProductListSearchAjaxErrorIssue149Test.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Tests\Regression;
+
+use Tests\TestCase;
+use Tests\Support\ActingAsStaff;
+
+/**
+ * GitHub #149: mencari produk (mis. "ka") memicu "DataTables warning: Ajax error"
+ * di halaman Daftar Produk. Root cause: kolom `products.product_unit` dan hasil
+ * CAST(units.unit_id AS CHAR) punya collation berbeda (drift lama antar tabel),
+ * jadi MySQL menolak perbandingan LIKE-nya dengan "Illegal mix of collations".
+ */
+class ProductListSearchAjaxErrorIssue149Test extends TestCase
+{
+    use ActingAsStaff;
+
+    public function test_get_product_search_does_not_error(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $response = $this->getJson('/getProduct?draw=1&start=0&length=10&search%5Bvalue%5D=ka');
+
+        $response->assertStatus(200)
+            ->assertJsonStructure(['draw', 'recordsTotal', 'recordsFiltered', 'data']);
+    }
+}


### PR DESCRIPTION
## Masalah
Search apa pun di halaman Daftar Produk memicu `DataTables warning: Ajax error` (#149).

## Root cause
Query server-side `getProduct()` (`ProductController::getProductDataTable`) membangun kondisi pencarian satuan lewat:
```sql
products.product_unit LIKE CONCAT('%"', CAST(units.unit_id AS CHAR), '"%')
```
`CAST(units.unit_id AS CHAR)` menghasilkan string ber-collation koneksi (`utf8mb4_0900_ai_ci`), sementara `products.product_unit` di data production/testing memakai collation lain (drift lama antar tabel). MySQL menolak perbandingan `LIKE` dua collation berbeda dengan `SQLSTATE[HY000]: 1267 Illegal mix of collations`, yang di sisi frontend muncul sebagai Ajax error generik dari DataTables.

Direproduksi dengan test PHPUnit yang memanggil `/getProduct?search[value]=ka` langsung terhadap DB `pegasus_testing` (snapshot data real).

## Fix
Paksa kedua sisi perbandingan ke collation yang sama secara eksplisit (`CONVERT(...) COLLATE utf8mb4_unicode_ci`), sehingga tidak lagi bergantung pada collation asli kolom yang sudah drift.

## Test
- Tambah `tests/Regression/ProductListSearchAjaxErrorIssue149Test.php` — reproduksi bug lalu verifikasi fix.
- `php artisan test --filter=Product`: 120 passed (2 kegagalan lain sudah ada sebelumnya, tidak terkait — migration drift `sol_use_system_stock` di `StockOpnameV2EndToEndTest`).

Closes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)