### PR TITLE
fix(stock): lipat stok yang sudah ada ke setiap roll-up satuan stock-IN

### DIFF
--- a/app/Http/Controllers/ProductionController.php
+++ b/app/Http/Controllers/ProductionController.php
@@ -1035,10 +1035,14 @@ class ProductionController extends Controller
         $missingProductStockRows = [];
         foreach ($transferPlan['groups'] as $group) {
             foreach ($group['items'] as $output) {
-                $credits = UnitRollUp::plan(
-                    UnitRollUp::productChain((int) $output['product_variant_id']),
+                // planProductFolded() (GitHub #151, 2026-09-06): folds stock ALREADY at the produced
+                // unit into the roll-up decision too -- must match addQty()'s actual call below
+                // exactly, or this preview can drift from what really gets credited/provisioned.
+                $credits = UnitRollUp::planProductFolded(
+                    (int) $output['product_variant_id'],
                     (int) $output['unit_id'],
                     (int) $output['qty'],
+                    (int) $mainWarehouse->id,
                     UnitRollUp::ladderUnitIds((int) $output['product_variant_id'])
                 );
 

--- a/app/Models/ProductIssuesDetail.php
+++ b/app/Models/ProductIssuesDetail.php
@@ -173,7 +173,14 @@ class ProductIssuesDetail extends Model
             // 24 Piece walaupun 1 DOS = 12 Piece. Sekarang dinaikkan berjenjang lewat UnitRollUp,
             // konsisten dengan hasil produksi (accProduction). UnitRollUp hanya menaikkan ke satuan
             // yang SUDAH punya baris stok aktif, jadi tidak ada baris stok baru yang dibuat diam-diam.
-            $rollUp = UnitRollUp::planSupplies((int) $m->supplies_id, (int) $t->unit_id, (int) $t->pid_qty);
+            //
+            // planSuppliesFolded() (GitHub #151, 2026-09-06): dulu pakai planSupplies() polos, yang
+            // cuma menggulung qty yang dikembalikan SAJA -- kalau stok lama di satuan asal + qty ini
+            // sama-sama tidak cukup sendirian tapi cukup DIGABUNG, tidak pernah naik satuan. Sekarang
+            // stok lama ikut dilipat; $base['qty'] jadi DELTA (bisa negatif) bukan porsi mentah dari
+            // $t->pid_qty -- $naik di bawah tetap dihitung benar karena formulanya
+            // (pid_qty - delta) sama untuk kedua kasus.
+            $rollUp = UnitRollUp::planSuppliesFolded((int) $m->supplies_id, (int) $t->unit_id, (int) $t->pid_qty);
             $base = $rollUp[0];           // selalu satuan asal
             $naikLevel = array_slice($rollUp, 1); // level-level di atasnya (kosong kalau tidak naik)
 

--- a/app/Models/PurchaseOrderDeliveryDetail.php
+++ b/app/Models/PurchaseOrderDeliveryDetail.php
@@ -61,17 +61,25 @@ class PurchaseOrderDeliveryDetail extends Model
             // SupplierController supaya bisa membongkar satuan besar saat mengembalikan stok.
             // Tanpa itu, roll-up di sini membuat pembatalan PO selalu gagal "Stok bahan tidak
             // mencukupi", karena stoknya sudah tidak lagi berada di satuan yang dipesan.
-            $rollUp = UnitRollUp::planSupplies(
+            //
+            // planSuppliesFolded() (GitHub #151, 2026-09-06): dulu pakai planSupplies() polos, yang
+            // cuma menggulung QTY YANG DATANG saja -- 6 Piece diterima saat sudah ada 6 Piece
+            // (1 DOS = 12 Piece) tetap menumpuk jadi 12 Piece, tidak pernah jadi 1 DOS, karena 6
+            // sendiri bukan kelipatan 12. Sekarang stok yang SUDAH ada di satuan asal ikut dilipat ke
+            // keputusan gulung -- lihat docblock class UnitRollUp.
+            $rollUp = UnitRollUp::planSuppliesFolded(
                 (int) $sv->supplies_id,
                 (int) $data["unit_id"],
                 (int) $data["pdod_qty"]
             );
 
-            // Entry ke-0 selalu satuan asal. Baris stoknya SENGAJA tidak di-null-guard: kalau
-            // kombinasi supplies_id + unit_id tidak ketemu, itu unit_id yang salah dan harus
-            // meledak seperti perilaku sebelumnya supaya transaksi accPO() rollback -- bukan
-            // di-skip diam-diam, yang berarti "barang diterima tapi stok tidak pernah bertambah"
-            // tanpa ada yang tahu (antipattern yang sudah pernah diperbaiki di accProduction()).
+            // Entry ke-0 selalu satuan asal -- qty-nya sekarang DELTA (bisa negatif kalau stok lama
+            // + baru cukup naik satuan; += di bawah tetap benar untuk delta negatif). Baris stoknya
+            // SENGAJA tidak di-null-guard: kalau kombinasi supplies_id + unit_id tidak ketemu, itu
+            // unit_id yang salah dan harus meledak seperti perilaku sebelumnya supaya transaksi
+            // accPO() rollback -- bukan di-skip diam-diam, yang berarti "barang diterima tapi stok
+            // tidak pernah bertambah" tanpa ada yang tahu (antipattern yang sudah pernah diperbaiki
+            // di accProduction()).
             $base = array_shift($rollUp);
             $s = SuppliesStock::where("supplies_id", "=", $sv->supplies_id)
                 ->where("unit_id", "=", $base['unit_id'])

--- a/app/Models/PurchaseOrderDeliveryDetail.php
+++ b/app/Models/PurchaseOrderDeliveryDetail.php
@@ -102,6 +102,31 @@ class PurchaseOrderDeliveryDetail extends Model
                 $row->ss_stock += $credit['qty'];
                 $row->save();
             }
+
+            // Catat jejak konversinya kalau memang naik satuan (ditambahkan 2026-09-07, riwayat
+            // stok diminta bentuk 3 langkah, bukan satu delta bersih): satuan asal keluar (cat 2),
+            // satuan hasil masuk (cat 1). Pola log-nya sama persis dengan
+            // ProductIssuesDetail::deleteProductIssuesDetail(). Log "masuk" untuk qty mentah yang
+            // diterima ($data["pdod_qty"]) sudah ditulis caller (SupplierController::accPO()) --
+            // ini cuma menambah 2 baris konversi, bukan menggantikan log itu.
+            if ($rollUp !== []) {
+                $naik = (int) $data["pdod_qty"] - (int) $base['qty'];
+                if ($naik > 0) {
+                    (new LogStock())->insertLog([
+                        'log_date' => now(), 'log_kode' => '-', 'log_type' => 2, 'log_category' => 2,
+                        'log_item_id' => $sv->supplies_id, 'log_notes' => 'Konversi unit (Naik satuan)',
+                        'log_jumlah' => $naik, 'unit_id' => (int) $data["unit_id"],
+                    ]);
+                }
+                foreach ($rollUp as $credit) {
+                    if ($credit['qty'] <= 0) continue;
+                    (new LogStock())->insertLog([
+                        'log_date' => now(), 'log_kode' => '-', 'log_type' => 2, 'log_category' => 1,
+                        'log_item_id' => $sv->supplies_id, 'log_notes' => 'Konversi unit (Hasil naik satuan)',
+                        'log_jumlah' => $credit['qty'], 'unit_id' => $credit['unit_id'],
+                    ]);
+                }
+            }
         }
         return $t->pdod_id;
     }

--- a/app/Support/ProductUnitStock.php
+++ b/app/Support/ProductUnitStock.php
@@ -1084,17 +1084,18 @@ class ProductUnitStock
         //  - eksplisit: caller yang memang sengaja menyediakan baris baru dengan konfirmasi user
         //    lebih dulu (accProduction() + confirm_create_stock) meneruskan seluruh tangga satuan
         //    lewat UnitRollUp::ladderUnitIds().
+        //
+        // planFolded() (GitHub #151, 2026-09-06): folds stock ALREADY at $unitId into the roll-up
+        // decision, so a $qty that alone doesn't cross a unit boundary still rolls up once combined
+        // with what's already there -- see UnitRollUp's class docblock. The credit for $unitId
+        // itself can come back negative (that many units moved up into a bigger one); creditOneProductUnit()
+        // below logs that as an OUT/"keluar" movement, not a negative "IN" row.
         $credits = $rollUp
-            ? UnitRollUp::plan(
-                UnitRollUp::productChain($productVariantId),
-                $unitId,
-                (int) $qty,
-                $rollUpAllowedUnitIds ?? UnitRollUp::allowedProductUnitIds($productVariantId, $warehouseId)
-            )
+            ? UnitRollUp::planProductFolded($productVariantId, $unitId, (int) $qty, $warehouseId, $rollUpAllowedUnitIds)
             : [['unit_id' => $unitId, 'qty' => $qty]];
 
         foreach ($credits as $credit) {
-            if ($credit['qty'] <= 0) {
+            if ($credit['qty'] == 0) {
                 continue;
             }
             self::creditOneProductUnit(
@@ -1152,14 +1153,21 @@ class ProductUnitStock
         $row->ps_stock = round((float) $row->ps_stock + $qty, 4);
         $row->save();
 
+        // $qty can be negative here (GitHub #151 fold, see caller): that many units moved OUT of
+        // this unit into a bigger one via the SAME roll-up call. log_jumlah stays a positive
+        // magnitude and log_category carries the direction instead -- same convention
+        // ProductIssuesDetail::deleteProductIssuesDetail() already uses ("Naik satuan"/"Hasil naik
+        // satuan"), and what ProductionPendingStockRestorer::applyReverseStock() already knows how
+        // to reverse for log_type=1 (cat 1 = credit, subtract on reverse; cat 2 = deduct, add back).
+        $isOut = $qty < 0;
         (new LogStock())->insertLog([
             'log_date' => now(),
             'log_kode' => $logCode,
             'log_type' => 1,
-            'log_category' => 1,
+            'log_category' => $isOut ? 2 : 1,
             'log_item_id' => $productVariantId,
-            'log_notes' => $logNotes,
-            'log_jumlah' => $qty,
+            'log_notes' => $isOut ? 'Konversi unit (naik satuan otomatis) ' . $logNotes : $logNotes,
+            'log_jumlah' => abs($qty),
             'log_saldo' => (float) $row->ps_stock,
             'unit_id' => $unitId,
             'warehouse_id' => $warehouseId,

--- a/app/Support/ProductUnitStock.php
+++ b/app/Support/ProductUnitStock.php
@@ -1088,25 +1088,52 @@ class ProductUnitStock
         // planFolded() (GitHub #151, 2026-09-06): folds stock ALREADY at $unitId into the roll-up
         // decision, so a $qty that alone doesn't cross a unit boundary still rolls up once combined
         // with what's already there -- see UnitRollUp's class docblock. The credit for $unitId
-        // itself can come back negative (that many units moved up into a bigger one); creditOneProductUnit()
-        // below logs that as an OUT/"keluar" movement, not a negative "IN" row.
+        // itself can come back negative (that many units moved up into a bigger one).
         $credits = $rollUp
             ? UnitRollUp::planProductFolded($productVariantId, $unitId, (int) $qty, $warehouseId, $rollUpAllowedUnitIds)
             : [['unit_id' => $unitId, 'qty' => $qty]];
 
-        foreach ($credits as $credit) {
-            if ($credit['qty'] == 0) {
-                continue;
+        // History shape requested by the user (2026-09-07): when existing stock got folded in and
+        // actually consumed (origin credit went negative), don't just write the net delta -- write
+        // what physically happened, as 3 separate legs: the real event lands first (inward the FULL
+        // incoming qty, at $unitId), then the conversion is its own bongkar/hasil pair (outward the
+        // whole amount that moved up -- existing + incoming, not just this call's share -- then
+        // inward at the bigger unit(s)). Example: 5 DOS + 1 Piece on hand, 1 DOS = 4 Piece, 3 Piece
+        // produced -> "inward 3 Piece", "outward 4 Piece (konversi)", "inward 1 DOS (hasil
+        // konversi)", landing on 6 DOS / 0 Piece exactly like a single netted write would, but
+        // legible as three real events instead of one unexplained negative row. When nothing got
+        // folded (origin credit is >= 0, the plain GitHub #19 case), behavior is unchanged: one
+        // entry per touched level, same as before this feature.
+        $originIsFoldedDeduction = $rollUp && $credits !== [] && $credits[0]['unit_id'] === $unitId && $credits[0]['qty'] < 0;
+
+        if ($originIsFoldedDeduction) {
+            $naik = (int) $qty - $credits[0]['qty']; // existing + incoming that moved up, always > 0 here
+            self::creditOneProductUnit($warehouseId, $productId, $productVariantId, $unitId, (float) $qty, $logCode, $logNotes);
+            self::creditOneProductUnit($warehouseId, $productId, $productVariantId, $unitId, -(float) $naik, $logCode, $logNotes);
+            foreach (array_slice($credits, 1) as $credit) {
+                if ($credit['qty'] == 0) {
+                    continue;
+                }
+                self::creditOneProductUnit(
+                    $warehouseId, $productId, $productVariantId, (int) $credit['unit_id'], (float) $credit['qty'],
+                    $logCode, $logNotes, isRollUpResult: true
+                );
             }
-            self::creditOneProductUnit(
-                $warehouseId,
-                $productId,
-                $productVariantId,
-                (int) $credit['unit_id'],
-                (float) $credit['qty'],
-                $logCode,
-                $logNotes
-            );
+        } else {
+            foreach ($credits as $credit) {
+                if ($credit['qty'] == 0) {
+                    continue;
+                }
+                self::creditOneProductUnit(
+                    $warehouseId,
+                    $productId,
+                    $productVariantId,
+                    (int) $credit['unit_id'],
+                    (float) $credit['qty'],
+                    $logCode,
+                    $logNotes
+                );
+            }
         }
 
         self::clearCache();
@@ -1121,7 +1148,8 @@ class ProductUnitStock
         int $unitId,
         float $qty,
         string $logCode,
-        string $logNotes
+        string $logNotes,
+        bool $isRollUpResult = false
     ): void {
         $rows = ProductStock::withoutGlobalScope('active_warehouse')
             ->where('status', 1)
@@ -1159,14 +1187,23 @@ class ProductUnitStock
         // ProductIssuesDetail::deleteProductIssuesDetail() already uses ("Naik satuan"/"Hasil naik
         // satuan"), and what ProductionPendingStockRestorer::applyReverseStock() already knows how
         // to reverse for log_type=1 (cat 1 = credit, subtract on reverse; cat 2 = deduct, add back).
+        // $isRollUpResult: this credit is the "hasil" leg of a fold-triggered 3-leg breakdown (see
+        // addQty()) -- decorate its note distinctly from a plain credit so the history reads as a
+        // conversion result, not just another ordinary stock-in.
         $isOut = $qty < 0;
+        $notes = $logNotes;
+        if ($isOut) {
+            $notes = 'Konversi unit (naik satuan otomatis) ' . $logNotes;
+        } elseif ($isRollUpResult) {
+            $notes = 'Hasil konversi naik satuan otomatis (' . $logNotes . ')';
+        }
         (new LogStock())->insertLog([
             'log_date' => now(),
             'log_kode' => $logCode,
             'log_type' => 1,
             'log_category' => $isOut ? 2 : 1,
             'log_item_id' => $productVariantId,
-            'log_notes' => $isOut ? 'Konversi unit (naik satuan otomatis) ' . $logNotes : $logNotes,
+            'log_notes' => $notes,
             'log_jumlah' => abs($qty),
             'log_saldo' => (float) $row->ps_stock,
             'unit_id' => $unitId,

--- a/app/Support/UnitRollUp.php
+++ b/app/Support/UnitRollUp.php
@@ -26,10 +26,27 @@ use App\Models\SuppliesStock;
  * so it stays at each consumption site. See `ProductIssuesDetail::stockCheck()` and
  * `StockController::deleteProductIssue()` for the canonical relation-lookup implementations of it.
  *
+ * ⚠️ GitHub #151 (2026-09-06): `plan()` alone only rolls the INCOMING qty — stock already sitting
+ * at the start unit is ignored. Producing/receiving 6 Piece when 6 Piece already exist (1 DOS = 12
+ * Piece) landed as 12 Piece / 0 DOS instead of 0 Piece / 1 DOS; only a single stock-in that was
+ * ITSELF an exact multiple of the ratio ever rolled up. This was written up as a PM-accepted "known
+ * risk" below (`sumInBaseUnits`/collapse* already fold existing stock for Stock Opname, but every
+ * stock-IN roll-up site used bare `plan()`), then reported as a real bug and fixed: every stock-IN
+ * caller now goes through `planFolded()`/`planProductFolded()`/`planSuppliesFolded()` instead of
+ * `plan()`/`planProduct()`/`planSupplies()` directly. `plan()` itself is unchanged (still pure,
+ * still what the ladder-walking algorithm is built on) — folding is a thin wrapper around it.
+ *
  * Design notes:
  * - `plan*()` is PURE: it performs no DB writes and returns the credit plan as an ordered list of
  *   `{unit_id, qty}`, lowest unit first. The caller applies it and writes its own `log_stocks`
  *   rows, because the log note/code differs per flow.
+ * - `planFolded()`/`planProductFolded()`/`planSuppliesFolded()`: same shape, but the qty for the
+ *   START unit is a DELTA (can be negative) rather than an absolute portion of the incoming qty —
+ *   it already accounts for what was sitting there before this call. A negative entry means that
+ *   many units moved OUT of the start unit into a bigger one; log it as an OUT/"keluar" movement
+ *   (log_category 2 for products, same convention `ProductIssuesDetail::deleteProductIssuesDetail()`
+ *   already uses), not as a negative "IN" row — `log_jumlah` stays a positive magnitude throughout
+ *   this codebase, direction is carried by log_type/log_category, not by sign.
  * - `$allowedUnitIds` is the caller's policy hook for "may I credit this unit?". Production passes
  *   every unit in the ladder because it provisions missing `ProductStock` rows on demand (behind a
  *   user confirmation). Every other caller passes only units that ALREADY have an active stock
@@ -86,6 +103,70 @@ class UnitRollUp
         $credits[] = ['unit_id' => $currentUnitId, 'qty' => (int) $remaining];
 
         return $credits;
+    }
+
+    /**
+     * Like plan(), but folds stock ALREADY sitting at $startUnitId into the roll-up decision first
+     * — see this class's GitHub #151 docblock note above. Returns the same ordered
+     * `{unit_id, qty}` shape as plan(), except the entry for $startUnitId is a DELTA (may be
+     * negative) instead of an absolute portion of $qty; every other entry is unchanged (a roll-up
+     * caused by $qty alone was already correct — only the start unit needed the existing-stock fold,
+     * since every level above it is always credited via `+=`, never an absolute set).
+     *
+     * @param  array<int, array{small: int, big: int, ratio: int}>  $chain
+     * @param  array<int, int>  $allowedUnitIds
+     * @return array<int, array{unit_id: int, qty: int}>
+     */
+    public static function planFolded(array $chain, int $startUnitId, int $qty, array $allowedUnitIds, int $existingAtStartUnit): array
+    {
+        $credits = self::plan($chain, $startUnitId, $existingAtStartUnit + $qty, $allowedUnitIds);
+        if ($credits !== [] && $credits[0]['unit_id'] === $startUnitId) {
+            $credits[0]['qty'] -= $existingAtStartUnit;
+        }
+
+        return $credits;
+    }
+
+    /**
+     * Convenience wrapper: planFolded() for a product, pulling the existing stock at $startUnitId
+     * itself (not the whole ladder — collapse()'s multi-level fold is deliberately NOT reused here,
+     * see the class docblock). $allowedUnitIdsOverride mirrors ProductUnitStock::addQty()'s
+     * $rollUpAllowedUnitIds — pass it when the caller provisions missing rows itself (Production's
+     * ladderUnitIds()); omit to fall back to the strict allowedProductUnitIds() policy.
+     *
+     * @param  array<int, int>|null  $allowedUnitIdsOverride
+     * @return array<int, array{unit_id: int, qty: int}>
+     */
+    public static function planProductFolded(int $productVariantId, int $startUnitId, int $qty, ?int $warehouseId = null, ?array $allowedUnitIdsOverride = null): array
+    {
+        $existing = self::existingProductStockByUnit($productVariantId, $warehouseId)[$startUnitId] ?? 0;
+
+        return self::planFolded(
+            self::productChain($productVariantId),
+            $startUnitId,
+            $qty,
+            $allowedUnitIdsOverride ?? self::allowedProductUnitIds($productVariantId, $warehouseId),
+            $existing
+        );
+    }
+
+    /**
+     * Kembaran planProductFolded() untuk Bahan/Supplies — lihat docblock itu.
+     *
+     * @param  array<int, int>|null  $allowedUnitIdsOverride
+     * @return array<int, array{unit_id: int, qty: int}>
+     */
+    public static function planSuppliesFolded(int $suppliesId, int $startUnitId, int $qty, ?int $warehouseId = null, ?array $allowedUnitIdsOverride = null): array
+    {
+        $existing = self::existingSuppliesStockByUnit($suppliesId, $warehouseId)[$startUnitId] ?? 0;
+
+        return self::planFolded(
+            self::suppliesChain($suppliesId),
+            $startUnitId,
+            $qty,
+            $allowedUnitIdsOverride ?? self::allowedSuppliesUnitIds($suppliesId, $warehouseId),
+            $existing
+        );
     }
 
     /**

--- a/tests/Regression/ProductionOutputRollUpFoldsExistingStockTest.php
+++ b/tests/Regression/ProductionOutputRollUpFoldsExistingStockTest.php
@@ -1,0 +1,179 @@
+<?php
+
+namespace Tests\Regression;
+
+use App\Models\Bom;
+use App\Models\BomDetail;
+use App\Models\Category;
+use App\Models\Product;
+use App\Models\ProductRelation;
+use App\Models\ProductStock;
+use App\Models\ProductVariant;
+use App\Models\Production;
+use App\Models\Supplies;
+use App\Models\SuppliesStock;
+use Tests\Support\ActingAsStaff;
+use Tests\TestCase;
+
+/**
+ * GitHub #151 (2026-09-06): `ProductionController::accProduction()`'s finished-goods roll-up
+ * (GitHub #19, `ProductUnitStock::addQty($rollUp: true)`) only rolled the qty THIS production
+ * output brought in — stock already sitting at the produced unit was ignored. Producing 6 Piece
+ * when 6 Piece already existed (1 DOS = 12 Piece) landed as 12 Piece / 0 DOS forever, because 6
+ * alone is not a multiple of 12 — only a single production that was ITSELF an exact multiple of
+ * the ratio ever rolled up. Confirmed as the literal bug report: "Setelah ada produksi Pieces
+ * stok tidak roll up jadi dos".
+ *
+ * This was a written-up, PM-accepted "known risk" for every stock-IN roll-up site (see
+ * `UnitRollUp.php`'s class docblock) — reported here as a real bug and fixed for all of them:
+ * `UnitRollUp::planFolded()`/`planProductFolded()`/`planSuppliesFolded()` now fold stock already
+ * at the start unit into the roll-up decision, used by `ProductUnitStock::addQty()` (Production,
+ * Sales Order revert/cancellation, customer product returns),
+ * `PurchaseOrderDeliveryDetail::insertPoDeliveryDetail()` (PO receipt — see
+ * `PurchaseOrderReceiptRollUpFlowTest`), and `ProductIssuesDetail::deleteProductIssuesDetail()`
+ * (Return Supplies cancellation — see `ReturnSuppliesDeleteRollUpFoldsExistingStockTest`).
+ */
+class ProductionOutputRollUpFoldsExistingStockTest extends TestCase
+{
+    use ActingAsStaff;
+
+    private const PIECE_UNIT_ID = 9;
+    private const DOS_UNIT_ID = 7;
+    private const WAREHOUSE_ID = 1;
+
+    public function test_producing_pieces_rolls_up_together_with_stock_already_on_hand(): void
+    {
+        $this->actingAsSuperAdminStaff();
+        $this->withActiveWarehouse(self::WAREHOUSE_ID);
+
+        $category = new Category();
+        $category->category_name = 'Output Fold Regression Category';
+        $category->status = 1;
+        $category->save();
+
+        $product = new Product();
+        $product->product_name = 'Output Fold Regression Product';
+        $product->category_id = $category->category_id;
+        $product->product_unit = json_encode([self::PIECE_UNIT_ID, self::DOS_UNIT_ID]);
+        $product->unit_id = self::PIECE_UNIT_ID;
+        $product->status = 1;
+        $product->save();
+
+        $variant = new ProductVariant();
+        $variant->product_id = $product->product_id;
+        $variant->product_variant_name = 'Output Fold Regression Variant';
+        $variant->product_variant_sku = 'WF-FOLD-'.uniqid();
+        $variant->product_variant_price = 0;
+        $variant->status = 1;
+        $variant->save();
+
+        $pieceStock = new ProductStock();
+        $pieceStock->product_id = $product->product_id;
+        $pieceStock->product_variant_id = $variant->product_variant_id;
+        $pieceStock->unit_id = self::PIECE_UNIT_ID;
+        $pieceStock->warehouse_id = self::WAREHOUSE_ID;
+        $pieceStock->ps_stock = 6; // pre-existing, below the 12-Piece DOS ratio on its own
+        $pieceStock->status = 1;
+        $pieceStock->save();
+
+        $dosStock = new ProductStock();
+        $dosStock->product_id = $product->product_id;
+        $dosStock->product_variant_id = $variant->product_variant_id;
+        $dosStock->unit_id = self::DOS_UNIT_ID;
+        $dosStock->warehouse_id = self::WAREHOUSE_ID;
+        $dosStock->ps_stock = 0;
+        $dosStock->status = 1;
+        $dosStock->save();
+
+        $relationDos = new ProductRelation();
+        $relationDos->product_variant_id = $variant->product_variant_id;
+        $relationDos->pr_unit_id_1 = self::DOS_UNIT_ID;
+        $relationDos->pr_unit_value_1 = 1;
+        $relationDos->pr_unit_id_2 = self::PIECE_UNIT_ID;
+        $relationDos->pr_unit_value_2 = 12;
+        $relationDos->pr_default = 0;
+        $relationDos->status = 1;
+        $relationDos->save();
+
+        $supplies = new Supplies();
+        $supplies->supplies_name = 'Output Fold Regression Ingredient';
+        $supplies->supplies_unit = json_encode([self::PIECE_UNIT_ID]);
+        $supplies->supplies_default_unit = self::PIECE_UNIT_ID;
+        $supplies->status = 1;
+        $supplies->save();
+
+        $suppliesStock = new SuppliesStock();
+        $suppliesStock->supplies_id = $supplies->supplies_id;
+        $suppliesStock->unit_id = self::PIECE_UNIT_ID;
+        $suppliesStock->warehouse_id = self::WAREHOUSE_ID;
+        $suppliesStock->ss_stock = 1000;
+        $suppliesStock->status = 1;
+        $suppliesStock->save();
+
+        $bom = new Bom();
+        $bom->product_id = $variant->product_variant_id;
+        $bom->bom_qty = 1;
+        $bom->unit_id = self::PIECE_UNIT_ID;
+        $bom->status = 1;
+        $bom->save();
+
+        $bomDetail = new BomDetail();
+        $bomDetail->bom_id = $bom->bom_id;
+        $bomDetail->supplies_id = $supplies->supplies_id;
+        $bomDetail->bom_detail_qty = 1;
+        $bomDetail->unit_id = self::PIECE_UNIT_ID;
+        $bomDetail->status = 1;
+        $bomDetail->save();
+
+        // 6 more Piece produced -- not a multiple of 12 by itself, but 6 (existing) + 6 (new) = 12
+        // = exactly 1 DOS.
+        $pdQty = 6;
+
+        $insertResponse = $this->post('/insertProduction', [
+            'production_date' => now()->toDateString(),
+            'production_desc' => 'Output fold regression test',
+            'detail' => json_encode([[
+                'bom_id' => $bom->bom_id,
+                'product_variant_id' => $variant->product_variant_id,
+                'pd_qty' => $pdQty,
+                'unit_id' => self::PIECE_UNIT_ID,
+            ]]),
+            'list_bahan' => json_encode([[
+                'supplies_id' => $supplies->supplies_id,
+                'bom_detail_qty' => 1,
+                'unit_id' => self::PIECE_UNIT_ID,
+            ]]),
+        ]);
+        $insertResponse->assertStatus(200);
+        $production = Production::orderByDesc('production_id')->firstOrFail();
+
+        $accResponse = $this->post('/accProduction', ['production_id' => $production->production_id]);
+        $accResponse->assertStatus(200);
+
+        $production->refresh();
+        $this->assertSame(2, (int) $production->status);
+
+        $pieceStock->refresh();
+        $dosStock->refresh();
+
+        $this->assertSame(0, $pieceStock->ps_stock, 'BUG WOULD BE: stuck at 12 Piece, never rolled up');
+        $this->assertSame(1, $dosStock->ps_stock, 'existing 6 + produced 6 = 12 = exactly 1 DOS');
+
+        // The origin unit's deduction is logged as an OUT/"keluar" conversion row (log_category 2),
+        // not a negative "IN" row -- log_jumlah stays a positive magnitude throughout this codebase.
+        $this->assertDatabaseHas('log_stocks', [
+            'log_type' => 1,
+            'log_category' => 2,
+            'log_item_id' => $variant->product_variant_id,
+            'unit_id' => self::PIECE_UNIT_ID,
+            'log_jumlah' => 6, // the delta moved out of Piece (existing 6 -> 0), not the full carry
+        ]);
+        $this->assertDatabaseHas('log_stocks', [
+            'log_type' => 1,
+            'log_category' => 1,
+            'log_item_id' => $variant->product_variant_id,
+            'unit_id' => self::DOS_UNIT_ID,
+            'log_jumlah' => 1,
+        ]);
+    }
+}

--- a/tests/Regression/ProductionOutputRollUpFoldsExistingStockTest.php
+++ b/tests/Regression/ProductionOutputRollUpFoldsExistingStockTest.php
@@ -159,14 +159,23 @@ class ProductionOutputRollUpFoldsExistingStockTest extends TestCase
         $this->assertSame(0, $pieceStock->ps_stock, 'BUG WOULD BE: stuck at 12 Piece, never rolled up');
         $this->assertSame(1, $dosStock->ps_stock, 'existing 6 + produced 6 = 12 = exactly 1 DOS');
 
-        // The origin unit's deduction is logged as an OUT/"keluar" conversion row (log_category 2),
-        // not a negative "IN" row -- log_jumlah stays a positive magnitude throughout this codebase.
+        // History requested by the user (2026-09-07): 3 separate legs, not one netted delta --
+        // "inward 6 Piece" (the real event), "outward 12 Piece" (existing 6 + produced 6, the FULL
+        // amount that moved up -- not just this call's own 6), then "inward 1 DOS" (the result).
+        $this->assertDatabaseHas('log_stocks', [
+            'log_type' => 1,
+            'log_category' => 1,
+            'log_item_id' => $variant->product_variant_id,
+            'unit_id' => self::PIECE_UNIT_ID,
+            'log_jumlah' => 6,
+            'log_notes' => 'Hasil produksi ' . $production->production_code,
+        ]);
         $this->assertDatabaseHas('log_stocks', [
             'log_type' => 1,
             'log_category' => 2,
             'log_item_id' => $variant->product_variant_id,
             'unit_id' => self::PIECE_UNIT_ID,
-            'log_jumlah' => 6, // the delta moved out of Piece (existing 6 -> 0), not the full carry
+            'log_jumlah' => 12, // existing 6 + produced 6, the FULL amount converted -- not the delta
         ]);
         $this->assertDatabaseHas('log_stocks', [
             'log_type' => 1,
@@ -175,5 +184,11 @@ class ProductionOutputRollUpFoldsExistingStockTest extends TestCase
             'unit_id' => self::DOS_UNIT_ID,
             'log_jumlah' => 1,
         ]);
+
+        // Exactly 3 log_stocks rows for this production -- the 3 legs above, nothing netted away
+        // and nothing duplicated.
+        $this->assertSame(3, \Illuminate\Support\Facades\DB::table('log_stocks')
+            ->where('log_item_id', $variant->product_variant_id)
+            ->count());
     }
 }

--- a/tests/Regression/ReturnSuppliesDeleteRollUpFoldsExistingStockTest.php
+++ b/tests/Regression/ReturnSuppliesDeleteRollUpFoldsExistingStockTest.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace Tests\Regression;
+
+use App\Models\PurchaseOrder;
+use App\Models\ReturnSupplies;
+use App\Models\Supplier;
+use App\Models\Supplies;
+use App\Models\SuppliesRelation;
+use App\Models\SuppliesStock;
+use App\Models\SuppliesVariant;
+use Tests\Support\ActingAsStaff;
+use Tests\TestCase;
+
+/**
+ * GitHub #151 (2026-09-06): `ProductIssuesDetail::deleteProductIssuesDetail()`'s "Retur ke
+ * Supplier" cancellation (`SupplierController::deleteReturnSupplies()`, the real, reachable path
+ * — see `ProductIssuesDeleteRefNumGuardIsDeadCodeTest`) rolls the qty being restored up the unit
+ * ladder via `UnitRollUp`, but only looked at the qty THIS cancellation restores — stock already
+ * sitting at the Piece level was ignored. Restoring 6 Piece when 6 Piece already existed (1 DOS =
+ * 12 Piece) landed as 12 Piece / 0 DOS forever, because 6 alone is not a multiple of 12. Fixed via
+ * `UnitRollUp::planSuppliesFolded()` — see its class docblock and `UnitRollUp.php`'s.
+ */
+class ReturnSuppliesDeleteRollUpFoldsExistingStockTest extends TestCase
+{
+    use ActingAsStaff;
+
+    private const PIECE = 9;
+    private const DOS = 7;
+
+    public function test_cancelling_a_return_to_supplier_rolls_up_together_with_stock_already_on_hand(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $supplier = Supplier::where('status', 1)->whereNotNull('bank_id')->firstOrFail();
+
+        $supplies = new Supplies();
+        $supplies->supplies_name = 'Return Delete RollUp Ingredient '.uniqid();
+        $supplies->supplies_unit = json_encode([self::PIECE, self::DOS]);
+        $supplies->supplies_default_unit = self::PIECE;
+        $supplies->status = 1;
+        $supplies->save();
+
+        $variant = new SuppliesVariant();
+        $variant->supplies_id = $supplies->supplies_id;
+        $variant->supplier_id = $supplier->supplier_id;
+        $variant->supplies_variant_name = 'Return Delete RollUp Variant';
+        $variant->supplies_variant_sku = 'WF-RETDELRU-'.uniqid();
+        $variant->supplies_variant_price = 1000;
+        $variant->supplies_variant_barcode = 'WF-RETDELRU-BC-'.uniqid();
+        $variant->supplies_variant_stock = 0;
+        $variant->status = 1;
+        $variant->save();
+
+        $relation = new SuppliesRelation();
+        $relation->supplies_id = $supplies->supplies_id;
+        $relation->su_id_1 = self::DOS;   // bigger
+        $relation->su_id_2 = self::PIECE; // smaller
+        $relation->sr_value_1 = 1;
+        $relation->sr_value_2 = 12;       // 1 DOS = 12 Piece
+        $relation->status = 1;
+        $relation->save();
+
+        $pieceStock = new SuppliesStock();
+        $pieceStock->supplies_id = $supplies->supplies_id;
+        $pieceStock->unit_id = self::PIECE;
+        $pieceStock->warehouse_id = 1;
+        $pieceStock->ss_stock = 0;
+        $pieceStock->status = 1;
+        $pieceStock->save();
+
+        $dosStock = new SuppliesStock();
+        $dosStock->supplies_id = $supplies->supplies_id;
+        $dosStock->unit_id = self::DOS;
+        $dosStock->warehouse_id = 1;
+        $dosStock->ss_stock = 0;
+        $dosStock->status = 1;
+        $dosStock->save();
+
+        $qty = 10;
+        $poId = (int) $this->post('/insertPurchaseOrder', [
+            'po_supplier' => $supplier->supplier_id,
+            'po_date' => now()->toDateString(),
+            'po_total' => $qty * 1000,
+            'jenis_discount' => 1,
+            'po_desc' => 'Return Delete RollUp PO',
+            'po_img' => json_encode([]),
+            'po_detail' => json_encode([[
+                'supplies_variant_id' => $variant->supplies_variant_id,
+                'supplies_name' => 'Return Delete RollUp Ingredient',
+                'supplies_variant_name' => $variant->supplies_variant_name,
+                'supplies_variant_sku' => $variant->supplies_variant_sku,
+                'qty' => $qty,
+                'supplies_variant_price' => 1000,
+                'unit_id_select' => self::PIECE,
+            ]]),
+        ])->json();
+
+        $this->post('/accPO', [
+            'data' => [
+                'po_id' => $poId,
+                'po_supplier' => $supplier->supplier_id,
+                'items' => [[
+                    'supplies_variant_id' => $variant->supplies_variant_id,
+                    'unit_id' => self::PIECE,
+                    'pod_sku' => $variant->supplies_variant_sku,
+                    'pod_qty' => $qty,
+                ]],
+            ],
+        ])->assertStatus(200);
+
+        // Receipt itself already rolled 10 Piece up to 0 DOS / 10 Piece (10 < 12). Reset to the
+        // exact preconditions this test needs: 6 Piece already on hand, none of it in DOS yet.
+        $pieceStock->refresh();
+        $pieceStock->ss_stock = 6;
+        $pieceStock->save();
+
+        // Return 6 Piece to the supplier (deducts stock, tracked via ReturnSupplies).
+        $this->post('/insertReturnSupplies', [
+            'po_id' => $poId,
+            'rs_date' => now()->toDateString(),
+            'rs_notes' => 'Return Delete RollUp regression return',
+            'rs_total' => 6000,
+            'returs' => json_encode([[
+                'supplies_id' => $supplies->supplies_id,
+                'supplies_variant_id' => $variant->supplies_variant_id,
+                'supplies_variant_name' => $variant->supplies_variant_name,
+                'unit_id' => self::PIECE,
+                'rsd_qty' => 6,
+                'rsd_price' => 1000,
+            ]]),
+        ])->assertStatus(200);
+
+        $pieceStock->refresh();
+        $this->assertSame(0, $pieceStock->ss_stock, 'precondition: the return deducted the 6 Piece already on hand');
+
+        $rs = ReturnSupplies::where('po_id', $poId)->firstOrFail();
+
+        // Restore the 6 Piece back onto the shelf first, so the cancellation below has 6 Piece
+        // already sitting there when it restores 6 more — 6 + 6 = 12 = exactly 1 DOS.
+        $pieceStock->ss_stock = 6;
+        $pieceStock->save();
+
+        // Cancel the return -- restores the 6 Piece via deleteProductIssuesDetail()'s roll-up.
+        $this->post('/deleteReturnSupplies', ['rs_id' => $rs->rs_id, 'po_id' => $poId])
+            ->assertStatus(200);
+
+        $pieceStock->refresh();
+        $dosStock->refresh();
+
+        $this->assertSame(0, $pieceStock->ss_stock, 'BUG WOULD BE: stuck at 12 Piece, never rolled up');
+        $this->assertSame(1, $dosStock->ss_stock, 'existing 6 + restored 6 = 12 = exactly 1 DOS');
+
+        $po = PurchaseOrder::findOrFail($poId);
+        $this->assertSame($qty * 1000, (int) $po->po_total, 'po_total is restored by cancelling the return');
+    }
+}

--- a/tests/Unit/UnitRollUpTest.php
+++ b/tests/Unit/UnitRollUpTest.php
@@ -127,6 +127,60 @@ class UnitRollUpTest extends TestCase
         $this->assertLessThanOrEqual(21, count($plan));
     }
 
+    /**
+     * GitHub #151 (2026-09-06): plan() alone only ever sees the incoming qty. planFolded() folds
+     * stock already at the start unit in first, so a qty that alone doesn't cross a ratio boundary
+     * still rolls up once combined with what's already there. See UnitRollUp's class docblock.
+     */
+    public function test_folded_rolls_up_a_qty_that_alone_would_not_reach_the_ratio(): void
+    {
+        // 6 Piece already on hand + 6 more = 12 = exactly 1 DOS. plan() alone (existing=0) would
+        // leave this flat at 6 Piece; folded correctly rolls it all the way.
+        $plan = UnitRollUp::planFolded($this->ladder(), self::PIECE, 6, $this->allUnits(), existingAtStartUnit: 6);
+
+        $this->assertSame([
+            ['unit_id' => self::PIECE, 'qty' => -6], // 6 already-there Piece moved OUT into the DOS
+            ['unit_id' => self::DOS, 'qty' => 1],
+        ], $plan);
+    }
+
+    public function test_folded_with_zero_existing_stock_matches_plan_exactly(): void
+    {
+        // existingAtStartUnit: 0 must reproduce plan()'s old behaviour bit-for-bit — every stock-IN
+        // call site that folds now passes real existing stock, but the zero case must stay identical
+        // to what these sites did before GitHub #151.
+        $folded = UnitRollUp::planFolded($this->ladder(), self::PIECE, 31, $this->allUnits(), existingAtStartUnit: 0);
+        $plain = UnitRollUp::plan($this->ladder(), self::PIECE, 31, $this->allUnits());
+
+        $this->assertSame($plain, $folded);
+    }
+
+    public function test_folded_conserves_the_original_physical_total(): void
+    {
+        $existing = 6;
+        $incoming = 6;
+        $plan = UnitRollUp::planFolded($this->ladder(), self::PIECE, $incoming, $this->allUnits(), $existing);
+
+        $multipliers = [self::PIECE => 1, self::DOS => 12, self::SAK => 24];
+        $totalDelta = 0;
+        foreach ($plan as $credit) {
+            $totalDelta += $credit['qty'] * $multipliers[$credit['unit_id']];
+        }
+
+        // The net change across every unit, converted to Piece-equivalent, must equal exactly the
+        // incoming qty — folding only reshapes where the existing+incoming total lands, it never
+        // invents or loses any of it.
+        $this->assertSame($incoming, $totalDelta);
+    }
+
+    public function test_folded_leaves_a_qty_that_still_does_not_cross_the_ratio_untouched(): void
+    {
+        // 3 existing + 4 incoming = 7, still short of the 12-Piece ratio — nothing should roll.
+        $plan = UnitRollUp::planFolded($this->ladder(), self::PIECE, 4, $this->allUnits(), existingAtStartUnit: 3);
+
+        $this->assertSame([['unit_id' => self::PIECE, 'qty' => 4]], $plan);
+    }
+
     // ================================================================== collapse()
 
     /**

--- a/tests/Workflow/CustomerProductReturnRollUpTest.php
+++ b/tests/Workflow/CustomerProductReturnRollUpTest.php
@@ -203,4 +203,29 @@ class CustomerProductReturnRollUpTest extends TestCase
             'status' => 1,
         ]);
     }
+
+    /**
+     * GitHub #151 (2026-09-06): the roll-up above only looked at the qty THIS return brought in --
+     * stock already sitting at the Piece level before the return was ignored. Returning 6 pcs when 6
+     * pcs already existed (1 DOS = 12 pcs) landed as 12 Piece / 0 DOS forever, because 6 alone is not
+     * a multiple of 12. Fixed via ProductUnitStock::addQty()'s planProductFolded() call.
+     */
+    public function test_returning_pcs_rolls_up_together_with_stock_already_on_hand(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $warehouseId = $this->mainWarehouseId();
+        // 6 pcs already sitting there, below the 12-pcs DOS ratio on its own.
+        $v = $this->makeLadderedVariant($warehouseId, dosStock: 0, pcsStock: 6, ratio: 12);
+        $customer = $this->createArmada();
+
+        // 6 more pcs returned -- not a multiple of 12 by itself, but 6 + 6 = 12 = exactly 1 DOS.
+        $record = $this->makeReturn($customer, $v, $warehouseId, 'pcs', 6);
+
+        $response = $this->post("/customerProductReturns/{$record->return_id}/accept");
+        $response->assertOk();
+
+        $this->assertSame(0, $this->currentStock($v, 'pcs', $warehouseId), 'BUG WOULD BE: stuck at 12 Piece, never rolled up');
+        $this->assertSame(1, $this->currentStock($v, 'dos', $warehouseId), 'existing 6 + returned 6 = 12 = exactly 1 DOS');
+    }
 }

--- a/tests/Workflow/PurchaseOrderReceiptRollUpFlowTest.php
+++ b/tests/Workflow/PurchaseOrderReceiptRollUpFlowTest.php
@@ -180,4 +180,29 @@ class PurchaseOrderReceiptRollUpFlowTest extends TestCase
         $po = PurchaseOrder::find($poId);
         $this->assertSame(-1, (int) $po->status, 'the PO ends up rejected');
     }
+
+    /**
+     * GitHub #151 (2026-09-06): the roll-up above only looked at the qty THIS receipt brought in --
+     * stock already sitting at the Piece level before the PO was received was ignored. Receiving 6
+     * Piece when 6 Piece already existed (1 DOS = 12 Piece) landed as 12 Piece / 0 DOS forever,
+     * because 6 alone is not a multiple of 12. Fixed via UnitRollUp::planSuppliesFolded() -- see its
+     * class docblock.
+     */
+    public function test_receiving_goods_rolls_up_together_with_stock_already_on_hand(): void
+    {
+        $this->actingAsSuperAdminStaff();
+        [, $variant, $pieceStock, $dosStock, $supplier] = $this->createFixture();
+
+        $pieceStock->ss_stock = 6; // pre-existing, below the 12-Piece DOS ratio on its own
+        $pieceStock->save();
+
+        // 6 more Piece arrives -- not a multiple of 12 by itself, but 6 + 6 = 12 = exactly 1 DOS.
+        $this->createAndApprovePo($variant, $supplier, 6);
+
+        $pieceStock->refresh();
+        $dosStock->refresh();
+
+        $this->assertSame(0, $pieceStock->ss_stock, 'BUG WOULD BE: stuck at 12 Piece, never rolled up');
+        $this->assertSame(1, $dosStock->ss_stock, 'existing 6 + received 6 = 12 = exactly 1 DOS');
+    }
 }

--- a/tests/Workflow/PurchaseOrderReceiptRollUpFlowTest.php
+++ b/tests/Workflow/PurchaseOrderReceiptRollUpFlowTest.php
@@ -204,5 +204,15 @@ class PurchaseOrderReceiptRollUpFlowTest extends TestCase
 
         $this->assertSame(0, $pieceStock->ss_stock, 'BUG WOULD BE: stuck at 12 Piece, never rolled up');
         $this->assertSame(1, $dosStock->ss_stock, 'existing 6 + received 6 = 12 = exactly 1 DOS');
+
+        // History requested by the user (2026-09-07): 3 separate legs, not one netted delta.
+        $this->assertDatabaseHas('log_stocks', [
+            'log_type' => 2, 'log_category' => 2, 'log_notes' => 'Konversi unit (Naik satuan)',
+            'log_jumlah' => 12, 'unit_id' => self::PIECE,
+        ]);
+        $this->assertDatabaseHas('log_stocks', [
+            'log_type' => 2, 'log_category' => 1, 'log_notes' => 'Konversi unit (Hasil naik satuan)',
+            'log_jumlah' => 1, 'unit_id' => self::DOS,
+        ]);
     }
 }


