### PR TITLE
fix(stock): fix 3 more roll-up gaps found in full rescan (#157, #158, #159) + Bahan Pengembalian

### DIFF
--- a/app/Http/Controllers/CustomerReturnController.php
+++ b/app/Http/Controllers/CustomerReturnController.php
@@ -14,6 +14,7 @@ use App\Models\SuppliesStock;
 use App\Support\CustomerReturnCreation;
 use App\Support\ProductUnitStock;
 use App\Support\RoleAccess;
+use App\Support\SuppliesUnitStock;
 use Barryvdh\DomPDF\Facade\Pdf;
 use Carbon\Carbon;
 use Illuminate\Http\JsonResponse;
@@ -404,39 +405,29 @@ class CustomerReturnController extends Controller
             ])->all();
         $this->validateSupplyDetails($details);
 
-        foreach ($details as $detail) {
-            $stock = SuppliesStock::withoutGlobalScope('active_warehouse')
-                ->where('supplies_id', $detail['supplies_id'])
-                ->where('unit_id', $detail['unit_id'])
-                ->where('warehouse_id', $detail['warehouse_id'])
-                ->lockForUpdate()
-                ->first();
-            if (! $stock) {
-                $stock = new SuppliesStock([
-                    'supplies_id' => $detail['supplies_id'],
-                    'unit_id' => $detail['unit_id'],
-                    'warehouse_id' => $detail['warehouse_id'],
-                    'ss_stock' => 0,
-                    'status' => 1,
-                    'created_by' => $this->userId(),
-                ]);
-            }
-            $stock->status = 1;
-            $stock->ss_stock = (int) $stock->ss_stock + $detail['qty'];
-            $stock->created_by = $this->userId();
-            $stock->save();
+        // Follow-up to GitHub #132/#159 (2026-09-07): kembaran persis acceptProduct() di bawah --
+        // dulu di sini cuma `$stock->ss_stock += qty` polos di satuan yang dikembalikan, tanpa
+        // roll-up sama sekali (flagged-but-not-fixed saat #132 ditutup, karena belum ada
+        // SuppliesUnitStock::addQty() untuk dipakai). Sekarang lewat SuppliesUnitStock::addQty()
+        // dengan $rollUp cuma untuk gudang UTAMA -- gudang eceran tetap kredit flat.
+        $mainWarehouseIds = DB::table('warehouses as w')
+            ->join('warehouse_types as wt', 'wt.id', '=', 'w.warehouse_type_id')
+            ->whereIn('w.id', collect($details)->pluck('warehouse_id')->unique()->all())
+            ->where('wt.is_main_warehouse', 1)
+            ->pluck('w.id')
+            ->map(fn ($id) => (int) $id)
+            ->all();
 
-            (new LogStock())->insertLog([
-                'log_date' => now(),
-                'log_kode' => $record->return_group ?: $record->return_number,
-                'log_type' => 2,
-                'log_category' => 1,
-                'log_item_id' => $detail['supplies_id'],
-                'log_notes' => 'Pengembalian bahan/kemasan dari armada ' . $customerName,
-                'log_jumlah' => $detail['qty'],
-                'unit_id' => $detail['unit_id'],
-                'warehouse_id' => $detail['warehouse_id'],
-            ]);
+        foreach ($details as $detail) {
+            SuppliesUnitStock::addQty(
+                $detail['warehouse_id'],
+                $detail['supplies_id'],
+                $detail['unit_id'],
+                (float) $detail['qty'],
+                $record->return_group ?: $record->return_number,
+                'Pengembalian bahan/kemasan dari armada ' . $customerName,
+                rollUp: in_array($detail['warehouse_id'], $mainWarehouseIds, true)
+            );
         }
 
         $record->status = 2;

--- a/app/Http/Controllers/CustomerSupplyReturnController.php
+++ b/app/Http/Controllers/CustomerSupplyReturnController.php
@@ -7,6 +7,7 @@ use App\Models\CustomerSupplyReturnDetail;
 use App\Models\LogStock;
 use App\Models\SuppliesStock;
 use App\Support\RoleAccess;
+use App\Support\SuppliesUnitStock;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
@@ -261,39 +262,30 @@ class CustomerSupplyReturnController extends Controller
                 ])->all();
             $this->validateDetails($details);
 
-            foreach ($details as $detail) {
-                $stock = SuppliesStock::withoutGlobalScope('active_warehouse')
-                    ->where('supplies_id', $detail['supplies_id'])
-                    ->where('unit_id', $detail['unit_id'])
-                    ->where('warehouse_id', $detail['warehouse_id'])
-                    ->lockForUpdate()
-                    ->first();
-                if (! $stock) {
-                    $stock = new SuppliesStock([
-                        'supplies_id' => $detail['supplies_id'],
-                        'unit_id' => $detail['unit_id'],
-                        'warehouse_id' => $detail['warehouse_id'],
-                        'ss_stock' => 0,
-                        'status' => 1,
-                        'created_by' => $this->userId(),
-                    ]);
-                }
-                $stock->status = 1;
-                $stock->ss_stock = (int) $stock->ss_stock + $detail['qty'];
-                $stock->created_by = $this->userId();
-                $stock->save();
+            // Follow-up to GitHub #132/#159 (2026-09-07): kembaran persis
+            // CustomerReturnController::acceptSupply()/acceptProduct() -- dulu di sini cuma
+            // `$stock->ss_stock += qty` polos di satuan yang dikembalikan, tanpa roll-up sama
+            // sekali (flagged-but-not-fixed saat #132 ditutup, karena belum ada
+            // SuppliesUnitStock::addQty() untuk dipakai). Sekarang lewat SuppliesUnitStock::
+            // addQty() dengan $rollUp cuma untuk gudang UTAMA -- gudang eceran tetap kredit flat.
+            $mainWarehouseIds = DB::table('warehouses as w')
+                ->join('warehouse_types as wt', 'wt.id', '=', 'w.warehouse_type_id')
+                ->whereIn('w.id', collect($details)->pluck('warehouse_id')->unique()->all())
+                ->where('wt.is_main_warehouse', 1)
+                ->pluck('w.id')
+                ->map(fn ($id) => (int) $id)
+                ->all();
 
-                (new LogStock())->insertLog([
-                    'log_date' => now(),
-                    'log_kode' => $record->return_number,
-                    'log_type' => 2,
-                    'log_category' => 1,
-                    'log_item_id' => $detail['supplies_id'],
-                    'log_notes' => 'Pengembalian bahan/kemasan dari armada ' . $customerName,
-                    'log_jumlah' => $detail['qty'],
-                    'unit_id' => $detail['unit_id'],
-                    'warehouse_id' => $detail['warehouse_id'],
-                ]);
+            foreach ($details as $detail) {
+                SuppliesUnitStock::addQty(
+                    $detail['warehouse_id'],
+                    $detail['supplies_id'],
+                    $detail['unit_id'],
+                    (float) $detail['qty'],
+                    $record->return_number,
+                    'Pengembalian bahan/kemasan dari armada ' . $customerName,
+                    rollUp: in_array($detail['warehouse_id'], $mainWarehouseIds, true)
+                );
             }
 
             $record->status = 2;

--- a/app/Http/Controllers/ProductionController.php
+++ b/app/Http/Controllers/ProductionController.php
@@ -1655,70 +1655,77 @@ class ProductionController extends Controller
                 }
             }
 
-            // Cari relasi dari unit terkecil ke unit atas
-            $sr = SuppliesRelation::where('supplies_id', $suppliesId)
-                ->where('su_id_2', $stokBawah->unit_id) // su_id_2 = Piece
-                ->where('status', 1)
-                ->first();
+            // GitHub #159 (2026-09-07): dulu konversi satu-tingkat manual lewat SuppliesRelation
+            // langsung (`floor($butuhTersedia / $sr->sr_value_2)`), dan TIDAK melipat stok yang
+            // SUDAH ADA di $stokBawah sebelum kredit ini masuk -- bug class yang sama dengan #151
+            // (6 Piece sudah ada + 6 Piece kembali = tetap 12 Piece, bukan naik jadi 1 Dos). Sekarang
+            // lewat UnitRollUp::planSuppliesFolded(), yang melipat stok existing DAN menelusuri
+            // seluruh tangga satuan (bukan cuma satu tingkat ke atas), hanya menaikkan ke satuan
+            // yang SUDAH punya baris stok aktif -- sama seperti
+            // ProductIssuesDetail::deleteProductIssuesDetail() dan
+            // PurchaseOrderDeliveryDetail::insertPoDeliveryDetail().
+            $credits = UnitRollUp::planSuppliesFolded((int) $suppliesId, (int) $stokBawah->unit_id, (int) $butuhTersedia);
+            $base = array_shift($credits);      // selalu satuan bawah (bisa DELTA negatif kalau naik satuan)
+            $naikLevel = $credits;               // level-level di atasnya (kosong kalau tidak naik)
 
