### PR TITLE
fix(kas): tombol Tambah di Kas Besar/Kas Kecil cek akses create Kas

### DIFF
--- a/resources/views/components/page-header.blade.php
+++ b/resources/views/components/page-header.blade.php
@@ -235,20 +235,22 @@
                     @endroleCan
                 @endif
                 @if (Route::is(['cash']))
-                    @roleCanAny(['Kas', 'Kas Operasional'], 'create')
+                    {{-- Halaman Kas Besar hanya POST ke /insertCash (dijaga Kas|create) --}}
+                    @roleCan('Kas', 'create')
                     <li>
                         <a class="btn btn-primary btnAdd"><i class="fa fa-plus-circle me-2" aria-hidden="true"></i>Tambah
                             Pencatatan</a>
                     </li>
-                    @endroleCanAny
+                    @endroleCan
                 @endif
                 @if (Route::is(['pettyCash']))
-                    @roleCanAny(['Kas', 'Kas Operasional'], 'create')
+                    {{-- Halaman Kas Kecil hanya POST ke /insertPettyCash (dijaga Kas|create) --}}
+                    @roleCan('Kas', 'create')
                     <li>
                         <a class="btn btn-primary btnAdd"><i class="fa fa-plus-circle me-2" aria-hidden="true"></i>Tambah
                             Kas Kecil</a>
                     </li>
-                    @endroleCanAny
+                    @endroleCan
                 @endif
                 @if (Route::is(['operationalCash']))
                     @roleCanAny(['Kas', 'Kas Operasional'], 'create')


### PR DESCRIPTION
## Ringkasan
Laporan bug: role dengan akses view+approve (others) di modul Kas Besar ternyata bisa lihat tombol "Tambah".

**Investigasi**: server-side (`/insertCash`, `/insertPettyCash`) sudah benar digate `check.access:Kas|create` — submit dari user tanpa akses tetap ditolak (403). Bug-nya ada di UI: tombol Tambah di halaman Kas Besar/Kas Kecil pakai `@roleCanAny(['Kas','Kas Operasional'],'create')`, jadi ikut muncul untuk user yang punya `create` di modul **Kas Operasional** (berbeda dari Kas Besar).

## Fix
Ganti gating ke `@roleCan('Kas','create')` untuk kedua halaman tsb, sesuai endpoint yang benar-benar dipanggil. Halaman `operationalCash` tidak diubah (memang bisa create ke beberapa endpoint Kas Operasional).

Closes #169

🤖 Generated with [Claude Code](https://claude.com/claude-code)