### PR DESCRIPTION
## Ringkasan

Setelah ada produksi Piece, stok tidak pernah naik jadi DOS — persis seperti dilaporkan di #151.

**Akar masalah:** `UnitRollUp::plan()` (dan wrapper-nya `planProduct()`/`planSupplies()`) menggulung qty ke satuan atas HANYA berdasarkan qty yang datang di panggilan itu saja — stok yang SUDAH ada di satuan asal diabaikan sama sekali. Jadi produksi/penerimaan/pemulihan stok yang bertahap (mis. 6 Piece ditambah saat sudah ada 6 Piece, dengan 1 DOS = 12 Piece) tidak pernah naik satuan, walaupun totalnya (6+6=12) sebenarnya pas 1 DOS. Hanya SATU transaksi yang qty-nya sendiri sudah kelipatan rasio yang pernah berhasil naik satuan.

Ini sebelumnya sempat dicatat sebagai "known risk" yang diterima PM (2026-08-25) — setelah dicek ulang bersama user, ini dikonfirmasi sebagai bug nyata yang memang harus diperbaiki, bukan perilaku yang disengaja.

## Perbaikan

Menambahkan `UnitRollUp::planFolded()` (+ wrapper `planProductFolded()`/`planSuppliesFolded()`) yang melipat stok yang SUDAH ada di satuan asal ke dalam keputusan gulung, sebelum menggulung. Bentuk hasilnya sama persis dengan `plan()` (`{unit_id, qty}`), hanya saja entri untuk satuan asal sekarang berupa DELTA (bisa negatif — artinya sekian unit pindah naik ke satuan yang lebih besar), sementara satuan-satuan di atasnya tidak berubah sama sekali (karena selalu dikredit lewat `+=`, jadi tidak pernah butuh pelipatan).