-            if ($sr && $butuhTersedia >= $sr->sr_value_2) {
-                // Hitung konversi: 144 Piece / 24 = 6 DOS
-                $kembalikanDos = floor($butuhTersedia / $sr->sr_value_2);
-                $sisaPiece     = fmod($butuhTersedia, $sr->sr_value_2);
+            $stokBawah->ss_stock += $base['qty'];
+            $stokBawah->save();
 
-                // Kembalikan ke unit atas (DOS)
-                $stokAtas = SuppliesStock::where('supplies_id', $suppliesId)
-                    ->where('unit_id', $sr->su_id_1)
+            foreach ($naikLevel as $credit) {
+                if ($credit['qty'] <= 0) continue;
+
+                $row = SuppliesStock::where('supplies_id', $suppliesId)
+                    ->where('unit_id', $credit['unit_id'])
                     ->where('status', 1)
                     ->first();
+                if (!$row) continue;
 
-                if ($stokAtas) {
-                    $stokAtas->ss_stock += $kembalikanDos;
-                    $stokAtas->save();
+                $row->ss_stock += $credit['qty'];
+                $row->save();
+            }
 
+            // Log utama: qty penuh yang dikembalikan, di satuan bawah tempat butuhTersedia dihitung
+            // -- riwayat tetap menyebut "pengembalian" walau sebagian/semua ikut naik satuan.
+            (new LogStock())->insertLog([
+                'log_date'     => now(),
+                'log_kode'     => $p->production_code,
+                'log_type'     => 2,
+                'log_category' => 1,
+                'log_item_id'  => $suppliesId,
+                'log_notes'    => "Pengembalian stok bahan akibat pembatalan produksi " . LogStock::actorSuffix(),
+                'log_jumlah'   => $butuhTersedia,
+                'unit_id'      => $stokBawah->unit_id,
+            ]);
+
+            // Jejak konversi kalau memang naik satuan: satuan asal keluar (cat 2), satuan hasil
+            // masuk (cat 1) -- pola sama persis dengan deleteProductIssuesDetail().
+            if ($naikLevel !== []) {
+                $naik = (int) $butuhTersedia - (int) $base['qty'];
+                if ($naik > 0) {
                     (new LogStock())->insertLog([
                         'log_date'     => now(),
                         'log_kode'     => $p->production_code,
                         'log_type'     => 2,
-                        'log_category' => 1,
+                        'log_category' => 2,
                         'log_item_id'  => $suppliesId,
-                        'log_notes'    => "Pengembalian stok bahan akibat pembatalan produksi " . LogStock::actorSuffix(),
-                        'log_jumlah'   => $kembalikanDos,
-                        'unit_id'      => $sr->su_id_1,
-                    ]);
-                }
-
-                // Kembalikan sisa piece kalau ada
-                if ($sisaPiece > 0) {
-                    $stokBawah->ss_stock += $sisaPiece;
-                    $stokBawah->save();
-
-                    (new LogStock())->insertLog([
-                        'log_date'     => now(),
-                        'log_kode'     => $p->production_code,
-                        'log_type'     => 2,
-                        'log_category' => 1,
-                        'log_item_id'  => $suppliesId,
-                        'log_notes'    => "Pengembalian stok bahan akibat pembatalan produksi " . LogStock::actorSuffix(),
-                        'log_jumlah'   => $sisaPiece,
+                        'log_notes'    => "Konversi unit (Naik satuan) pembatalan produksi " . LogStock::actorSuffix(),
+                        'log_jumlah'   => $naik,
                         'unit_id'      => $stokBawah->unit_id,
                     ]);
                 }
-            } else {
-                // Tidak ada relasi atau jumlah kurang dari 1 DOS — kembalikan langsung ke unit terkecil
-                $stokBawah->ss_stock += $butuhTersedia;
-                $stokBawah->save();
-
-                (new LogStock())->insertLog([
-                    'log_date'     => now(),
-                    'log_kode'     => $p->production_code,
-                    'log_type'     => 2,
-                    'log_category' => 1,
-                    'log_item_id'  => $suppliesId,
-                    'log_notes'    => "Pengembalian stok bahan akibat pembatalan produksi " . LogStock::actorSuffix(),
-                    'log_jumlah'   => $butuhTersedia,
-                    'unit_id'      => $stokBawah->unit_id,
-                ]);
+                foreach ($naikLevel as $credit) {
+                    if ($credit['qty'] <= 0) continue;
+                    (new LogStock())->insertLog([
+                        'log_date'     => now(),
+                        'log_kode'     => $p->production_code,
+                        'log_type'     => 2,
+                        'log_category' => 1,
+                        'log_item_id'  => $suppliesId,
+                        'log_notes'    => "Konversi unit (Hasil naik satuan) pembatalan produksi " . LogStock::actorSuffix(),
+                        'log_jumlah'   => $credit['qty'],
+                        'unit_id'      => $credit['unit_id'],
+                    ]);
+                }
             }
         }
 

--- a/app/Http/Controllers/StockController.php
+++ b/app/Http/Controllers/StockController.php
@@ -32,6 +32,7 @@ use App\Models\Unit;
 use App\Models\Warehouse;
 use App\Support\ProductUnitStock;
 use App\Support\RoleAccess;
+use App\Support\UnitRollUp;
 use App\Support\UnitStockSorter;
 use App\Support\StockOpname\OpnameLifecycle;
 use App\Support\StockOpname\OpnameLineReader;
@@ -1807,293 +1808,61 @@ class StockController extends Controller
         }
     }
 
