### PR TITLE
fix(stock): roll up produk bermasalah retur Armada saat ACC

### DIFF
--- a/app/Http/Controllers/StockController.php
+++ b/app/Http/Controllers/StockController.php
@@ -32,6 +32,7 @@ use App\Models\Unit;
 use App\Models\Warehouse;
 use App\Support\ProductUnitStock;
 use App\Support\RoleAccess;
+use App\Support\UnitRollUp;
 use App\Support\UnitStockSorter;
 use App\Support\StockOpname\OpnameLifecycle;
 use App\Support\StockOpname\OpnameLineReader;
@@ -2530,43 +2531,53 @@ class StockController extends Controller
                 else {
                     $itemId = $value["item_id"];
                     $m = ProductVariant::find($itemId);
-                    $s = ProductStock::where('product_variant_id', '=', $m->product_variant_id)->where('unit_id', '=', $value["unit_id"])->first();
-                    $stocks = $s->ps_stock ?? 0;
-                    $stocks += $value["pid_qty"];
 
-                    $s->ps_stock = $stocks;
-                    $m->save();
-                    $s->save();
+                    // GitHub #155: dulu ps_stock ditambah flat di satuan yang diretur, tanpa roll
+                    // up sama sekali -- 1 Dos 4 Piece + 8 Piece jadi "1 Dos 12 Piece" alih-alih naik
+                    // jadi "2 Dos 0 Piece". Roll-up cuma masuk akal untuk gudang utama (retur Armada
+                    // masuk balik ke stok gudang utama), jadi pakai ProductUnitStock::addQty() dengan
+                    // $rollUp aktif kalau gudang aktif sesi ini memang gudang utama -- sama seperti
+                    // ProductionController::accProduction() (GH #19/#151). Kalau gudang aktif BUKAN
+                    // gudang utama, kredit tetap flat seperti sebelumnya (tidak ada roll-up di gudang
+                    // eceran).
+                    // resolveWarehouseId() (bukan session() mentah): sama seperti scope
+                    // 'active_warehouse' yang tadinya dipakai query ProductStock di sini --
+                    // eksplisit > session > gudang utama > gudang aktif pertama -- supaya gudang
+                    // yang dipakai konsisten dengan yang tadinya dibaca lewat scope itu.
+                    $activeWarehouseId = ProductStock::resolveWarehouseId();
+                    $isMainWarehouse = $activeWarehouseId > 0
+                        && ProductStock::warehouseIsMain($activeWarehouseId) === true;
+
+                    ProductUnitStock::addQty(
+                        $activeWarehouseId,
+                        (int) $m->product_id,
+                        (int) $m->product_variant_id,
+                        (int) $value['unit_id'],
+                        (float) $value['pid_qty'],
+                        $pi->pi_code,
+                        'Produk bermasalah retur Armada ' . LogStock::actorSuffix(),
+                        $isMainWarehouse,
+                        $isMainWarehouse ? UnitRollUp::allowedProductUnitIds((int) $m->product_variant_id, $activeWarehouseId) : null
+                    );
                 }
-                // Catat Log
-                $logNotes = "";
-                $logCategory = 0;
-                $logType = 0;
-                $itemId = 0;
+                // Catat Log (retur supplier saja -- retur Armada sudah dicatat oleh
+                // ProductUnitStock::addQty() di atas)
                 if ($pi->tipe_return == 1) {
                     $sup = SuppliesVariant::find($value['item_id']);
                     $spr = Supplier::find($sup->supplier_id);
                     $logNotes = 'Produk bermasalah retur supplier ' . $spr->supplier_name . ' ' . LogStock::actorSuffix();
-                    $logCategory = 2;
-                    $logType = 2;
 
-                    $itemId = $sup->supplies_id;
-                } elseif ($pi->tipe_return == 2) {
-                    $logNotes = 'Produk bermasalah retur Armada ' . LogStock::actorSuffix();
-                    $logCategory = 1;
-                    $logType = 1;
-                    $itemId = $value['item_id'];
+                    (new LogStock())->insertLog([
+                        'log_date' => now(),
+                        'log_kode'    => $pi->pi_code,
+                        'log_type'    => 2,
+                        'log_category' => 2,
+                        'log_item_id' => $sup->supplies_id,
+                        'log_notes'  => $logNotes,
+                        'log_jumlah' => $value['pid_qty'],
+                        'unit_id'    => $value['unit_id'],
+                    ]);
                 }