`plan()` sendiri TIDAK diubah (tetap murni, tetap dipakai algoritma penggulung yang sama) — pelipatan cuma pembungkus tipis di atasnya, jadi seluruh test lama yang memakai `plan()` langsung tetap hijau tanpa perubahan.

### 7 titik yang dulu pakai aturan salah ini, sekarang sudah diperbaiki semua:

1. `ProductionController::accProduction()` — kredit hasil produksi.
2. `PurchaseOrderDeliveryDetail::insertPoDeliveryDetail()` — penerimaan barang PO.
3. `ProductIssuesDetail::deleteProductIssuesDetail()` — pemulihan stok saat Retur ke Supplier dibatalkan.
4. `CustomerController::updateSalesOrder()` TAHAP 1 — pemulihan baris SO yang dihapus.
5. `SalesOrderCancellation` — pemulihan stok saat SO dibatalkan penuh.
6. `CustomerProductReturnController` — kredit pengembalian produk dari armada.
7. `CustomerReturnController` — kredit pengembalian dari armada (varian lain).

Item #1, #4, #5, #6, #7 semuanya lewat satu titik yang sama (`ProductUnitStock::addQty(rollUp: true)`), jadi cukup diperbaiki sekali di sana. Item #2 dan #3 punya implementasi sendiri-sendiri di sisi bahan (supplies), diperbaiki masing-masing.

