### PR TITLE
fix(pembelian): urutkan log stok bahan mentah, masuk sebelum konversi (#167)

### DIFF
--- a/app/Http/Controllers/StockController.php
+++ b/app/Http/Controllers/StockController.php
@@ -2117,9 +2117,12 @@ class StockController extends Controller
             }
 
             $value['po_id'] = $pi['po_id'];
-            (new ProductIssuesDetail())->deleteProductIssuesDetail($value);
 
-            // Catat Log
+            // Catat Log DULU, baru deleteProductIssuesDetail() (yang untuk tipe_return==1 menaikkan
+            // satuan lewat UnitRollUp dan bisa menulis log konversi "keluar"/"hasil naik satuan" di
+            // dalamnya -- lihat docblock ProductIssuesDetail::deleteProductIssuesDetail()). Urutan
+            // sebelumnya terbalik, sama seperti bug GitHub #167 di SupplierController::accPO(): log
+            // masuk baru ditulis SETELAH konversi, jadi histori terbaca keluar → konversi → masuk.
             $logNotes    = "";
             $logCategory = 0;
             $logType     = 0;
@@ -2150,6 +2153,8 @@ class StockController extends Controller
                 'log_jumlah'   => $value['pid_qty'],
                 'unit_id'      => $value['unit_id'],
             ]);
+
+            (new ProductIssuesDetail())->deleteProductIssuesDetail($value);
         }
         DB::commit();
         } catch (\Throwable $e) {

--- a/app/Http/Controllers/SupplierController.php
+++ b/app/Http/Controllers/SupplierController.php
@@ -1038,9 +1038,11 @@ class SupplierController extends Controller
             $value['retur_pembelian'] = 1;
             $value['total_retur'] = $total_retur;
             $value['po_id'] = $data['po_id'];
-            (new ProductIssuesDetail())->deleteProductIssuesDetail($value);
 
-            // Catat Log
+            // Catat Log DULU, baru deleteProductIssuesDetail() (yang menaikkan satuan lewat
+            // UnitRollUp dan bisa menulis log konversi "keluar"/"hasil naik satuan" di dalamnya --
+            // lihat docblock-nya). Urutan sebelumnya terbalik, bug yang sama dengan GitHub #167 di
+            // accPO(): histori terbaca keluar → konversi → masuk, membingungkan.
             $sup = SuppliesVariant::find($value['supplies_variant_id']);
 
             (new LogStock())->insertLog([
@@ -1053,6 +1055,8 @@ class SupplierController extends Controller
                 'log_jumlah' => $value['rsd_qty'],
                 'unit_id'    => $value['unit_id'],
             ]);
+
+            (new ProductIssuesDetail())->deleteProductIssuesDetail($value);
         }
         foreach ($returs as $key => $value) {
             (new ReturnSuppliesDetail())->deleteReturnSuppliesDetail($value);

--- a/app/Http/Controllers/SupplierController.php
+++ b/app/Http/Controllers/SupplierController.php
@@ -597,9 +597,14 @@ class SupplierController extends Controller
             $value["pdod_qty"] = $value["pod_qty"];
             $value["statusPO"] = 2;
             $value["status"] = 2;
-            (new PurchaseOrderDeliveryDetail())->insertPoDeliveryDetail($value);
 
-            // Catat Log
+            // Catat Log "masuk" DULU, baru insertPoDeliveryDetail() (yang menaikkan satuan lewat
+            // UnitRollUp dan bisa menulis log konversi "keluar" + "hasil naik satuan" di
+            // dalamnya) -- lihat docblock insertPoDeliveryDetail(). Urutan sebelumnya terbalik
+            // (insertPoDeliveryDetail() dipanggil duluan), jadi histori terbaca keluar → konversi
+            // → baru masuk, membingungkan (GitHub #167). insertPoDeliveryDetail() sendiri sudah
+            // mengasumsikan log "masuk" ditulis caller lebih dulu -- ini hanya menyamakan urutan
+            // panggilan dengan asumsi itu, tanpa mengubah isi logic-nya.
             $sv = SuppliesVariant::find($value['supplies_variant_id']);
             $sup = Supplier::find($sv->supplier_id);
             (new LogStock())->insertLog([
@@ -612,6 +617,8 @@ class SupplierController extends Controller
                 'log_jumlah' => $value["pdod_qty"],
                 'unit_id'    => $value['unit_id'],
             ]);
+
+            (new PurchaseOrderDeliveryDetail())->insertPoDeliveryDetail($value);
         }
         $s = Supplier::find($data["po_supplier"]);
         $due  = date('Y-m-d', strtotime('+'.$s->supplier_top.' days'));

