### PR TITLE
fix(ui): perbaiki tabel & navbar hancur di layar tablet/hp (#153)

### DIFF
--- a/resources/views/Backoffice/Customer/customer.blade.php
+++ b/resources/views/Backoffice/Customer/customer.blade.php
@@ -4,6 +4,10 @@
     <style>
         #tableCustomer {
             width: 100% !important;
+            /* Sama seperti isu #153 di tabel Pengiriman: jangan sampai kolom
+               diperas di layar sempit — min-width memaksa tabel overflow
+               horizontal sehingga .table-responsive bisa di-scroll ke samping. */
+            min-width: 900px;
             table-layout: fixed;
         }
 
@@ -24,6 +28,10 @@
             letter-spacing: .4px;
             background: #f1f5f9;
             border-bottom: 1px solid #e2e8f0;
+            /* Label header pendek — kalau tidak muat, pindahkan seluruh kata ke
+               baris berikutnya, jangan dipenggal di tengah huruf. */
+            word-break: keep-all;
+            overflow-wrap: normal;
         }
 
         #tableCustomer tbody td {
@@ -70,7 +78,7 @@
                 <div class="col-sm-12">
                     <div class="card-table">
                         <div class="card-body">
-                            <div class="table-responsive dt-pending" id="tableCustomer-wrap" style="border: 1px solid #e2e8f0; border-radius: 8px; overflow: hidden;">
+                            <div class="table-responsive dt-pending" id="tableCustomer-wrap" style="border: 1px solid #e2e8f0; border-radius: 8px; overflow-x: auto; overflow-y: hidden;">
                                 <table class="table table-center table-hover mb-0" id="tableCustomer">
                                     <thead style="background:#f1f5f9; border-bottom: 1px solid #e2e8f0;">
                                         <tr>

--- a/resources/views/Backoffice/Customers/Sales_Order.blade.php
+++ b/resources/views/Backoffice/Customers/Sales_Order.blade.php
@@ -40,6 +40,10 @@
 
         #tableSalesOrder {
             width: 100% !important;
+            /* Jaga proporsi kolom, tapi jangan sampai diperas di layar sempit (tablet/hp) —
+               min-width memaksa tabel overflow horizontal sehingga .table-responsive bisa
+               di-scroll ke samping, bukan meremukkan tiap kolom jadi tidak terbaca. */
+            min-width: 1000px;
             table-layout: fixed;
         }
 
@@ -59,6 +63,10 @@
             letter-spacing: .4px;
             background: #f1f5f9;
             border-bottom: 1px solid #e2e8f0;
+            /* Header cuma berisi label pendek (mis. "NO. INVOICE") — jangan sampai
+               kata dipenggal di tengah huruf, biarkan seluruh kata pindah baris. */
+            word-break: keep-all;
+            overflow-wrap: normal;
         }
 
         #tableSalesOrder tbody td {
@@ -328,7 +336,7 @@
                 <div class="col-sm-12">
                     <div class=" card-table">
                         <div class="card-body">
-                            <div class="table-responsive dt-pending" id="tableSalesOrder-wrap" style="border: 1px solid #e2e8f0; border-radius: 8px; overflow: hidden;">
+                            <div class="table-responsive dt-pending" id="tableSalesOrder-wrap" style="border: 1px solid #e2e8f0; border-radius: 8px; overflow-x: auto; overflow-y: hidden;">
                                 <div class="dt-skeleton" aria-hidden="true">
                                     <div style="padding: 16px 25px;">
                                         <span class="skel-text" style="width: 250px; height: 38px; border-radius: 20px;"></span>

--- a/resources/views/Backoffice/Production/Bom.blade.php
+++ b/resources/views/Backoffice/Production/Bom.blade.php
@@ -14,6 +14,9 @@
         /* Pola DataTable sama Produksi */
         #tableBom {
             width: 100% !important;
+            /* Sama seperti isu #153 di tabel Pengiriman: min-width memaksa tabel
+               overflow horizontal di layar sempit, bukan meremukkan kolom. */
+            min-width: 900px;
             table-layout: fixed;
         }
 
@@ -33,6 +36,10 @@
             letter-spacing: .4px;
             background: #f1f5f9;
             border-bottom: 1px solid #e2e8f0;
+            /* Header pendek — pindahkan seluruh kata ke baris berikutnya kalau
+               tidak muat, jangan dipenggal di tengah huruf. */
+            word-break: keep-all;
+            overflow-wrap: normal;
         }
 
         #tableBom tbody td {