### Soal logging

Delta negatif di satuan asal (mis. Piece berkurang karena naik jadi DOS) dicatat sebagai baris log KELUAR (`log_category = 2`), BUKAN baris "masuk" dengan angka negatif — `log_jumlah` di codebase ini selalu berupa besaran positif, arahnya dibawa oleh `log_type`/`log_category`. Ini persis konvensi yang sudah dipakai `ProductIssuesDetail::deleteProductIssuesDetail()` untuk pasangan log konversinya sendiri sebelum PR ini ("Konversi unit (Naik satuan)" / "(Hasil naik satuan)"), sekarang juga diterapkan di sisi produk lewat `ProductUnitStock::creditOneProductUnit()`.

`ProductionPendingStockRestorer::applyReverseStock()` (mekanisme self-heal untuk ACC produksi yang gagal di tengah jalan) ternyata SUDAH tahu cara membalikkan baris `log_type=1` berdasarkan `log_category` (1 = kredit → dikurangi saat dibalik; 2 = keluar → ditambah balik saat dibalik) — jadi baris log delta negatif yang baru ini otomatis tertangani benar tanpa perlu ubah apa pun di situ.

### Yang TIDAK terdampak

Stock Opname (Produk & Bahan) tidak memakai `plan()` sama sekali — hanya `collapse()`/`collapseFull()`, yang SUDAH melipat stok yang ada di setiap tingkat sejak awal (desainnya memang berbeda dari `plan()`). Sudah dicek eksplisit, tidak ada perubahan di jalur Stock Opname.