+    // GitHub #157 (2026-09-07): dulu method ini memutasi ps_stock/ss_stock langsung (flat, tanpa
+    // roll-up -- sama seperti bug #155) untuk dokumen `product_issues` yang statusnya MASIH
+    // PENDING (belum di-ACC), dan melakukannya lewat 3 blok terpisah yang saling tumpang tindih
+    // (stockCheck() dengan efek samping bongkar, "Kembalikan stock semua" yang MENGANGGAP SEMUA
+    // baris detail adalah retur supplier walau dokumennya retur Armada -- akan crash
+    // `SuppliesVariant::find()` pada product_variant_id, dan pengurangan ps_stock manual untuk
+    // baris baru). Itu melanggar invariant yang sudah diverifikasi test lain
+    // (ProductIssuesFlowTest): stok baru boleh berubah saat accProductIssues(), insert/update
+    // dokumen pending TIDAK PERNAH menyentuh stok. Endpoint ini juga sudah dikonfirmasi TIDAK
+    // reachable dari UI produksi hari ini -- tombol edit sengaja disembunyikan (lihat
+    // cdocs/docs/flows/produk-bermasalah/FLOW.md). Sekarang disamakan persis dengan
+    // insertProductIssue(): pre-check stok murni-baca (productIssuesStockPrecheck(), retur ke
+    // supplier saja) sebelum menulis apa pun, lalu HANYA menyentuh product_issues/
+    // product_issues_details -- tidak pernah ps_stock/ss_stock.
     function updateProductIssue(Request $req)
     {
         $data = $req->all();
-        $image = $req->photo;
 
-        // Hilangkan prefix base64
-        $image = preg_replace('/^data:image\/\w+;base64,/', '', $image);
+        if ($req->photo) {
+            $image = preg_replace('/^data:image\/\w+;base64,/', '', $req->photo);
+            $imageData = base64_decode($image);
+            $imageName = 'photo_' . time() . '.png';
+            file_put_contents(public_path('issue/' . $imageName), $imageData);
+            $data["pi_img"] = $imageName;
+        }
 
-        // Decode
-        $imageData = base64_decode($image);
+        $items = json_decode($data['items'], true);
+        $tipeReturn = (int) ($data['tipe_return'] ?? 0);
 
-        // Nama file
-        $imageName = 'photo_' . time() . '.png';
+        if ($tipeReturn === 1) {
+            $stockFail = $this->productIssuesStockPrecheck($items, 1);
+            if ($stockFail !== null) {
+                $stockFail['header'] = 'Gagal Update';
+                return response()->json($stockFail);
+            }
+        }
 
-        // Path tujuan di public/produksi
-        $path = public_path('issue/' . $imageName);
-        // Simpan file
-        file_put_contents($path, $imageData);
-        $data["pi_img"] = $imageName;
-
-        $id = [];
-
-        // if ($data['tipe_return'] == 1) {
-        //     $inv = PurchaseOrderDetailInvoice::find($data['ref_num']);
-        //     $po = PurchaseOrder::find($inv->po_id);
-        //     $data['po_id'] = $po->po_id;
-        // }
-        // Ditambahkan (2026-08-24): dulu tidak ada transaksi di sini sama sekali. Perhatikan
-        // urutannya -- updateProductIssues() di bawah SUDAH memutasi stok, baru setelah itu blok
-        // "Cek stock" menjalankan stockCheck() yang bisa `return -1`. Artinya jalur gagal yang
-        // normal pun meninggalkan mutasi stok yang terlanjur tersimpan. Sekarang seluruh method
-        // (write + cek + loop detail di bawah) satu transaksi, jadi setiap `return -1` ikut
-        // ter-rollback bersih.
         DB::beginTransaction();
         try {
-        $pi = (new ProductIssues())->updateProductIssues($data);
+            $pi = (new ProductIssues())->updateProductIssues($data);
 
-        // Cek stock
-        $getPi = ProductIssuesDetail::where('pi_id', $pi->pi_id)->where('status', '>=', 1)->get();
-        $stockKurang = [];
-        if (count($getPi) > 0) {
-            foreach ($getPi as $key => $val) {
-                foreach (json_decode($data['items'], true) as $key => $value) {
-                    if ($data['tipe_return'] == 1) {
-                        if ($value['supplies_variant_id'] == $val['item_id'] && $value['unit_id'] == $val['unit_id']) {
-                            $val['tipe_return'] = $data['tipe_return'];
-                            $val['pid_qty'] = $value['pid_qty'];
-                            $c = (new ProductIssuesDetail())->stockCheck($val);
-                            if ($c == -1) {
-                                $stockKurang[] = $value['supplies_name']
-                                    ?? $this->productIssuesItemLabel($value, 1);
-                            }
-                        }
-                    }
-                    if ($data['tipe_return'] == 2) {
-                        if ($value['product_variant_id'] == $val['item_id'] && $value['unit_id'] == $val['unit_id']) {
-                            $val['tipe_return'] = $data['tipe_return'];
-                            $val['pid_qty'] = $value['pid_qty'];
-                            $c = (new ProductIssuesDetail())->stockCheck($val);
-                            if ($c == -1) {
-                                $stockKurang[] = $value['product_name']
-                                    ?? $this->productIssuesItemLabel($value, 2);
-                            }
-                        }
-                    }
-                }
+            $id = [];
+            foreach ($items as $value) {
+                $value['pi_id'] = $pi->pi_id;
+                if (isset($pi->ref_num)) $value['ref_num'] = $pi->ref_num;
+
+                $t = !isset($value["pid_id"])
+                    ? (new ProductIssuesDetail())->insertProductIssuesDetail($value)
+                    : (new ProductIssuesDetail())->updateProductIssuesDetail($value);
+
+                array_push($id, $t);
             }
-        }
-        if (count($stockKurang) > 0) {
-            DB::rollBack();
-            return response()->json([
-                'status' => -1,
-                'header' => 'Gagal Update',
-                'message' => 'Stok tidak mencukupi: ' . implode(', ', array_unique($stockKurang)),
-            ]);
-        }
-        // Pengecekan invoice
-        // if (isset($pi->ref_num) && $pi->ref_num > 0){
-        // $bermasalah = [];
-        // foreach (json_decode($data['items'], true) as $key => $value) {
-        //     $inv = PurchaseOrderDetailInvoice::find($pi->ref_num);
-        //     $po = PurchaseOrder::find($inv->po_id);
-        //     $pod = PurchaseOrderDetail::where('po_id', $po->po_id)->get();
-
-        //     $ada = -1;
-        //     foreach ($pod as $key => $detail) {
-        //         if ($detail['supplies_variant_id'] == $value['supplies_variant_id'] && $detail['unit_id'] == $value['unit_id']) {
-        //             $ada = 1;
-        //             break;
-        //         }
-        //     }
-        //     if ($ada == -1) {
-        //         array_push($bermasalah, $value['supplies_name']);
-        //     }
-        // }
-        // if (count($bermasalah) > 0) {
-        //     return [
-        //         "status"=>-1,
-        //         "message"=>"Bahan tidak ditemukan dalam invoice : ".implode(", ",$bermasalah)
-        //     ];
-        // }
-
-        // Kembalikan stock semua
-        $getPi = ProductIssuesDetail::where('pi_id', $pi->pi_id)->where('status', '>=', 1)->get();
-        if (count($getPi) > 0) {
-            foreach ($getPi as $key => $val) {
-                // Kembalikan stock invoice
-                // $total = 0;
-                // foreach ($pod as $key => $detail) {
-                //     if ($val->item_id == $detail['supplies_variant_id'] && $val->unit_id == $detail['unit_id']){
-                //         $detail['pod_qty'] += $val['pid_qty'];
-                //         $detail['pod_subtotal'] = $detail['pod_harga'] * $detail['pod_qty'];
-                //         $detail->save();
-                //     }
-                //     $total += $detail['pod_subtotal'];
-                // }
-                // if ($po->jenis_discount == "persen"){
-                //     $total -= $total * $po->po_discount/100;
-                // } else {
-                //     $total -= $po->po_discount;
-                // }
-                // $total += $total * $po->po_ppn/100;
-                // $total += $po->po_cost;
-
-                // $inv->poi_total = $total;
-                // $inv->save();
-                // $po->po_total = $total;
-                // $po->save();
-
-                // Kembalikan stock
-                $svr = SuppliesVariant::find($val->item_id);
-                $ss = SuppliesStock::where('supplies_id', $svr->supplies_id)->where('unit_id', $val->unit_id)->first();
-                $ss->ss_stock += $val['pid_qty'];
-                $ss->save();
-
-                // Catat Log
-                $logNotes = "";
-                $spr = Supplier::find($svr->supplier_id);
-                $logNotes = 'Perubahan data produk bermasalah retur supplier ' . $spr->supplier_name . ' ' . LogStock::actorSuffix();
-                (new LogStock())->insertLog([
-                    'log_date' => now(),
-                    'log_kode'    => $pi->pi_code,
-                    'log_type'    => 2,
-                    'log_category' => 1,
-                    'log_item_id' => $svr->supplies_id,
-                    'log_notes'  => $logNotes,
-                    'log_jumlah' => $val['pid_qty'],
-                    'unit_id'    => $val['unit_id'],
-                ]);
-            }
-        }
-        // }
-
-        foreach (json_decode($data['items'], true) as $key => $value) {
-            $value['pi_id'] = $data["pi_id"];
-            if (isset($pi->ref_num)) $value['ref_num'] = $pi->ref_num;
-
-            if (!isset($value["pid_id"])) {
-                if ($pi->tipe_return == 2) {
-                    $getPi = ProductIssuesDetail::where('pi_id', $pi->pi_id)->where('status', '>=', 1)->get();
-                    if (count($getPi) > 0) {
-                        foreach ($getPi as $key => $val) {
-                            $ps = ProductStock::where('product_variant_id', $value['product_variant_id'])->where('unit_id', $val->unit_id)->first();
-
-                            $ps->ps_stock -= $val->pid_qty;
-                            $ps->save();
-
-                            // Catat Log
-                            $logNotes = "";
-                            $logNotes = 'Perubahan data produk bermasalah retur Armada ' . LogStock::actorSuffix();
-                            (new LogStock())->insertLog([
-                                'log_date' => now(),
-                                'log_kode'    => $pi->pi_code,
-                                'log_type'    => 1,
-                                'log_category' => 2,
-                                'log_item_id' => $value['product_variant_id'],
-                                'log_notes'  => $logNotes,
-                                'log_jumlah' => $val['pid_qty'],
-                                'unit_id'    => $val['unit_id'],
-                            ]);
-                        }
-                    }
-                }
-
-                // Pengurangan stock
-                $t = (new ProductIssuesDetail())->insertProductIssuesDetail($value);
-
-                // Catat Log
-                $logNotes = "";
-                $logCategory = 0;
-                $logType = 0;
-                $itemId = 0;
-                if ($pi->tipe_return == 1) {
-                    $sup = SuppliesVariant::find($value['supplies_variant_id']);
-                    $spr = Supplier::find($sup->supplier_id);
-
-                    $logNotes = 'Perubahan data produk bermasalah retur supplier ' . $spr->supplier_name . ' ' . LogStock::actorSuffix();
-                    $logCategory = 2;
-                    $logType = 2;
-
-                    $itemId = $sup->supplies_id;
-                } elseif ($pi->tipe_return == 2) {
-                    $logNotes = 'Perubahan data produk bermasalah retur Armada ' . LogStock::actorSuffix();
-                    $logCategory = 1;
-                    $logType = 1;
-                    $itemId = $value['product_variant_id'];
-                }
-                (new LogStock())->insertLog([
-                    'log_date' => now(),
-                    'log_kode'    => $pi->pi_code,
-                    'log_type'    => $logType,
-                    'log_category' => $logCategory,
-                    'log_item_id' => $itemId,
-                    'log_notes'  => $logNotes,
-                    'log_jumlah' => $value['pid_qty'],
-                    'unit_id'    => $value['unit_id'],
-                ]);
-            } else {
-                // Catat Log
-                $logNotes = "";
-                $logCategory = 0;
-                $logType = 0;
-                $itemId = 0;
-                if ($pi->tipe_return == 1) {
-                    $sup = SuppliesVariant::find($value['supplies_variant_id']);
-                    $spr = Supplier::find($sup->supplier_id);
-
-                    $logNotes = 'Perubahan data produk bermasalah retur supplier ' . $spr->supplier_name . ' ' . LogStock::actorSuffix();
-                    $logCategory = 1;
-                    $logType = 2;
-                    $itemId = $sup->supplies_id;
-                } elseif ($pi->tipe_return == 2) {
-                    $logNotes = 'Perubahan data produk bermasalah retur Armada ' . LogStock::actorSuffix();
-                    $logCategory = 2;
-                    $logType = 1;
-                    $itemId = $value['product_variant_id'];
-                }
-
-                (new LogStock())->insertLog([
-                    'log_date' => now(),
-                    'log_kode'    => $pi->pi_code,
-                    'log_type'    => $logType,
-                    'log_category' => $logCategory,
-                    'log_item_id' => $itemId,
-                    'log_notes'  => $logNotes,
-                    'log_jumlah' => $value['pid_qty'],
-                    'unit_id'    => $value['unit_id'],
-                ]);
-
-                $t = (new ProductIssuesDetail())->updateProductIssuesDetail($value);
-
-                // Catat Log
-                $logNotes = "";
-                $logCategory = 0;
-                $logType = 0;
-                $itemId = 0;
-                if ($pi->tipe_return == 1) {
-                    $sup = SuppliesVariant::find($value['supplies_variant_id']);
-                    $spr = Supplier::find($sup->supplier_id);
-
-                    $logNotes = 'Perubahan data produk bermasalah retur supplier ' . $spr->supplier_name . ' ' . LogStock::actorSuffix();
-                    $logCategory = 2;
-                    $logType = 2;
-                    $itemId = $sup->supplies_id;
-                } elseif ($pi->tipe_return == 2) {
-                    $logNotes = 'Perubahan data produk bermasalah retur Armada ' . LogStock::actorSuffix();
-                    $logCategory = 1;
-                    $logType = 1;
-                    $itemId = $value['product_variant_id'];
-                }
-
-                (new LogStock())->insertLog([
-                    'log_date' => now(),
-                    'log_kode'    => $pi->pi_code,
-                    'log_type'    => $logType,
-                    'log_category' => $logCategory,
-                    'log_item_id' => $itemId,
-                    'log_notes'  => $logNotes,
-                    'log_jumlah' => $value['pid_qty'],
-                    'unit_id'    => $value['unit_id'],
-                ]);
-            }
-            array_push($id, $t);
-
-        }
-        ProductIssuesDetail::where('pi_id', '=', $data["pi_id"])->whereNotIn("pid_id", $id)->update(["status" => 0]);
-        DB::commit();
+            ProductIssuesDetail::where('pi_id', '=', $pi->pi_id)->whereNotIn("pid_id", $id)->update(["status" => 0]);
+            DB::commit();
+            return 1;
         } catch (\Throwable $e) {
             DB::rollBack();
             throw $e;
@@ -3152,9 +2921,17 @@ class StockController extends Controller
             return response()->json(['status' => 0, 'message' => 'Data tidak valid'], 422);
         }
 
+        // GitHub #158 (2026-09-07): dulu qty ditambahkan flat ke ps_stock (`$row->ps_stock += $qty`)
+        // tanpa roll-up sama sekali -- kalau hasilnya melewati rasio ke satuan yang lebih besar
+        // (mis. 12 Piece = 1 Dos), stok tetap menumpuk di satuan kecil selamanya, pola bug yang
+        // sama dengan #155. Sekarang lewat ProductUnitStock::addQty() dengan $rollUp aktif kalau
+        // gudang aktif adalah gudang utama -- sama seperti accProduction() (GH #19/#151) dan fix
+        // #155. Pengurangan ps_safety_stock TETAP flat di satuan asal apa adanya (safety stock
+        // memang cuma ditumpuk per satuan, bukan barang fisik yang perlu dikonversi ke atas).
+        $isMainWarehouse = ProductStock::warehouseIsMain($warehouseId) === true;
+
         DB::beginTransaction();
         try {
-            $logger = new LogStock();
             $moved = 0;
             foreach ($items as $item) {
                 $unitId = (int) ($item['unit_id'] ?? 0);
@@ -3177,20 +2954,22 @@ class StockController extends Controller
                     throw new \RuntimeException('Qty transfer melebihi safety stock');
                 }
                 $row->ps_safety_stock = round($safety - $qty, 4);
-                $row->ps_stock = round((float) $row->ps_stock + $qty, 4);
                 $row->save();
 
-                $logger->insertLog([
-                    'log_date' => now(),
-                    'log_kode' => 'SS' . $row->ps_id,
-                    'log_type' => 1,
-                    'log_category' => 1,
-                    'log_item_id' => $variantId,
-                    'log_notes' => 'Transfer Safety Stock ke Stok Produk',
-                    'log_jumlah' => $qty,
-                    'unit_id' => $unitId,
-                    'warehouse_id' => $warehouseId,
-                ]);
+                $add = ProductUnitStock::addQty(
+                    $warehouseId,
+                    (int) $row->product_id,
+                    $variantId,
+                    $unitId,
+                    $qty,
+                    'SS' . $row->ps_id,
+                    'Transfer Safety Stock ke Stok Produk',
+                    $isMainWarehouse,
+                    $isMainWarehouse ? UnitRollUp::allowedProductUnitIds($variantId, $warehouseId) : null
+                );
+                if (! ($add['ok'] ?? false)) {
+                    throw new \RuntimeException($add['message'] ?? 'Gagal tambah stok produk');
+                }
                 $moved++;
             }
             if ($moved === 0) {

--- a/app/Models/ProductIssuesDetail.php
+++ b/app/Models/ProductIssuesDetail.php
@@ -72,83 +72,25 @@ class ProductIssuesDetail extends Model
         return $t->pid_id;  
     } 
 
+    // GitHub #157 (2026-09-07): dulu method ini memutasi ss_stock/ps_stock (flat, tanpa roll-up)
+    // DAN PurchaseOrderDetail/po_total langsung di sini -- padahal dipanggil dari
+    // StockController::updateProductIssue() untuk dokumen `product_issues` yang MASIH PENDING
+    // (status belum di-ACC). Itu melanggar invariant yang sudah diverifikasi test lain
+    // (ProductIssuesFlowTest): stok baru boleh berubah saat accProductIssues(), insert/update
+    // dokumen pending TIDAK PERNAH menyentuh stok -- persis seperti insertProductIssuesDetail() di
+    // atas, yang dari awal memang tidak pernah menyentuh stok sama sekali. Endpoint ini juga sudah
+    // dikonfirmasi TIDAK reachable dari UI produksi hari ini (tombol edit sengaja disembunyikan --
+    // lihat cdocs/docs/flows/produk-bermasalah/FLOW.md), dan blok invoice PO di atas adalah dead
+    // code (insertProductIssue() tidak pernah mengisi ref_num). Sekarang method ini HANYA mengubah
+    // kolom baris detailnya sendiri, konsisten dengan insertProductIssuesDetail().
     function updateProductIssuesDetail($data)
     {
         $pi = ProductIssues::find($data['pi_id']);
-        $t =  self::find($data["pid_id"]);
-        $itemId = 0;
+        $t = self::find($data["pid_id"]);
 
-        // Return to Supplier
-        if ($pi->tipe_return == 1){
-            $itemId = $data['supplies_variant_id'];
-            $m = SuppliesVariant::find($itemId);
-            $s = SuppliesStock::where('supplies_id','=',$m->supplies_id)->where('unit_id','=',$data["unit_id"])->first();
-            
-            $inv = PurchaseOrderDetailInvoice::find($data['ref_num']);
-            $po = PurchaseOrder::find($inv->po_id);
-            $pod = PurchaseOrderDetail::where('po_id', $po->po_id)->get();
-
-            // pengurangan qty invoice
-            $total = 0;
-            foreach ($pod as $key => $value) {
-                if ($data['supplies_variant_id'] == $value['supplies_variant_id'] && $data['unit_id'] == $value['unit_id']){
-                    if (($value['pod_qty'] - $data['pid_qty']) >= 0) {
-                        $value['pod_qty'] -= $data['pid_qty'];
-                        $value['pod_subtotal'] = $value['pod_harga'] * $value['pod_qty'];
-                        $value->save();
-                    }
-                    else return -1;
-                }
-                $total += $value['pod_subtotal'];
-            }
-            if ($po->jenis_discount == "persen"){
-                $total -= $total * $po->po_discount/100;
-            } else {
-                $total -= $po->po_discount;
-            }
-            $total += $total * $po->po_ppn/100;
-            $total += $po->po_cost;
-
-            $data_retur = ReturnSupplies::where('po_id', $po->po_id)->where('status', 1)->get();
-            $total_retur = 0;
-            if ($data_retur){
-                foreach ($data_retur as $key => $value) {
-                    $total_retur += $value->rs_total;
-                }
-                if (isset($data['total_retur'])) $total -= $data['total_retur'];
-                else $total -= $total_retur;
-            }
-
-            $inv->poi_total = $total;
-            $po->po_total = $total;
-            $inv->save();
-            $po->save();
-            
-            if($m->pid_qty != $data["pid_qty"]){
-                if ($s->ss_stock - $data["pid_qty"] >= 0) {
-                    $s->ss_stock -= $data["pid_qty"];
-                } else {
-                    return -1;
-                }
-            }
-            // $s->ss_stock = $stocks;
-            $m->save();
-            $s->save();
-        }
-
-        // Return from customer 
-        else{
-            $itemId = $data["product_variant_id"];
-            $m = ProductVariant::find($itemId);
-            $s = ProductStock::where('product_variant_id','=',$m->product_variant_id)->where('unit_id','=',$data["unit_id"])->first();
-            
-            if($m->pid_qty != $data["pid_qty"]){
-                $s->ps_stock -= $t->pid_qty;
-                $s->ps_stock += $data["pid_qty"];
-            }
-            $m->save();
-            $s->save();
-        }
+        $itemId = $pi->tipe_return == 1
+            ? $data['supplies_variant_id']
+            : $data["product_variant_id"];
 
         $t->pi_id = $data["pi_id"];
         $t->pid_qty = $data["pid_qty"];
@@ -156,7 +98,7 @@ class ProductIssuesDetail extends Model
         $t->unit_id = $data["unit_id"];
         $t->save();
 
-        return $t->pid_id;  
+        return $t->pid_id;
     }
 
     function deleteProductIssuesDetail($data)

--- a/app/Support/SuppliesUnitStock.php
+++ b/app/Support/SuppliesUnitStock.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace App\Support;
+
+use App\Models\LogStock;
+use App\Models\SuppliesStock;
+use Illuminate\Support\Facades\Session;
+
+/**
+ * Bahan/Supplies counterpart of ProductUnitStock::addQty() — same contract, same roll-up
+ * mechanics (UnitRollUp::planSuppliesFolded()), just against SuppliesStock instead of
+ * ProductStock.
+ *
+ * Why this exists (2026-09-07, follow-up to GitHub #159): the Bahan/Supplies side of Pengembalian
+ * (`CustomerReturnController::acceptSupply()` / `CustomerSupplyReturnController::accept()`) had
+ * the exact same flat-credit-no-rollup gap as GitHub #132/#155, but there was no `ss_stock`
+ * equivalent of `ProductUnitStock::addQty()` to reuse — see `cdocs/testing/KNOWN_ISSUES.md`'s
+ * #132 entry ("Not fixed in this pass: ... there is no SuppliesUnitStock equivalent ... building
+ * one was out of scope"). This class is that follow-up.
+ */
+class SuppliesUnitStock
+{
+    /**
+     * Tambah stok bahan di gudang (satuan yang sama, kecuali $rollUp). Buat baris stok jika belum
+     * ada. Lihat docblock `ProductUnitStock::addQty()` untuk desain lengkapnya — method ini adalah
+     * kembarannya persis, hanya menyasar `SuppliesStock`/`UnitRollUp::planSuppliesFolded()`.
+     *
+     * @return array{ok: bool, message?: string}
+     */
+    public static function addQty(
+        int $warehouseId,
+        int $suppliesId,
+        int $unitId,
+        float $qty,
+        string $logCode,
+        string $logNotes = 'Stock masuk',
+        bool $rollUp = false,
+        ?array $rollUpAllowedUnitIds = null
+    ): array {
+        if ($qty <= 0) {
+            return ['ok' => true];
+        }
+
+        $credits = $rollUp
+            ? UnitRollUp::planSuppliesFolded($suppliesId, $unitId, (int) $qty, $warehouseId, $rollUpAllowedUnitIds)
+            : [['unit_id' => $unitId, 'qty' => $qty]];
+
+        // Sama seperti ProductUnitStock::addQty() (lihat docblock-nya): kalau stok existing di
+        // $unitId ikut terlipat ke keputusan roll-up sampai negatif, tulis sebagai 3 leg terpisah
+        // (masuk penuh, lalu konversi keluar/hasil) alih-alih satu delta bersih yang tidak
+        // terjelaskan.
+        $originIsFoldedDeduction = $rollUp && $credits !== [] && $credits[0]['unit_id'] === $unitId && $credits[0]['qty'] < 0;
+
+        if ($originIsFoldedDeduction) {
+            $naik = (int) $qty - $credits[0]['qty'];
+            self::creditOneSuppliesUnit($warehouseId, $suppliesId, $unitId, (float) $qty, $logCode, $logNotes);
+            self::creditOneSuppliesUnit($warehouseId, $suppliesId, $unitId, -(float) $naik, $logCode, $logNotes);
+            foreach (array_slice($credits, 1) as $credit) {
+                if ($credit['qty'] == 0) {
+                    continue;
+                }
+                self::creditOneSuppliesUnit(
+                    $warehouseId, $suppliesId, (int) $credit['unit_id'], (float) $credit['qty'],
+                    $logCode, $logNotes, isRollUpResult: true
+                );
+            }
+        } else {
+            foreach ($credits as $credit) {
+                if ($credit['qty'] == 0) {
+                    continue;
+                }
+                self::creditOneSuppliesUnit(
+                    $warehouseId,
+                    $suppliesId,
+                    (int) $credit['unit_id'],
+                    (float) $credit['qty'],
+                    $logCode,
+                    $logNotes
+                );
+            }
+        }
+
+        return ['ok' => true];
+    }
+
+    private static function creditOneSuppliesUnit(
+        int $warehouseId,
+        int $suppliesId,
+        int $unitId,
+        float $qty,
+        string $logCode,
+        string $logNotes,
+        bool $isRollUpResult = false
+    ): void {
+        $rows = SuppliesStock::withoutGlobalScope('active_warehouse')
+            ->where('status', 1)
+            ->where('warehouse_id', $warehouseId)
+            ->where('supplies_id', $suppliesId)
+            ->where('unit_id', $unitId)
+            ->lockForUpdate()
+            ->get();
+        $row = $rows->first();
+
+        if (! $row) {
+            $row = new SuppliesStock();
+            $row->warehouse_id = $warehouseId;
+            $row->supplies_id = $suppliesId;
+            $row->unit_id = $unitId;
+            $row->ss_stock = 0;
+            $row->status = 1;
+            $row->created_by = Session::get('user')->staff_id ?? null;
+            $row->save();
+        } else {
+            $row->ss_stock = (float) $rows->sum('ss_stock');
+            $rows->skip(1)->each(function ($duplicate) {
+                $duplicate->ss_stock = 0;
+                $duplicate->save();
+            });
+        }
+
+        $row->ss_stock = round((float) $row->ss_stock + $qty, 4);
+        $row->save();
+
+        // $qty bisa negatif di sini (fold roll-up, lihat caller): sejumlah itu berpindah KELUAR
+        // dari satuan ini ke satuan yang lebih besar lewat panggilan roll-up yang SAMA. log_jumlah
+        // tetap magnitude positif, arah dibawa log_category -- konvensi yang sama dipakai
+        // ProductIssuesDetail::deleteProductIssuesDetail().
+        $isOut = $qty < 0;
+        $notes = $logNotes;
+        if ($isOut) {
+            $notes = 'Konversi unit (naik satuan otomatis) ' . $logNotes;
+        } elseif ($isRollUpResult) {
+            $notes = 'Hasil konversi naik satuan otomatis (' . $logNotes . ')';
+        }
+        (new LogStock())->insertLog([
+            'log_date' => now(),
+            'log_kode' => $logCode,
+            'log_type' => 2,
+            'log_category' => $isOut ? 2 : 1,
+            'log_item_id' => $suppliesId,
+            'log_notes' => $notes,
+            'log_jumlah' => abs($qty),
+            'log_saldo' => (float) $row->ss_stock,
+            'unit_id' => $unitId,
+            'warehouse_id' => $warehouseId,
+        ]);
+    }
+}

--- a/tests/Regression/ProductIssuesUpdatePendingNoStockMutationTest.php
+++ b/tests/Regression/ProductIssuesUpdatePendingNoStockMutationTest.php
@@ -1,0 +1,201 @@
+<?php
+
+namespace Tests\Regression;
+
+use App\Models\ProductIssues;
+use App\Models\ProductIssuesDetail;
+use App\Models\ProductStock;
+use App\Models\SuppliesStock;
+use App\Models\SuppliesVariant;
+use Tests\Support\ActingAsStaff;
+use Tests\TestCase;
+
+/**
+ * GitHub #157 (2026-09-07): `StockController::updateProductIssue()` (editing a Produk Bermasalah
+ * document that is still pending/not yet ACC'd) used to mutate `ps_stock`/`ss_stock` directly
+ * (flat, no roll-up -- same class of bug as #155) via 3 separate, overlapping blocks
+ * (`stockCheck()`'s bongkar side effect, an unconditional "Kembalikan stock semua" block that
+ * treated every detail row as a supplies return even for `tipe_return == 2`, and a manual
+ * `ps_stock -=`/`insertProductIssuesDetail()` pair for new rows). That contradicted the invariant
+ * `ProductIssuesFlowTest` already asserts for insert: a `product_issues` document only ever
+ * mutates stock at `accProductIssues()`, never before. This endpoint was also confirmed unreachable
+ * from the production UI (its edit button is commented out in `Product_Issues.js`) — see
+ * `cdocs/docs/flows/produk-bermasalah/FLOW.md`.
+ *
+ * Fixed by stripping every stock mutation out of `updateProductIssue()`/
+ * `ProductIssuesDetail::updateProductIssuesDetail()`, mirroring `insertProductIssue()`: pre-check
+ * only (read-only, supplier-return side), write `product_issues`/`product_issues_details`, never
+ * touch `ps_stock`/`ss_stock`.
+ */
+class ProductIssuesUpdatePendingNoStockMutationTest extends TestCase
+{
+    use ActingAsStaff;
+
+    private function insertProductIssue(int $tipeReturn, array $items): int
+    {
+        $response = $this->post('/insertProductIssues', [
+            'tipe_return' => $tipeReturn,
+            'pi_type' => $tipeReturn == 1 ? 2 : 1,
+            'pi_date' => now()->format('d-m-Y'),
+            'pi_notes' => 'GH #157 regression test',
+            'items' => json_encode($items),
+        ]);
+        $response->assertStatus(200);
+
+        return (int) ProductIssues::orderByDesc('pi_id')->value('pi_id');
+    }
+
+    public function test_editing_a_pending_armada_return_never_touches_product_stock(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $stock = ProductStock::withoutGlobalScope('active_warehouse')
+            ->where('status', 1)
+            ->where('warehouse_id', 1)
+            ->firstOrFail();
+        $startingStock = $stock->ps_stock;
+
+        $piId = $this->insertProductIssue(2, [[
+            'product_variant_id' => $stock->product_variant_id,
+            'pr_name' => 'GH157 test product',
+            'unit_id' => $stock->unit_id,
+            'pid_qty' => 5,
+        ]]);
+        $pi = ProductIssues::findOrFail($piId);
+        $existingDetail = ProductIssuesDetail::where('pi_id', $piId)->where('status', 1)->firstOrFail();
+
+        $stock->refresh();
+        $this->assertSame($startingStock, $stock->ps_stock, 'inserting must not touch stock');
+
+        // Edit: bump the existing item's qty AND add a brand new item -- both should update
+        // product_issues_details, neither should touch ps_stock at all.
+        $updateResponse = $this->post('/updateProductIssues', [
+            'pi_id' => $piId,
+            'pi_code' => $pi->pi_code,
+            'pi_type' => $pi->pi_type,
+            'ref_num' => 0,
+            'tipe_return' => 2,
+            'pi_date' => now()->format('d-m-Y'),
+            'pi_notes' => 'GH #157 regression test, edited',
+            'items' => json_encode([
+                [
+                    'pid_id' => $existingDetail->pid_id,
+                    'product_variant_id' => $stock->product_variant_id,
+                    'unit_id' => $stock->unit_id,
+                    'pid_qty' => 9, // was 5
+                ],
+                [
+                    'product_variant_id' => $stock->product_variant_id,
+                    'unit_id' => $stock->unit_id,
+                    'pid_qty' => 3, // brand new line
+                ],
+            ]),
+        ]);
+        $updateResponse->assertStatus(200);
+
+        $stock->refresh();
+        $this->assertSame($startingStock, $stock->ps_stock, 'editing a pending document must never touch stock');
+
+        $pi->refresh();
+        $this->assertSame(1, (int) $pi->status, 'still pending -- unaffected by edit');
+
+        $existingDetail->refresh();
+        $this->assertSame(9, $existingDetail->pid_qty, 'existing line qty must be updated');
+        $this->assertSame(1, (int) $existingDetail->status, 'existing line stays active');
+
+        $this->assertDatabaseHas('product_issues_details', [
+            'pi_id' => $piId,
+            'item_id' => $stock->product_variant_id,
+            'pid_qty' => 3,
+            'status' => 1,
+        ]);
+        $this->assertSame(
+            2,
+            ProductIssuesDetail::where('pi_id', $piId)->where('status', 1)->count(),
+            'exactly the 2 lines from the edit payload should remain active'
+        );
+    }
+
+    public function test_removing_a_line_on_edit_marks_it_inactive_without_touching_stock(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $stock = ProductStock::withoutGlobalScope('active_warehouse')
+            ->where('status', 1)
+            ->where('warehouse_id', 1)
+            ->firstOrFail();
+        $startingStock = $stock->ps_stock;
+
+        $piId = $this->insertProductIssue(2, [[
+            'product_variant_id' => $stock->product_variant_id,
+            'pr_name' => 'GH157 test product',
+            'unit_id' => $stock->unit_id,
+            'pid_qty' => 5,
+        ]]);
+        $pi = ProductIssues::findOrFail($piId);
+        $existingDetail = ProductIssuesDetail::where('pi_id', $piId)->where('status', 1)->firstOrFail();
+
+        // Edit with an EMPTY items array -- the one existing line should be dropped (status 0),
+        // no stock reversal since none was ever applied.
+        $this->post('/updateProductIssues', [
+            'pi_id' => $piId,
+            'pi_code' => $pi->pi_code,
+            'pi_type' => $pi->pi_type,
+            'ref_num' => 0,
+            'tipe_return' => 2,
+            'pi_date' => now()->format('d-m-Y'),
+            'pi_notes' => 'GH #157 regression test, line removed',
+            'items' => json_encode([]),
+        ])->assertStatus(200);
+
+        $stock->refresh();
+        $this->assertSame($startingStock, $stock->ps_stock);
+
+        $existingDetail->refresh();
+        $this->assertSame(0, (int) $existingDetail->status, 'line dropped from the payload must be marked inactive');
+    }
+
+    public function test_editing_a_pending_supplier_return_never_touches_supplies_stock(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $variant = SuppliesVariant::where('status', 1)->firstOrFail();
+        $stock = SuppliesStock::where('supplies_id', $variant->supplies_id)->where('status', 1)->where('ss_stock', '>', 10)->firstOrFail();
+        $startingStock = $stock->ss_stock;
+
+        $piId = $this->insertProductIssue(1, [[
+            'supplies_variant_id' => $variant->supplies_variant_id,
+            'supplies_name' => 'GH157 test supplies',
+            'unit_id' => $stock->unit_id,
+            'pid_qty' => 3,
+        ]]);
+        $pi = ProductIssues::findOrFail($piId);
+        $existingDetail = ProductIssuesDetail::where('pi_id', $piId)->where('status', 1)->firstOrFail();
+
+        $stock->refresh();
+        $this->assertSame($startingStock, $stock->ss_stock);
+
+        $this->post('/updateProductIssues', [
+            'pi_id' => $piId,
+            'pi_code' => $pi->pi_code,
+            'pi_type' => $pi->pi_type,
+            'ref_num' => 0,
+            'tipe_return' => 1,
+            'pi_date' => now()->format('d-m-Y'),
+            'pi_notes' => 'GH #157 regression test, edited',
+            'items' => json_encode([[
+                'pid_id' => $existingDetail->pid_id,
+                'supplies_variant_id' => $variant->supplies_variant_id,
+                'supplies_name' => 'GH157 test supplies',
+                'unit_id' => $stock->unit_id,
+                'pid_qty' => 7, // was 3
+            ]]),
+        ])->assertStatus(200);
+
+        $stock->refresh();
+        $this->assertSame($startingStock, $stock->ss_stock, 'editing a pending document must never touch supplies stock');
+
+        $existingDetail->refresh();
+        $this->assertSame(7, $existingDetail->pid_qty);
+    }
+}

--- a/tests/Regression/ProductionCancelBahanReturnRollUpTest.php
+++ b/tests/Regression/ProductionCancelBahanReturnRollUpTest.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace Tests\Regression;
+
+use App\Models\Bom;
+use App\Models\BomDetail;
+use App\Models\Category;
+use App\Models\Product;
+use App\Models\ProductStock;
+use App\Models\ProductVariant;
+use App\Models\Production;
+use App\Models\Supplies;
+use App\Models\SuppliesRelation;
+use App\Models\SuppliesStock;
+use Tests\Support\ActingAsStaff;
+use Tests\TestCase;
+
+/**
+ * GitHub #159 (2026-09-07): when an already-approved production is cancelled
+ * (`ProductionController::accDeleteProduction()`), the consumed bahan is returned to stock via a
+ * hand-rolled one-level conversion through `SuppliesRelation` directly, bypassing `UnitRollUp`
+ * entirely -- same bug class as #151: stock already sitting at the target unit BEFORE this credit
+ * was never folded into the roll-up decision. Returning 6 Piece (1 DOS = 12 Piece) when 6 Piece
+ * were already left sitting there landed as 12 Piece / 0 DOS forever instead of rolling up to 1
+ * DOS. Fixed via `UnitRollUp::planSuppliesFolded()`.
+ */
+class ProductionCancelBahanReturnRollUpTest extends TestCase
+{
+    use ActingAsStaff;
+
+    private const PIECE_UNIT_ID = 9;
+    private const DOS_UNIT_ID = 7;
+    private const WAREHOUSE_ID = 1;
+    private const BOM_DETAIL_QTY = 6;
+
+    public function test_cancelling_a_production_returns_bahan_rolled_up_together_with_stock_already_on_hand(): void
+    {
+        $this->actingAsSuperAdminStaff();
+        $this->withActiveWarehouse(self::WAREHOUSE_ID);
+
+        $category = new Category();
+        $category->category_name = 'GH159 Cancel Bahan RollUp Category';
+        $category->status = 1;
+        $category->save();
+
+        $product = new Product();
+        $product->product_name = 'GH159 Cancel Bahan RollUp Product';
+        $product->category_id = $category->category_id;
+        $product->product_unit = json_encode([self::PIECE_UNIT_ID]);
+        $product->unit_id = self::PIECE_UNIT_ID;
+        $product->status = 1;
+        $product->save();
+
+        $variant = new ProductVariant();
+        $variant->product_id = $product->product_id;
+        $variant->product_variant_name = 'GH159 Cancel Bahan RollUp Variant';
+        $variant->product_variant_sku = 'WF-GH159-'.uniqid();
+        $variant->product_variant_price = 0;
+        $variant->status = 1;
+        $variant->save();
+
+        $productStock = new ProductStock();
+        $productStock->product_id = $product->product_id;
+        $productStock->product_variant_id = $variant->product_variant_id;
+        $productStock->unit_id = self::PIECE_UNIT_ID;
+        $productStock->warehouse_id = self::WAREHOUSE_ID;
+        $productStock->ps_stock = 0;
+        $productStock->status = 1;
+        $productStock->save();
+
+        // Bahan dengan tangga satuan 1 DOS = 12 Piece. Nama sengaja TIDAK mengandung "dos"/"pack"
+        // supaya accDeleteProduction()'s isKemasanBesar regex tidak nyala (jalur konsumsi biasa).
+        $supplies = new Supplies();
+        $supplies->supplies_name = 'GH159 Cancel Bahan RollUp Ingredient';
+        $supplies->supplies_unit = json_encode([self::PIECE_UNIT_ID, self::DOS_UNIT_ID]);
+        $supplies->supplies_default_unit = self::PIECE_UNIT_ID;
+        $supplies->status = 1;
+        $supplies->save();
+
+        // 12 Piece di awal -- cukup untuk konsumsi 6 Piece tanpa perlu bongkar, menyisakan
+        // TEPAT 6 Piece yang masih ada saat pembatalan nanti terjadi.
+        $pieceStock = new SuppliesStock();
+        $pieceStock->supplies_id = $supplies->supplies_id;
+        $pieceStock->unit_id = self::PIECE_UNIT_ID;
+        $pieceStock->warehouse_id = self::WAREHOUSE_ID;
+        $pieceStock->ss_stock = 12;
+        $pieceStock->status = 1;
+        $pieceStock->save();
+
+        $dosStock = new SuppliesStock();
+        $dosStock->supplies_id = $supplies->supplies_id;
+        $dosStock->unit_id = self::DOS_UNIT_ID;
+        $dosStock->warehouse_id = self::WAREHOUSE_ID;
+        $dosStock->ss_stock = 0;
+        $dosStock->status = 1;
+        $dosStock->save();
+
+        $relation = new SuppliesRelation();
+        $relation->supplies_id = $supplies->supplies_id;
+        $relation->su_id_1 = self::DOS_UNIT_ID;
+        $relation->su_id_2 = self::PIECE_UNIT_ID;
+        $relation->sr_value_1 = 1;
+        $relation->sr_value_2 = 12;
+        $relation->status = 1;
+        $relation->save();
+
+        $bom = new Bom();
+        $bom->product_id = $variant->product_variant_id;
+        $bom->bom_qty = 1;
+        $bom->unit_id = self::PIECE_UNIT_ID;
+        $bom->status = 1;
+        $bom->save();
+
+        $bomDetail = new BomDetail();
+        $bomDetail->bom_id = $bom->bom_id;
+        $bomDetail->supplies_id = $supplies->supplies_id;
+        $bomDetail->bom_detail_qty = self::BOM_DETAIL_QTY;
+        $bomDetail->unit_id = self::PIECE_UNIT_ID;
+        $bomDetail->status = 1;
+        $bomDetail->save();
+
+        // Produksi 1 batch -> konsumsi 6 Piece, menyisakan 6 Piece di stok.
+        $insertResponse = $this->post('/insertProduction', [
+            'production_date' => now()->toDateString(),
+            'production_desc' => 'GH159 cancel bahan rollup test',
+            'detail' => json_encode([[
+                'bom_id' => $bom->bom_id,
+                'product_variant_id' => $variant->product_variant_id,
+                'pd_qty' => 1,
+                'unit_id' => self::PIECE_UNIT_ID,
+            ]]),
+            'list_bahan' => json_encode([[
+                'supplies_id' => $supplies->supplies_id,
+                'bom_detail_qty' => self::BOM_DETAIL_QTY,
+                'unit_id' => self::PIECE_UNIT_ID,
+            ]]),
+        ]);
+        $insertResponse->assertStatus(200);
+        $production = Production::orderByDesc('production_id')->firstOrFail();
+
+        $this->post('/accProduction', ['production_id' => $production->production_id])->assertStatus(200);
+
+        $pieceStock->refresh();
+        $this->assertSame(6, (int) $pieceStock->ss_stock, 'produksi mengonsumsi 6 Piece, menyisakan 6');
+
+        // Batalkan produksi yang sudah di-ACC: ajukan lalu setujui pembatalan.
+        $this->post('/deleteProduction', [
+            'production_id' => $production->production_id,
+            'delete_reason' => 'GH159 cancel bahan rollup test',
+        ])->assertStatus(200);
+
+        $this->post('/accDeleteProduction', ['production_id' => $production->production_id])->assertStatus(200);
+
+        $pieceStock->refresh();
+        $dosStock->refresh();
+
+        // 6 Piece yang sudah ada + 6 Piece yang dikembalikan = 12 = tepat 1 DOS.
+        $this->assertSame(0, (int) $pieceStock->ss_stock, 'BUG WOULD BE: stuck at 12 Piece, never rolled up');
+        $this->assertSame(1, (int) $dosStock->ss_stock, 'existing 6 + returned 6 = 12 = exactly 1 DOS');
+    }
+}

--- a/tests/Regression/TransferSafetyToStockRollUpTest.php
+++ b/tests/Regression/TransferSafetyToStockRollUpTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Tests\Regression;
+
+use App\Models\Category;
+use App\Models\Product;
+use App\Models\ProductRelation;
+use App\Models\ProductStock;
+use App\Models\ProductVariant;
+use App\Models\Unit;
+use App\Models\Warehouse;
+use Tests\Support\ActingAsStaff;
+use Tests\TestCase;
+
+/**
+ * GitHub #158 (2026-09-07): `StockController::transferSafetyToStock()` moved qty from
+ * `ps_safety_stock` into `ps_stock` on the same unit row with a flat
+ * `round($row->ps_stock + $qty, 4)` -- no roll-up at all. If the push crossed a unit-ratio
+ * boundary (e.g. 12 Piece = 1 Dos), the qty stayed stuck at the small unit forever, same failure
+ * mode as #155. Fixed by routing the credit through `ProductUnitStock::addQty($rollUp: true)`,
+ * gated to the active warehouse being the main warehouse (same policy as every other roll-up
+ * site).
+ */
+class TransferSafetyToStockRollUpTest extends TestCase
+{
+    use ActingAsStaff;
+
+    private const PIECE_UNIT_ID = 9;
+    private const DOS_UNIT_ID = 7;
+    private const WAREHOUSE_ID = 1; // main warehouse in the test seed
+
+    public function test_transferring_safety_stock_rolls_up_together_with_stock_already_on_hand(): void
+    {
+        $this->actingAsSuperAdminStaff();
+        $this->withActiveWarehouse(self::WAREHOUSE_ID);
+
+        $category = new Category();
+        $category->category_name = 'GH158 Safety Stock RollUp Category';
+        $category->status = 1;
+        $category->save();
+
+        $product = new Product();
+        $product->product_name = 'GH158 Safety Stock RollUp Product';
+        $product->category_id = $category->category_id;
+        $product->product_unit = json_encode([self::PIECE_UNIT_ID, self::DOS_UNIT_ID]);
+        $product->unit_id = self::PIECE_UNIT_ID;
+        $product->status = 1;
+        $product->save();
+
+        $variant = new ProductVariant();
+        $variant->product_id = $product->product_id;
+        $variant->product_variant_name = 'GH158 Safety Stock RollUp Variant';
+        $variant->product_variant_sku = 'WF-GH158-'.uniqid();
+        $variant->product_variant_price = 0;
+        $variant->status = 1;
+        $variant->save();
+
+        // 6 pcs already on hand + 6 pcs sitting in Safety Stock, below the 12-pcs DOS ratio on its
+        // own either way.
+        $pieceStock = new ProductStock();
+        $pieceStock->product_id = $product->product_id;
+        $pieceStock->product_variant_id = $variant->product_variant_id;
+        $pieceStock->unit_id = self::PIECE_UNIT_ID;
+        $pieceStock->warehouse_id = self::WAREHOUSE_ID;
+        $pieceStock->ps_stock = 6;
+        $pieceStock->ps_safety_stock = 6;
+        $pieceStock->status = 1;
+        $pieceStock->save();
+
+        $dosStock = new ProductStock();
+        $dosStock->product_id = $product->product_id;
+        $dosStock->product_variant_id = $variant->product_variant_id;
+        $dosStock->unit_id = self::DOS_UNIT_ID;
+        $dosStock->warehouse_id = self::WAREHOUSE_ID;
+        $dosStock->ps_stock = 0;
+        $dosStock->status = 1;
+        $dosStock->save();
+
+        $relation = new ProductRelation();
+        $relation->product_variant_id = $variant->product_variant_id;
+        $relation->pr_unit_id_1 = self::DOS_UNIT_ID;
+        $relation->pr_unit_value_1 = 1;
+        $relation->pr_unit_id_2 = self::PIECE_UNIT_ID;
+        $relation->pr_unit_value_2 = 12;
+        $relation->pr_default = 0;
+        $relation->status = 1;
+        $relation->save();
+
+        // Transfer all 6 Safety Stock pcs into normal stock -- 6 (existing) + 6 (transferred) = 12
+        // = exactly 1 DOS.
+        $response = $this->post('/transferSafetyToStock', [
+            'product_variant_id' => $variant->product_variant_id,
+            'warehouse_id' => self::WAREHOUSE_ID,
+            'items' => json_encode([
+                ['unit_id' => self::PIECE_UNIT_ID, 'qty' => 6],
+            ]),
+        ]);
+        $response->assertOk();
+        $response->assertJson(['status' => 1]);
+
+        $pieceStock->refresh();
+        $dosStock->refresh();
+
+        $this->assertSame(0.0, (float) $pieceStock->ps_safety_stock, 'safety stock harus habis ditransfer');
+        $this->assertSame(0, (int) $pieceStock->ps_stock, 'BUG WOULD BE: stuck at 12 Piece, never rolled up');
+        $this->assertSame(1, (int) $dosStock->ps_stock, 'existing 6 + transferred 6 = 12 = exactly 1 DOS');
+    }
+}

--- a/tests/Workflow/CustomerReturnAcceptSupplyRollUpTest.php
+++ b/tests/Workflow/CustomerReturnAcceptSupplyRollUpTest.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace Tests\Workflow;
+
+use App\Models\CustomerSupplyReturn;
+use App\Models\CustomerSupplyReturnDetail;
+use App\Models\Customer;
+use App\Models\Supplies;
+use App\Models\SuppliesRelation;
+use App\Models\SuppliesStock;
+use App\Models\Unit;
+use App\Models\Warehouse;
+use Tests\Support\ActingAsStaff;
+use Tests\TestCase;
+
+/**
+ * Follow-up to GitHub #132/#159 (2026-09-07): `CustomerReturnController::acceptSupply()` is the
+ * docKey-based twin of `CustomerSupplyReturnController::accept()` (see
+ * CustomerSupplyReturnRollUpTest for that one) and had the exact same flat-credit-no-rollup gap.
+ * Fixed via the same `App\Support\SuppliesUnitStock::addQty()`.
+ */
+class CustomerReturnAcceptSupplyRollUpTest extends TestCase
+{
+    use ActingAsStaff;
+
+    private array $units = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $rows = Unit::where('status', 1)->limit(2)->get();
+        $this->assertGreaterThanOrEqual(2, $rows->count(), 'fixture butuh minimal 2 satuan aktif');
+        $this->units = ['dos' => $rows[0], 'pcs' => $rows[1]];
+    }
+
+    private function mainWarehouseId(): int
+    {
+        return (int) Warehouse::query()
+            ->where('warehouses.status', 1)
+            ->whereHas('type', fn ($q) => $q->where('status', 1)->where('is_main_warehouse', 1))
+            ->orderBy('warehouses.id')
+            ->value('id');
+    }
+
+    private function makeLadderedSupplies(int $warehouseId, int $dosStock, int $pcsStock, int $ratio = 12): Supplies
+    {
+        $supplies = new Supplies();
+        $supplies->supplies_name = 'Combined Return RollUp Test '.uniqid();
+        $supplies->supplies_unit = json_encode([$this->units['dos']->unit_id, $this->units['pcs']->unit_id]);
+        $supplies->supplies_default_unit = $this->units['pcs']->unit_id;
+        $supplies->status = 1;
+        $supplies->save();
+
+        $relation = new SuppliesRelation();
+        $relation->supplies_id = $supplies->supplies_id;
+        $relation->su_id_1 = $this->units['dos']->unit_id;
+        $relation->su_id_2 = $this->units['pcs']->unit_id;
+        $relation->sr_value_1 = 1;
+        $relation->sr_value_2 = $ratio;
+        $relation->status = 1;
+        $relation->save();
+
+        foreach ([['dos', $dosStock], ['pcs', $pcsStock]] as [$key, $qty]) {
+            $s = new SuppliesStock();
+            $s->supplies_id = $supplies->supplies_id;
+            $s->unit_id = $this->units[$key]->unit_id;
+            $s->warehouse_id = $warehouseId;
+            $s->ss_stock = $qty;
+            $s->status = 1;
+            $s->save();
+        }
+
+        return $supplies;
+    }
+
+    private function createArmada(): Customer
+    {
+        $customer = new Customer();
+        $customer->customer_name = 'Combined Return RollUp Test Armada';
+        $customer->customer_code = 'CRU'.random_int(1000, 9999);
+        $customer->status = 1;
+        $customer->save();
+
+        return $customer;
+    }
+
+    private function currentStock(Supplies $s, string $unitKey, int $warehouseId): int
+    {
+        return (int) SuppliesStock::withoutGlobalScope('active_warehouse')
+            ->where('supplies_id', $s->supplies_id)
+            ->where('unit_id', $this->units[$unitKey]->unit_id)
+            ->where('warehouse_id', $warehouseId)
+            ->value('ss_stock');
+    }
+
+    private function staffId(): int
+    {
+        return (int) \Illuminate\Support\Facades\DB::table('staffs')->where('status', 1)->value('staff_id');
+    }
+
+    public function test_accepting_a_supply_only_combined_return_rolls_up_together_with_stock_already_on_hand(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $warehouseId = $this->mainWarehouseId();
+        // 6 pcs already sitting there, below the 12-pcs DOS ratio on its own.
+        $s = $this->makeLadderedSupplies($warehouseId, dosStock: 0, pcsStock: 6, ratio: 12);
+        $customer = $this->createArmada();
+
+        $record = new CustomerSupplyReturn();
+        $record->return_number = 'PBM-CRT-'.uniqid();
+        $record->customer_id = $customer->customer_id;
+        $record->return_date = now()->toDateString();
+        $record->proof_path = 'combined-return-rollup-test.png';
+        $record->status = 1;
+        $record->created_by = $this->staffId();
+        $record->save();
+
+        $detail = new CustomerSupplyReturnDetail();
+        $detail->return_id = $record->return_id;
+        $detail->supplies_id = $s->supplies_id;
+        $detail->unit_id = $this->units['pcs']->unit_id;
+        $detail->warehouse_id = $warehouseId;
+        $detail->qty = 6; // existing 6 + returned 6 = 12 = exactly 1 DOS
+        $detail->status = 1;
+        $detail->save();
+
+        // docKey "S:<id>" = supply-only bundle (no product side) -- see resolveBundle().
+        $response = $this->post("/customerReturns/S:{$record->return_id}/accept");
+        $response->assertOk();
+
+        $this->assertSame(0, $this->currentStock($s, 'pcs', $warehouseId), 'BUG WOULD BE: stuck at 12 Piece, never rolled up');
+        $this->assertSame(1, $this->currentStock($s, 'dos', $warehouseId), 'existing 6 + returned 6 = 12 = exactly 1 DOS');
+    }
+}

--- a/tests/Workflow/CustomerSupplyReturnRollUpTest.php
+++ b/tests/Workflow/CustomerSupplyReturnRollUpTest.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace Tests\Workflow;
+
+use App\Models\CustomerSupplyReturn;
+use App\Models\CustomerSupplyReturnDetail;
+use App\Models\Customer;
+use App\Models\Supplies;
+use App\Models\SuppliesRelation;
+use App\Models\SuppliesStock;
+use App\Models\Unit;
+use App\Models\Warehouse;
+use Tests\Support\ActingAsStaff;
+use Tests\TestCase;
+
+/**
+ * Follow-up to GitHub #132/#159 (2026-09-07): the Bahan/Supplies side of Pengembalian
+ * (`CustomerSupplyReturnController::accept()`) had the same flat-credit-no-rollup gap as
+ * `CustomerProductReturnController::accept()` (fixed for #132), but there was no `ss_stock`
+ * equivalent of `ProductUnitStock::addQty()` to reuse -- flagged-but-not-fixed in
+ * `cdocs/testing/KNOWN_ISSUES.md`. Fixed via the new `App\Support\SuppliesUnitStock::addQty()`.
+ */
+class CustomerSupplyReturnRollUpTest extends TestCase
+{
+    use ActingAsStaff;
+
+    private array $units = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $rows = Unit::where('status', 1)->limit(2)->get();
+        $this->assertGreaterThanOrEqual(2, $rows->count(), 'fixture butuh minimal 2 satuan aktif');
+        $this->units = ['dos' => $rows[0], 'pcs' => $rows[1]];
+    }
+
+    private function mainWarehouseId(): int
+    {
+        return (int) Warehouse::query()
+            ->where('warehouses.status', 1)
+            ->whereHas('type', fn ($q) => $q->where('status', 1)->where('is_main_warehouse', 1))
+            ->orderBy('warehouses.id')
+            ->value('id');
+    }
+
+    /** 1 DOS = 12 pcs, kedua satuan sudah punya baris SuppliesStock aktif di $warehouseId. */
+    private function makeLadderedSupplies(int $warehouseId, int $dosStock, int $pcsStock, int $ratio = 12): Supplies
+    {
+        $supplies = new Supplies();
+        $supplies->supplies_name = 'Supply Return RollUp Test '.uniqid();
+        $supplies->supplies_unit = json_encode([$this->units['dos']->unit_id, $this->units['pcs']->unit_id]);
+        $supplies->supplies_default_unit = $this->units['pcs']->unit_id;
+        $supplies->status = 1;
+        $supplies->save();
+
+        $relation = new SuppliesRelation();
+        $relation->supplies_id = $supplies->supplies_id;
+        $relation->su_id_1 = $this->units['dos']->unit_id; // besar
+        $relation->su_id_2 = $this->units['pcs']->unit_id; // kecil
+        $relation->sr_value_1 = 1;
+        $relation->sr_value_2 = $ratio;
+        $relation->status = 1;
+        $relation->save();
+
+        foreach ([['dos', $dosStock], ['pcs', $pcsStock]] as [$key, $qty]) {
+            $s = new SuppliesStock();
+            $s->supplies_id = $supplies->supplies_id;
+            $s->unit_id = $this->units[$key]->unit_id;
+            $s->warehouse_id = $warehouseId;
+            $s->ss_stock = $qty;
+            $s->status = 1;
+            $s->save();
+        }
+
+        return $supplies;
+    }
+
+    private function createArmada(): Customer
+    {
+        $customer = new Customer();
+        $customer->customer_name = 'Supply Return RollUp Test Armada';
+        $customer->customer_code = 'SRU'.random_int(1000, 9999);
+        $customer->status = 1;
+        $customer->save();
+
+        return $customer;
+    }
+
+    private function currentStock(Supplies $s, string $unitKey, int $warehouseId): int
+    {
+        return (int) SuppliesStock::withoutGlobalScope('active_warehouse')
+            ->where('supplies_id', $s->supplies_id)
+            ->where('unit_id', $this->units[$unitKey]->unit_id)
+            ->where('warehouse_id', $warehouseId)
+            ->value('ss_stock');
+    }
+
+    private function makeReturn(Customer $customer, Supplies $s, int $warehouseId, string $unitKey, int $qty): CustomerSupplyReturn
+    {
+        $record = new CustomerSupplyReturn();
+        $record->return_number = 'PBM-TEST-'.uniqid();
+        $record->customer_id = $customer->customer_id;
+        $record->return_date = now()->toDateString();
+        $record->proof_path = 'supply-return-rollup-test.png';
+        $record->status = 1;
+        $record->created_by = $this->staffId();
+        $record->save();
+
+        $detail = new CustomerSupplyReturnDetail();
+        $detail->return_id = $record->return_id;
+        $detail->supplies_id = $s->supplies_id;
+        $detail->unit_id = $this->units[$unitKey]->unit_id;
+        $detail->warehouse_id = $warehouseId;
+        $detail->qty = $qty;
+        $detail->status = 1;
+        $detail->save();
+
+        return $record;
+    }
+
+    private function staffId(): int
+    {
+        return (int) \Illuminate\Support\Facades\DB::table('staffs')->where('status', 1)->value('staff_id');
+    }
+
+    public function test_returning_pcs_rolls_up_into_the_bigger_unit(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $warehouseId = $this->mainWarehouseId();
+        $s = $this->makeLadderedSupplies($warehouseId, dosStock: 0, pcsStock: 0, ratio: 12);
+        $customer = $this->createArmada();
+
+        // Dikembalikan 100 pcs (1 DOS = 12 pcs) -> harus tergulung jadi 8 DOS + 4 Piece.
+        $record = $this->makeReturn($customer, $s, $warehouseId, 'pcs', 100);
+
+        $response = $this->post("/customerSupplyReturns/{$record->return_id}/accept");
+        $response->assertOk();
+
+        $this->assertSame(8, $this->currentStock($s, 'dos', $warehouseId));
+        $this->assertSame(4, $this->currentStock($s, 'pcs', $warehouseId));
+    }
+
+    public function test_returning_pcs_rolls_up_together_with_stock_already_on_hand(): void
+    {
+        $this->actingAsSuperAdminStaff();
+
+        $warehouseId = $this->mainWarehouseId();
+        // 6 pcs already sitting there, below the 12-pcs DOS ratio on its own.
+        $s = $this->makeLadderedSupplies($warehouseId, dosStock: 0, pcsStock: 6, ratio: 12);
+        $customer = $this->createArmada();
+
+        // 6 more pcs returned -- not a multiple of 12 by itself, but 6 + 6 = 12 = exactly 1 DOS.
+        $record = $this->makeReturn($customer, $s, $warehouseId, 'pcs', 6);
+
+        $response = $this->post("/customerSupplyReturns/{$record->return_id}/accept");
+        $response->assertOk();
+
+        $this->assertSame(0, $this->currentStock($s, 'pcs', $warehouseId), 'BUG WOULD BE: stuck at 12 Piece, never rolled up');
+        $this->assertSame(1, $this->currentStock($s, 'dos', $warehouseId), 'existing 6 + returned 6 = 12 = exactly 1 DOS');
+    }
+}