-                (new LogStock())->insertLog([
-                    'log_date' => now(),
-                    'log_kode'    => $pi->pi_code,
-                    'log_type'    => $logType,
-                    'log_category' => $logCategory,
-                    'log_item_id' => $itemId,
-                    'log_notes'  => $logNotes,
-                    'log_jumlah' => $value['pid_qty'],
-                    'unit_id'    => $value['unit_id'],
-                ]);
             }
 
             // 2. Status di-flip ke Approved HANYA SEKALI, setelah SEMUA item berhasil dimutasi —

--- a/tests/Regression/ProductIssuesArmadaReturnRollUpTest.php
+++ b/tests/Regression/ProductIssuesArmadaReturnRollUpTest.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace Tests\Regression;
+
+use App\Models\Category;
+use App\Models\Product;
+use App\Models\ProductIssues;
+use App\Models\ProductRelation;
+use App\Models\ProductStock;
+use App\Models\ProductVariant;
+use Tests\Support\ActingAsStaff;
+use Tests\TestCase;
+
+/**
+ * GitHub #155: approving a "Produk Bermasalah" (Product Issue) return from Armada credited the
+ * returned qty flat onto the returned unit with no roll-up at all, unlike every other stock-IN
+ * path (Production output, PO receipt, Sales Order revert). Reported case: 1 Dos + 4 Piece on
+ * hand (1 Dos = 12 Piece), then 8 Piece returned — landed as "1 Dos 12 Piece" instead of rolling
+ * up to "2 Dos 0 Piece".
+ *
+ * Fixed by routing `StockController::accProductIssues()`'s "Return from customer" branch through
+ * `ProductUnitStock::addQty($rollUp: true)` — same mechanism as `ProductionController::
+ * accProduction()` (GH #19/#151) — gated to only roll up when the active warehouse is the main
+ * warehouse, per the issue's own ask ("teruntuk active warehouse nya adalah gudang utama").
+ */
+class ProductIssuesArmadaReturnRollUpTest extends TestCase
+{
+    use ActingAsStaff;
+
+    private const PIECE_UNIT_ID = 9;
+    private const DOS_UNIT_ID = 7;
+    private const WAREHOUSE_ID = 1; // main warehouse in the test seed
+
+    private function insertProductIssue(array $items): int
+    {
+        $response = $this->post('/insertProductIssues', [
+            'tipe_return' => 2,
+            'pi_type' => 1,
+            'pi_date' => now()->format('d-m-Y'),
+            'pi_notes' => 'GH #155 regression test',
+            'items' => json_encode($items),
+        ]);
+        $response->assertStatus(200);
+
+        return (int) ProductIssues::orderByDesc('pi_id')->value('pi_id');
+    }
+
+    public function test_armada_return_rolls_up_together_with_stock_already_on_hand_in_main_warehouse(): void
+    {
+        $this->actingAsSuperAdminStaff();
+        $this->withActiveWarehouse(self::WAREHOUSE_ID);
+
+        $category = new Category();
+        $category->category_name = 'GH155 Regression Category';
+        $category->status = 1;
+        $category->save();
+
+        $product = new Product();
+        $product->product_name = 'GH155 Regression Product';
+        $product->category_id = $category->category_id;
+        $product->product_unit = json_encode([self::PIECE_UNIT_ID, self::DOS_UNIT_ID]);
+        $product->unit_id = self::PIECE_UNIT_ID;
+        $product->status = 1;
+        $product->save();
+
+        $variant = new ProductVariant();
+        $variant->product_id = $product->product_id;
+        $variant->product_variant_name = 'GH155 Regression Variant';
+        $variant->product_variant_sku = 'WF-GH155-'.uniqid();
+        $variant->product_variant_price = 0;
+        $variant->status = 1;
+        $variant->save();
+
+        $pieceStock = new ProductStock();
+        $pieceStock->product_id = $product->product_id;
+        $pieceStock->product_variant_id = $variant->product_variant_id;
+        $pieceStock->unit_id = self::PIECE_UNIT_ID;
+        $pieceStock->warehouse_id = self::WAREHOUSE_ID;
+        $pieceStock->ps_stock = 4; // 1 Dos + 4 Piece already on hand, as in the bug report
+        $pieceStock->status = 1;
+        $pieceStock->save();
+
+        $dosStock = new ProductStock();
+        $dosStock->product_id = $product->product_id;
+        $dosStock->product_variant_id = $variant->product_variant_id;
+        $dosStock->unit_id = self::DOS_UNIT_ID;
+        $dosStock->warehouse_id = self::WAREHOUSE_ID;
+        $dosStock->ps_stock = 1;
+        $dosStock->status = 1;
+        $dosStock->save();
+
+        $relationDos = new ProductRelation();
+        $relationDos->product_variant_id = $variant->product_variant_id;
+        $relationDos->pr_unit_id_1 = self::DOS_UNIT_ID;
+        $relationDos->pr_unit_value_1 = 1;
+        $relationDos->pr_unit_id_2 = self::PIECE_UNIT_ID;
+        $relationDos->pr_unit_value_2 = 12;
+        $relationDos->pr_default = 0;
+        $relationDos->status = 1;
+        $relationDos->save();
+
+        // 8 Piece returned from Armada -- alone not a multiple of 12, but 4 (existing) + 8
+        // (returned) = 12 = exactly 1 Dos.
+        $piId = $this->insertProductIssue([[
+            'product_variant_id' => $variant->product_variant_id,
+            'pr_name' => 'GH155 Regression Product',
+            'unit_id' => self::PIECE_UNIT_ID,
+            'pid_qty' => 8,
+        ]]);
+
+        $this->post('/accProductIssues', ['pi_id' => $piId])->assertStatus(200);
+
+        $pi = ProductIssues::findOrFail($piId);
+        $this->assertSame(2, (int) $pi->status);
+
+        $pieceStock->refresh();
+        $dosStock->refresh();
+
+        $this->assertSame(0, $pieceStock->ps_stock, 'BUG WOULD BE: stuck at 12 Piece, never rolled up');
+        $this->assertSame(2, $dosStock->ps_stock, 'existing 1 Dos + folded 12 Piece = 2 Dos');
+    }
+}