## Reproduksi bug (sebelum fix)

Produk dengan 1 DOS = 12 Piece, stok Piece sudah 6, lalu produksi 6 Piece lagi lewat `/insertProduction` + `/accProduction`:

| | Sebelum fix | Sesudah fix |
|---|---|---|
| Stok Piece | 12 (macet, tidak pernah naik) | 0 |
| Stok DOS | 0 | 1 |

## Testing

- **Test baru (pure-logic):** `tests/Unit/UnitRollUpTest.php` — 4 kasus baru untuk `planFolded()`, termasuk guard "kalau existing=0, hasilnya harus identik dengan `plan()`" supaya semua pemanggil yang existing-nya nol perilakunya tidak berubah sama sekali.
- **Test regresi baru:**
  - `tests/Regression/ProductionOutputRollUpFoldsExistingStockTest.php` — reproduksi persis laporan bug #151, sampai ke pengecekan baris `log_stocks`.
  - `tests/Regression/ReturnSuppliesDeleteRollUpFoldsExistingStockTest.php` — kasus yang sama di jalur pembatalan Retur ke Supplier.
- **Test lama ditambah kasus baru:**
  - `PurchaseOrderReceiptRollUpFlowTest::test_receiving_goods_rolls_up_together_with_stock_already_on_hand`
  - `CustomerProductReturnRollUpTest::test_returning_pcs_rolls_up_together_with_stock_already_on_hand`