@@ -149,7 +156,7 @@
                 <div class="col-sm-12">
                     <div class="card card-table">
                         <div class="card-body">
-                            <div class="table-responsive dt-pending" id="tableBom-wrap" style="border: 1px solid #e2e8f0; border-radius: 8px; overflow: hidden;">
+                            <div class="table-responsive dt-pending" id="tableBom-wrap" style="border: 1px solid #e2e8f0; border-radius: 8px; overflow-x: auto; overflow-y: hidden;">
                                 <div class="dt-skeleton" aria-hidden="true">
                                     <div style="padding: 16px 25px;">
                                         <span class="skel-text" style="width: 250px; height: 38px; border-radius: 20px;"></span>

--- a/resources/views/Backoffice/Reports/ReportStockTransfer.blade.php
+++ b/resources/views/Backoffice/Reports/ReportStockTransfer.blade.php
@@ -182,7 +182,7 @@
                 <div class="col-sm-12">
                     <div class="card-table">
                         <div class="card-body">
-                            <div class="table-responsive dt-pending" id="tableLogs-wrap" style="border: 1px solid #e2e8f0; border-radius: 8px; overflow: hidden;">
+                            <div class="table-responsive dt-pending" id="tableLogs-wrap" style="border: 1px solid #e2e8f0; border-radius: 8px; overflow-x: auto; overflow-y: hidden;">
                                 <div class="dt-skeleton" aria-hidden="true">
                                     <div style="padding: 16px 25px;">
                                         <span class="skel-text" style="width: 250px; height: 38px; border-radius: 20px;"></span>

--- a/resources/views/layout/partials/header.blade.php
+++ b/resources/views/layout/partials/header.blade.php
@@ -152,6 +152,29 @@
             gap: 8px;
             transition: all 0.2s ease;
         }
+        /* Di layar sempit (tablet/hp), nama gudang tidak muat berapa pun caranya
+           dipatahkan — daripada mendesak navbar sampai overflow, tampilkan
+           indikator gudang aktif sebagai ikon bulat saja. Nama tetap kebaca lewat
+           tooltip (title=) dan lewat isi dropdown saat dibuka. */
+        @media (max-width: 991.98px) {
+            /* Jangan kecilkan margin-left dari nilai inline aslinya (45px) — itu
+               jaraknya ke tombol hamburger (#toggle_btn) di kirinya. Sempat
+               diperkecil ke 16px dan malah membuat ikon gudang menabrak hamburger. */
+            .warehouse-custom-dropdown .btn-warehouse {
+                min-width: 0;
+                width: 36px;
+                height: 36px;
+                padding: 0;
+                border-radius: 50%;
+                justify-content: center;
+            }
+            .warehouse-custom-dropdown .btn-warehouse span {
+                display: none;
+            }
+            .warehouse-custom-dropdown .btn-warehouse::after {
+                display: none;
+            }
+        }
         .warehouse-custom-dropdown .btn-warehouse:hover,
         .warehouse-custom-dropdown .btn-warehouse:focus {
             background: #dbeafe;
@@ -678,7 +701,7 @@
                 return strtoupper($wh->type->warehouse_type_name ?? 'DAFTAR GUDANG');
             });
         @endphp
-        <button class="btn btn-warehouse dropdown-toggle" type="button" data-bs-toggle="dropdown" data-bs-auto-close="true" aria-expanded="false" autocomplete="off">
+        <button class="btn btn-warehouse dropdown-toggle" type="button" data-bs-toggle="dropdown" data-bs-auto-close="true" aria-expanded="false" autocomplete="off" title="{{ $activeWh ? ($activeWh->warehouse_name ?? $activeWh->name) : 'Pilih Gudang...' }}">
             <div class="d-flex align-items-center gap-2">
                 <i class="{{ $activeIconClass }}" style="color: #6366f1;"></i>
                 <span>{{ $activeWh ? ($activeWh->warehouse_name ?? $activeWh->name) : 'Pilih Gudang...' }}</span>


### PR DESCRIPTION
## Ringkasan