### PR DESCRIPTION
## Ringkasan
Follow-up ke #155: setelah fix #155 (PR #156), dilakukan rescan penuh atas SEMUA titik penulisan `ps_stock`/`ss_stock` di aplikasi (~50 lokasi) untuk pola bug yang sama ("kredit stok masuk tanpa roll-up"). 3 gap baru ditemukan dan difilekan sebagai issue, plus 1 gap lama yang sebelumnya sengaja belum dikerjakan -- **semuanya diperbaiki di PR ini**.

## Perbaikan

### #157 — Edit dokumen Produk Bermasalah pending memutasi stok langsung
`StockController::updateProductIssue()` memutasi `ps_stock`/`ss_stock` langsung (flat, tanpa roll-up) untuk dokumen yang **masih pending** (belum di-ACC) -- melanggar invariant yang sudah diverifikasi test lain (stok cuma boleh berubah saat `accProductIssues()`). Endpoint ini juga dikonfirmasi **tidak reachable dari UI produksi** (tombol edit sengaja disembunyikan).

**Fix:** semua mutasi stok dihapus dari path update, disamakan persis dengan `insertProductIssue()` -- pre-check baca-saja, tulis `product_issues`/`product_issues_details`, tidak pernah sentuh stok. Ini juga otomatis menghilangkan beberapa bug lain yang menumpang di kode lama (blok yang menganggap semua baris detail adalah retur supplier walau dokumennya retur Armada -- akan crash `SuppliesVariant::find()` pada product_variant_id; blok penyesuaian invoice PO yang memang tidak pernah bisa jalan).

