### PR TITLE
fix(pembelian): pertahankan satuan yang dipilih saat tambah bahan baru

### DIFF
--- a/public/Custom_js/Backoffice/Suppliers/Purchase_Order.js
+++ b/public/Custom_js/Backoffice/Suppliers/Purchase_Order.js
@@ -228,11 +228,13 @@
         $('#tablePurchaseModal tbody').html("");
         item.forEach((item,index) => {
             // console.log(item)
+            var selectedUnit = item.unit_id_select || (item.supplies_unit[0] && item.supplies_unit[0].unit_id);
             var opsi = "";
             item.supplies_unit.forEach(element => {
-                opsi += `<option value='${element.unit_id}'>${element.unit_short_name}</option>`;
+                var isSelected = (element.unit_id == selectedUnit) ? 'selected' : '';
+                opsi += `<option value='${element.unit_id}' ${isSelected}>${element.unit_short_name}</option>`;
             });
-            
+
             $('#tablePurchaseModal tbody').append(`
                 <tr>
                     <td style="width:16%">${item.supplies_name}</td>
@@ -260,6 +262,13 @@
         var index = $(this).attr("index");
         item.splice(index,1);
         refreshItem();
+    });
+
+    $(document).on("change",".units_id",function(){
+        var index = $(this).closest('tr').find('.qtyPesanan').attr("index");
+        if (item[index]) {
+            item[index].unit_id_select = $(this).val();
+        }
     });
 
     $(document).on("change",".qtyPesanan",function(){


### PR DESCRIPTION
## Ringkasan
Perbaiki bug UX di modal Tambah Pesanan Pembelian: setelah mengganti satuan pada baris bahan di tabel, lalu menambahkan bahan baru, satuan yang sudah diganti kembali ke default.

## Root cause
`refreshItem()` merender ulang seluruh `<tbody>` dari array `item` setiap kali item ditambah/diubah, tetapi perubahan dropdown `.units_id` tidak pernah ditulis kembali ke array `item` — nilainya hanya dibaca saat submit (`.btn-save`). Karena itu render ulang selalu memakai opsi pertama sebagai default, menghilangkan pilihan user.

## Fix
- Tambah handler `change` pada `.units_id` yang langsung menyimpan pilihan ke `item[index].unit_id_select`.
- `refreshItem()` sekarang menandai opsi yang sesuai `unit_id_select` (atau default ke satuan pertama) sebagai `selected` saat merender ulang.

Closes #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)