### PR DESCRIPTION
## Ringkasan
Fixes #155.

`StockController::accProductIssues()` menambah `ps_stock` flat di satuan yang diretur untuk cabang "Return from customer" (retur Armada), tanpa roll-up sama sekali — beda dengan setiap jalur stock-IN lain (Produksi, PO receipt, Sales Order revert) yang sudah lewat `ProductUnitStock::addQty($rollUp: true)`.

**Reproduksi dari issue:** stok 1 Dos + 4 Piece (1 Dos = 12 Piece), input retur 8 Piece → seharusnya 2 Dos 0 Piece, tapi jadi 1 Dos 12 Piece.

## Perbaikan
- Cabang retur Armada di `accProductIssues()` sekarang lewat `ProductUnitStock::addQty()` dengan `$rollUp` aktif — sama mekanismenya seperti `ProductionController::accProduction()` (GH #19/#151), termasuk fold-existing-stock (GH #151) jadi roll-up tetap benar walau qty retur sendiri bukan kelipatan rasio satuan.
- Roll-up hanya jalan kalau gudang aktif sesi adalah **gudang utama**, sesuai yang diminta di issue ("teruntuk active warehouse nya adalah gudang utama"). Di gudang eceran, kredit tetap flat seperti sebelumnya.
- Logging `log_stocks` untuk retur Armada dipindah ke `addQty()` (yang sudah menulis log-nya sendiri per satuan yang tersentuh) supaya tidak dobel catat. Retur ke supplier tidak berubah.

## Testing
- Test baru: `tests/Regression/ProductIssuesArmadaReturnRollUpTest.php` — replikasi persis kasus di issue (1 Dos 4 Piece + retur 8 Piece → 2 Dos 0 Piece).
- Test lama tetap hijau: `ProductIssuesFlowTest`, `ProductIssuesApprovalAtomicityTest`, `ProductIssuesArmadaBongkarFailsOnStockRowInsertionOrderTest`, `ProductionOutputRollUpFoldsExistingStockTest`, `SalesOrderUpdateRollUpFlowTest`, `ReturnSuppliesBongkarFlowTest`, `ProductIssuesDeleteRefNumGuardIsDeadCodeTest` — 15 tests, 87 assertions, semua pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)