--- a/tests/Regression/ReturnSuppliesDeleteRollUpFoldsExistingStockTest.php
+++ b/tests/Regression/ReturnSuppliesDeleteRollUpFoldsExistingStockTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Regression;
 
+use App\Models\LogStock;
 use App\Models\PurchaseOrder;
 use App\Models\ReturnSupplies;
 use App\Models\Supplier;
@@ -153,5 +154,24 @@ class ReturnSuppliesDeleteRollUpFoldsExistingStockTest extends TestCase
 
         $po = PurchaseOrder::findOrFail($poId);
         $this->assertSame($qty * 1000, (int) $po->po_total, 'po_total is restored by cancelling the return');
+
+        // GitHub #167 (same log-order bug found in SupplierController::accPO()): the "Pembatalan
+        // retur pembelian ... masuk" log must be written BEFORE deleteProductIssuesDetail()'s
+        // "Konversi unit" legs, not after -- otherwise the history reads keluar → konversi → masuk.
+        $logs = LogStock::where('log_type', 2)
+            ->where('log_item_id', $supplies->supplies_id)
+            ->orderBy('log_id')
+            ->get();
+        $cancelLogIndex = $logs->search(fn ($l) => str_starts_with($l->log_notes, 'Pembatalan retur pembelian'));
+        $this->assertNotFalse($cancelLogIndex, 'the cancellation masuk log must exist');
+        foreach ($logs as $i => $log) {
+            if (str_starts_with($log->log_notes, 'Konversi unit')) {
+                $this->assertGreaterThan(
+                    $cancelLogIndex,
+                    $i,
+                    'conversion leg "'.$log->log_notes.'" must come after the cancellation masuk log'
+                );
+            }
+        }
     }
 }

--- a/tests/Workflow/PurchaseOrderReceiptRollUpFlowTest.php
+++ b/tests/Workflow/PurchaseOrderReceiptRollUpFlowTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Workflow;
 
+use App\Models\LogStock;
 use App\Models\PurchaseOrder;
 use App\Models\Supplier;
 use App\Models\Supplies;
@@ -214,5 +215,38 @@ class PurchaseOrderReceiptRollUpFlowTest extends TestCase
             'log_type' => 2, 'log_category' => 1, 'log_notes' => 'Konversi unit (Hasil naik satuan)',
             'log_jumlah' => 1, 'unit_id' => self::DOS,
         ]);
+    }
+
+    /**
+     * GitHub #167: the raw "Pembelian bahan mentah masuk" log was inserted AFTER
+     * insertPoDeliveryDetail() had already written its "Naik satuan" (keluar) / "Hasil naik satuan"
+     * (masuk) conversion legs, so the history read keluar → konversi → masuk -- confusing, since
+     * nothing had "gone out" before the purchase itself ever landed. The masuk-first log must be
+     * the earliest row, followed by the conversion legs in their existing keluar-then-masuk order.
+     */
+    public function test_purchase_log_is_written_before_the_rollup_conversion_legs(): void
+    {
+        $this->actingAsSuperAdminStaff();
+        [$supplies, $variant, , , $supplier] = $this->createFixture();
+
+        // 26 Piece = 2 DOS + 2 Piece -> triggers a roll-up conversion.
+        $this->createAndApprovePo($variant, $supplier, 26);
+
+        $logs = LogStock::where('log_type', 2)
+            ->where('log_item_id', $supplies->supplies_id)
+            ->orderBy('log_id')
+            ->get();
+
+        $this->assertStringStartsWith(
+            'Pembelian bahan mentah '.$supplier->supplier_name,
+            $logs[0]->log_notes
+        );
+        $this->assertSame(1, (int) $logs[0]->log_category, 'purchase masuk log must be first');
+
+        $this->assertSame('Konversi unit (Naik satuan)', $logs[1]->log_notes);
+        $this->assertSame(2, (int) $logs[1]->log_category, 'bongkar leg (keluar) comes after the purchase log');
+
+        $this->assertSame('Konversi unit (Hasil naik satuan)', $logs[2]->log_notes);
+        $this->assertSame(1, (int) $logs[2]->log_category, 'hasil leg (masuk) comes last');
     }
 }