### #158 — Transfer Safety Stock ke Stok tidak roll-up
`StockController::transferSafetyToStock()` memindahkan qty dari `ps_safety_stock` ke `ps_stock` flat, tanpa roll-up. **Fix:** lewat `ProductUnitStock::addQty($rollUp: true)`, dibatasi ke gudang utama -- sama seperti `accProduction()`/fix #155.

### #159 — Pengembalian bahan saat pembatalan produksi tidak lewat UnitRollUp
`ProductionController::accDeleteProduction()`'s blok pengembalian bahan mengonversi satuan manual lewat `SuppliesRelation` langsung, tidak melipat stok yang sudah ada di satuan tujuan (bug class yang sama dengan #151). **Fix:** lewat `UnitRollUp::planSuppliesFolded()`, termasuk pemecahan log 3-leg yang sama dengan `ProductIssuesDetail::deleteProductIssuesDetail()`.

### Bahan Pengembalian (tanpa issue terpisah, sudah tercatat "flagged, belum dikerjakan" di penutupan #132)
`CustomerReturnController::acceptSupply()` dan `CustomerSupplyReturnController::accept()` punya gap flat-credit yang identik dengan sisi produk (yang sudah diperbaiki di #132) -- belum dikerjakan sebelumnya karena belum ada padanan `ss_stock` dari `ProductUnitStock::addQty()`.

**Fix:** menambahkan **`App\Support\SuppliesUnitStock::addQty()`** -- padanan langsung `ProductUnitStock::addQty()` untuk `SuppliesStock` (fold-existing-stock + log 3-leg yang sama) -- dan menyambungkan kedua method `accept()` lewatnya.

## Testing
Test baru untuk keempatnya:
- `tests/Regression/ProductIssuesUpdatePendingNoStockMutationTest.php`
- `tests/Regression/TransferSafetyToStockRollUpTest.php`
- `tests/Regression/ProductionCancelBahanReturnRollUpTest.php`
- `tests/Workflow/CustomerSupplyReturnRollUpTest.php`
- `tests/Workflow/CustomerReturnAcceptSupplyRollUpTest.php`

34 test terkait (baru + regresi) hijau, 197 assertion. Full-suite run menunjukkan 11 failure pra-eksisting (Stock Opname untouched-unit/V2 end-to-end, Akuntansi permission smoke test, Stock Transfer retail-edit guard) -- dikonfirmasi lewat `git stash` bahwa semuanya gagal identik TANPA perubahan ini, jadi tidak terkait.

Closes #157, Closes #158, Closes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)