Perbaikan untuk isu [#153](https://github.com/denny011299/pegasus/issues/153) — bagian tampilan tabel & navbar yang hancur di layar tablet/hp. Sesuai arahan, **modul Stock Opname Produk/Bahan (poin 4 & 6 di issue) sengaja belum disentuh** dan akan menyusul terpisah.

## Root Cause

Ditemukan dua pola bug yang berulang di beberapa modul:

1. **Kolom tabel diperas jadi tidak terbaca** — tabel memakai `table-layout: fixed; width: 100% !important;` tanpa `min-width`. Di layar sempit, ini memaksa semua kolom muat ke lebar viewport alih-alih meluber (overflow) sehingga bisa di-scroll — hasilnya kolom jadi sangat sempit dan tampilan berantakan ("hancur").
2. **Wrapper tabel tidak bisa di-scroll ke samping** — beberapa `div.table-responsive` punya inline style `overflow: hidden` yang menimpa `overflow-x: auto` bawaan Bootstrap. Akibatnya meskipun tabel meluber, tidak ada cara untuk scroll melihat kolom yang terpotong.

Selain itu ditemukan bug turunan:

3. **Kata di header tabel terpenggal per huruf** — aturan `word-wrap: break-word` pada `thead th` memotong kata di tengah huruf saat kolom terlalu sempit (mis. "INVOICE" jadi "INVOIC" + "E").
4. **Navbar (indikator gudang aktif) mendesak keluar layar** — tombol pil nama gudang aktif di navbar (`.btn-warehouse`) punya `min-width: 250px` tanpa `max-width`, dan default Bootstrap membuatnya `white-space: nowrap`. Nama gudang yang panjang (mis. "Gudang Besar Pegasus Hikari Pegasus Group Sidoarjo") jadi satu baris yang meluber sampai ke luar layar di tablet/hp.

## Perubahan

### Tabel (pola 1, 2, 3 di atas)
- [`Sales_Order.blade.php`](resources/views/Backoffice/Customers/Sales_Order.blade.php) — modul **Pengiriman** (poin 3 di issue)
- [`customer.blade.php`](resources/views/Backoffice/Customer/customer.blade.php) — modul **Armada** (poin 8 di issue; menu "Armada" mengarah ke route `/customer`)
- [`Bom.blade.php`](resources/views/Backoffice/Production/Bom.blade.php) — modul BOM Produksi (bug sama walau tidak eksplisit disebut di issue, ditemukan lewat sweep pola yang sama)
- [`ReportStockTransfer.blade.php`](resources/views/Backoffice/Reports/ReportStockTransfer.blade.php) — sudah punya `min-width` yang benar, hanya kena bug wrapper `overflow: hidden`

Untuk masing-masing:
- Tambah `min-width` pada tabel (900px–1000px sesuai jumlah kolom) supaya di layar sempit tabel overflow dan bisa di-scroll horizontal, bukan meremukkan kolom.
- Ganti `word-wrap: break-word` pada `thead th` menjadi `word-break: keep-all; overflow-wrap: normal;` supaya kata dipindah utuh ke baris berikutnya, tidak dipenggal di tengah huruf.
- Ganti inline `overflow: hidden` pada wrapper `.table-responsive` menjadi `overflow-x: auto; overflow-y: hidden;` supaya tabel benar-benar bisa di-scroll ke samping.

Setelah perubahan ini, sweep ulang ke seluruh `resources/views` untuk kedua pola bug di atas hanya menyisakan file-file Stock Opname (dikecualikan sesuai arahan) — sweep sudah tuntas untuk sisanya.

### Navbar (pola 4 di atas)
- [`header.blade.php`](resources/views/layout/partials/header.blade.php) — indikator gudang aktif (`.btn-warehouse`)
  - Tampilan **desktop tidak diubah sama sekali** (persis seperti semula).
  - Di layar `<=991.98px` (tablet & hp), pil nama gudang **kolaps jadi ikon bulat saja** (36×36px) — nama gudang tetap bisa dilihat lewat tooltip (`title=`) saat hover/tap-and-hold, dan tetap ditampilkan penuh di dalam daftar dropdown saat dibuka.

## Screenshot masalah (dari issue)

Lihat lampiran gambar di [issue #153](https://github.com/denny011299/pegasus/issues/153) untuk kondisi sebelum perbaikan.

## Yang belum dikerjakan (sengaja)

- **Stok Opname Produk** (poin 4) dan **Stok Opname Bahan** (poin 6) — belum disentuh, menyusul di PR terpisah.

🤖 Generated with [Claude Code](https://claude.com/claude-code)