### PR DESCRIPTION
## Ringkasan
Menyelesaikan #167 — urutan penulisan log stok saat penerimaan PO bahan mentah membingungkan: histori terbaca **keluar → konversi → masuk**, padahal seharusnya barang masuk dulu, baru (kalau perlu roll-up) satuan kecil keluar lalu satuan besar masuk.

Setelah fix pertama, saya audit semua pemanggil `UnitRollUp::` untuk pola bug yang sama dan menemukan **2 tempat lagi** dengan gap identik — sudah diperbaiki di commit lanjutan.

## Akar masalah #1 — `SupplierController::accPO()` (penerimaan PO)
Memanggil `PurchaseOrderDeliveryDetail::insertPoDeliveryDetail()` (yang menulis log "Konversi unit (Naik satuan)" / "Konversi unit (Hasil naik satuan)" lewat `UnitRollUp` saat penerimaan bikin stok naik satuan) **sebelum** menulis log "Pembelian bahan mentah ... masuk". Padahal komentar di `insertPoDeliveryDetail()` sendiri sudah mengasumsikan log masuk ditulis caller lebih dulu — asumsi itu tidak pernah benar-benar dipenuhi di `accPO()`.

## Akar masalah #2 — `SupplierController::deleteReturnSupplies()` (pembatalan retur pembelian)
Pola identik: memanggil `ProductIssuesDetail::deleteProductIssuesDetail()` (yang bisa menulis log konversi kalau roll-up terjadi) **sebelum** log "Pembatalan retur pembelian ... masuk"-nya sendiri. Ini jalur nyata/reachable dari UI.

## Akar masalah #3 — `StockController::deleteProductIssue()` (hapus data produk bermasalah retur)
Pola yang sama lagi di endpoint `/deleteProductIssues`. Endpoint ini sudah terdokumentasi UI-unreachable (tombol delete-nya di-comment out di frontend, lihat `ProductIssuesDeleteRefNumGuardIsDeadCodeTest`), tapi tetap diperbaiki urutannya untuk konsistensi/jaga-jaga.

## Fix
Di ketiga tempat: tukar urutan pemanggilan supaya log "masuk" ditulis dulu, baru fungsi model dipanggil (yang menambahkan leg konversi kalau memang terjadi roll-up). Logic roll-up/`UnitRollUp` sendiri tidak diubah sama sekali di ketiganya — perbaikan ini murni urutan pencatatan log.

## Testing
- Test baru `purchase_log_is_written_before_the_rollup_conversion_legs` di `PurchaseOrderReceiptRollUpFlowTest` — memverifikasi urutan log_id untuk kasus #1 (accPO).
- Assertion urutan log_id baru ditambahkan ke `ReturnSuppliesDeleteRollUpFoldsExistingStockTest` untuk kasus #2 (deleteReturnSupplies).
- Kasus #3 (`deleteProductIssue`) tidak ditambah test khusus karena jalurnya memang tidak terpakai (UI-unreachable).
- Ketiga test regresi baru dikonfirmasi gagal tanpa fix, lulus dengan fix.
- Full suite terkait PO/pembelian/retur/produksi (Workflow + Regression + DatabaseTransaction, ~517 test) tetap hijau; 10 kegagalan pra-eksisting (GitHub #161/#162, Stock Opname & Stock Transfer, tidak berhubungan) dikonfirmasi tetap gagal identik tanpa perubahan ini.

Closes #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)