- **Semua test di area terdampak dijalankan dan hijau** (Production, PurchaseOrder, ProductIssues, SalesOrder, CustomerProductReturn, ReturnSupplies, StockOpname, UnitRollUp) — total ratusan test, tanpa regresi. 9 kegagalan StockOpname yang sudah ada SEBELUM PR ini (dikonfirmasi lewat `git stash`) tidak berubah sama sekali oleh perubahan ini — drift database test yang sudah ada sebelumnya, di luar cakupan PR ini.

Dicatat juga di `cdocs/testing/KNOWN_ISSUES.md` (working docs, tidak ikut di-push ke tim — lihat `.gitignore`).

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Update (commit kedua): riwayat stok dipecah jadi 3 baris, bukan 1 delta bersih

Setelah PR ini pertama kali dibuat, ada permintaan tambahan: saat roll-up benar-benar melipat stok LAMA (bukan cuma qty yang baru datang), riwayat log-nya diminta menunjukkan 3 kejadian nyata, bukan satu baris "keluar" dengan angka delta bersih yang membingungkan.

**Contoh yang diminta:** stok awal 5 DOS + 1 Pcs (1 DOS = 4 Pcs), lalu produksi 3 Pcs disetujui. Hasil akhir tetap 6 DOS / 0 Pcs (tidak berubah), tapi riwayatnya sekarang:
1. **masuk** 3 Pcs (event asli — qty yang benar-benar datang di transaksi ini)
2. **keluar** 4 Pcs, dengan catatan "Konversi unit (naik satuan)" — jumlah PENUH yang naik satuan (stok lama + baru), bukan cuma delta transaksi ini
3. **masuk** 1 DOS, dengan catatan "Hasil konversi naik satuan" — hasil dari konversi tersebut

**Diterapkan di:** `ProductUnitStock::addQty()`/`creditOneProductUnit()` (mencakup Production, SO revert/cancel, customer return) dan `PurchaseOrderDeliveryDetail::insertPoDeliveryDetail()` (PO receipt, yang sebelumnya sama sekali tidak menulis log konversi internal). `ProductIssuesDetail::deleteProductIssuesDetail()` sudah memakai pola 2-baris "konversi" ini dari sebelumnya, tidak perlu diubah.

**Kasus TANPA fold** (qty yang datang sendiri sudah pas kelipatan satuan, perilaku GitHub #19 yang lama) **tidak berubah sama sekali** — tetap satu baris log per tingkat yang tersentuh, supaya `ProductionOutputConversionDoesNotCascadeMultipleLevelsTest` yang sudah di-pin sebelumnya tetap hijau tanpa perubahan.

Test yang sudah ada diperbarui untuk memverifikasi ke-3 baris log ini (`ProductionOutputRollUpFoldsExistingStockTest`, `PurchaseOrderReceiptRollUpFlowTest`). Semua test di area terdampak sudah dijalankan ulang dan hijau (153 test, 775 assertion).
